### PR TITLE
- Adds a reasoner.dispose() call to the batch handler's cleanup code.

### DIFF
--- a/INSTRUCTIONS.md
+++ b/INSTRUCTIONS.md
@@ -1,23 +1,50 @@
+<!-- MarkdownTOC -->
+
+- [About this document](#about-this-document)
+	- [Building the server](#building-the-server)
+		- [Prerequisites to build the code](#prerequisites-to-build-the-code)
+		- [Building the Minerva Server](#building-the-minerva-server)
+	- [Running the Minerva Server](#running-the-minerva-server)
+		- [Prerequisites](#prerequisites)
+		- [Start the MolecularModelManager server from the command line](#start-the-molecularmodelmanager-server-from-the-command-line)
+		- [Start Server via Eclipse:](#start-server-via-eclipse)
+	- [Running Tests](#running-tests)
+		- [Failing Tests](#failing-tests)
+		- [Quick Test via `curl`](#quick-test-via-curl)
+	- [Obtaining `owl-models` and `go-lego.owl`](#obtaining-owl-models-and-go-legoowl)
+		- [Useful source files for learning](#useful-source-files-for-learning)
+
+<!-- /MarkdownTOC -->
+
+# About this document
+
 This is a quick overview on how to setup a Java server for the MolecularModelManager (Minerva).
 
-Pre-Requisites to build the code:
+## Building the server
+
+### Prerequisites to build the code
+
  * Java (JDK 1.7 or later) as compiler
  * Maven (3.0.x) Build-Tool
 
-Build the code:
+### Building the Minerva Server
 
 ```
  ./build-server.sh
 ```
 
-Pre-Requisites to run the server
- * go-lego.owl (GO-SVN/trunk/ontology/extension/go-lego.owl) and catalog.xml to local copies
- * folder with model files (GO-SVN/trunk/experimental/lego/server/owl-models/)
+## Running the Minerva Server
 
-Start the MolecularModelManager server
- * Build the code, will result in a jar
- * Check memory settings in start-m3-server.sh, change as needed.
- * The start script is in the bin folder: start-m3-server.sh
+### Prerequisites
+
+* go-lego.owl (GO-SVN/trunk/ontology/extensionx/go-lego.owl) and catalog.xml to local copies
+* folder with model files (GO-SVN/trunk/experimental/lego/server/owl-models/)
+
+### Start the MolecularModelManager server from the command line
+
+* Build the code, will result in a jar
+* Check memory settings in start-m3-server.sh, change as needed.
+* The start script is in the bin folder: start-m3-server.sh
 
 The Minerva server expects parameters for:
 
@@ -39,8 +66,45 @@ start-m3-server.sh -c go-trunk/ontology/extensions/catalog-v001.xml \
 --port 6800
 ```
 
-## Alternative for developers:
+### Start Server via Eclipse:
 
- * Requires all data (go and models)
- * Build in eclipse, start as main with appropriate parameters.
+* Requires all data (go and models)
+* Build in eclipse, start as main with appropriate parameters.
+
+
+## Running Tests
+
+```
+	mvn -Dtest=FindGoCodesTest.testFindShortEvidence,LegoToGeneAnnotationTranslatorTest.testZfinExample test
+```
+
+### Failing Tests
+
+mvn -e -DfailIfNoTests=false -Dtest=FindGoCodesTest test
+
+https://raw.githubusercontent.com/evidenceontology/evidenceontology/master/gaf-eco-mapping.txt
+
+[Maven CLI](http://maven.apache.org/ref/3.3.9/maven-embedder/cli.html)
+
+
+### Quick Test via `curl`
+
+This assumes you are in the `minerva/` directory, which is the parent of `minerva-server/`.
+
+```
+curl localhost:6800/`cat minerva-server/src/test/resources/server-test/long-get.txt`
+```
+
+## Obtaining `owl-models` and `go-lego.owl`
+
+See [Monarch Ontology](https://github.com/monarch-initiative/monarch-ontology) and use the instructions there to generate a `catalog-v001.xml`.
+
+- ftp://ftp.geneontology.org/pub/go//experimental/lego/server/owl-models
+- ftp://ftp.geneontology.org/pub/go//ontology/extensions/go-lego.owl
+
+### Useful source files for learning
+
+- `/minerva-server/src/main/java/org/geneontology/minerva/server/handler/M3BatchHandler.java`
+
+
 

--- a/minerva-core/src/main/java/org/geneontology/minerva/util/DebugTools.java
+++ b/minerva-core/src/main/java/org/geneontology/minerva/util/DebugTools.java
@@ -1,0 +1,38 @@
+package org.geneontology.minerva.util;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.Stack;
+import java.util.UUID;
+
+import org.apache.log4j.Level;
+import org.apache.log4j.Logger;
+
+/**
+ *
+ *
+ * @author dbk
+ *
+ */
+public class DebugTools {
+	private static Logger LOG = Logger.getLogger(DebugTools.class);
+	private static Runtime runtime = Runtime.getRuntime();
+
+	public static void logMemory(
+		String title)
+	{
+		double bytesToMB = 1.0 / (double)(1024L*1024L);
+		String statusText = "DebugTools[memory] " + title;
+
+		runtime.gc();
+		statusText += " freeMemory: " + (int) (runtime.freeMemory() * bytesToMB);
+		LOG.info(statusText);
+	}
+}
+

--- a/minerva-core/src/main/java/org/geneontology/minerva/util/ParserWrapper.java
+++ b/minerva-core/src/main/java/org/geneontology/minerva/util/ParserWrapper.java
@@ -1,0 +1,14 @@
+package org.geneontology.minerva.util;
+
+import java.io.IOException;
+import owltools.io.CatalogXmlIRIMapper;
+
+public class ParserWrapper extends owltools.io.ParserWrapper {
+	public ParserWrapper() throws IOException
+	{
+		super();
+
+        addIRIMapper(new CatalogXmlIRIMapper("../cache/catalog-v001.xml"));
+	}
+}
+

--- a/minerva-server/src/main/java/org/geneontology/minerva/server/handler/JsonOrJsonpBatchHandler.java
+++ b/minerva-server/src/main/java/org/geneontology/minerva/server/handler/JsonOrJsonpBatchHandler.java
@@ -254,6 +254,13 @@ public class JsonOrJsonpBatchHandler extends OperationsImpl implements M3BatchHa
 		if( response.message == null ){
 			response.message = "success";
 		}
+
+		if (useReasoner) {
+			if (reasoner != null) {
+				reasoner.dispose();
+			}
+		}
+
 		return response;
 	}
 
@@ -291,7 +298,7 @@ public class JsonOrJsonpBatchHandler extends OperationsImpl implements M3BatchHa
 		}
 		return state;
 	}
-	
+
 	protected void checkPermissions(Entity entity, Operation operation, boolean isPrivileged) throws InsufficientPermissionsException {
 		// TODO make this configurable
 		if (isPrivileged == false) {

--- a/minerva-server/src/main/java/org/geneontology/minerva/server/handler/M3BatchHandler.java
+++ b/minerva-server/src/main/java/org/geneontology/minerva/server/handler/M3BatchHandler.java
@@ -219,7 +219,6 @@ public interface M3BatchHandler {
 			@QueryParam("intention") String intention,
 			@QueryParam("packet-id") String packetId,
 			@QueryParam("requests") String requests);
-	
 	/**
 	 * Jersey REST method for GET with three query parameters with privileged rights.
 	 * 
@@ -236,4 +235,5 @@ public interface M3BatchHandler {
 			@QueryParam("intention") String intention,
 			@QueryParam("packet-id") String packetId,
 			@QueryParam("requests") String requests);
+
 }

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,60 @@
+mvn package -am -pl minerva-server -Dmaven.javadoc.skip=true -Dsource.skip=true -DskipTests
+
+echo "------------------"
+echo "------------------"
+echo "------------------"
+
+export MINERVA_MEMORY=2G
+export MINERVA_PORT=6800
+export GO_ROOT=./cache
+export NOCTUA_MODELS=../noctua-models/models
+export MINERVA_SERVER=./minerva-server/bin/minerva-server.jar
+
+java \
+	-Xmx${MINERVA_MEMORY} \
+	-jar ${MINERVA_SERVER} \
+	-g ${GO_ROOT}/merged.owl \
+	-f ${NOCTUA_MODELS} \
+	--port ${MINERVA_PORT} \
+	-c ${GO_ROOT}/catalog-v001.xml \
+	--use-golr-url-logging \
+	--slme-elk \
+	--use-golr-url-logging \
+	--use-golr-url-logging \
+exit
+
+
+# gulp.task('run-minerva', shell.task(_run_cmd(
+#     ['java',
+#      '-Xmx' + minerva_max_mem + 'G',
+#      '-cp', './java/lib/minerva-cli.jar',
+#      'org.geneontology.minerva.server.StartUpTool',
+#      '--use-golr-url-logging',
+#      '--use-request-logging',
+#      '--slme-elk',
+#      '-g', 'http://purl.obolibrary.org/obo/go/extensions/go-lego.owl',
+#      '--set-important-relation-parent', 'http://purl.obolibrary.org/obo/LEGOREL_0000000',
+#      '--golr-labels', golr_neo_lookup_url,
+#      '--golr-seed', golr_lookup_url,
+#      '-c', geneontology_catalog,
+#      '-f', noctua_models,
+#      '--port', minerva_port
+#     ]
+# )));
+
+
+# java \
+# 	-Xmx${MINERVA_MEMORY} \
+# 	-jar ${MINERVA_SERVER} \
+# 	-c ${GO_SVN}/ontology/extensions/catalog-v001.xml \
+# 	-g http://purl.obolibrary.org/obo/go/extensions/go-lego.owl \
+# 	--obsolete-import http://purl.obolibrary.org/obo/go.owl \
+# 	--obsolete-import http://purl.obolibrary.org/obo/go/extensions/x-disjoint.owl \
+# 	--obsolete-import http://purl.obolibrary.org/obo/ro.owl \
+# 	--obsolete-import http://purl.obolibrary.org/obo/go/extensions/ro_pending.owl \
+# 	--obsolete-import http://purl.obolibrary.org/obo/eco.owl \
+# 	--set-important-relation-parent http://purl.obolibrary.org/obo/LEGOREL_0000000 \
+# 	-f ${GO_SVN}/experimental/lego/server/owl-models \
+# 	--gaf-folder ${GO_SVN}/gene-associations \
+# 	-p ${GO_SVN}/experimental/lego/server/protein/subset \
+# 	--port ${MINERVA_PORT}


### PR DESCRIPTION
- Adds a reasoner.dispose() call to the batch handler's cleanup code.

I tested the fix by running `test.sh` and then using the following `curl` command:

```
curl -v 'http://localhost:6800/m3BatchPrivileged?intention=action&requests=%5B%7B%22entity%22%3A%22model%22%2C%22operation%22%3A%22add%22%2C%22arguments%22%3A%7B%7D%7D%5D&uid=http%3A%2F%2Forcid.org%2F0000'
```

Without the dispose(), each `curl` request generates 8 Elk-Reasoner threads which are never released. With the dispose(), there are no Elk-Reasoner threads left around.

---


Additional changes with this PR, unrelated to the dispose() fix.
- Updates INSTRUCTIONS.md
- Adds DebugTools.logMemory() to print a message and the current free
memory.
- Adds a version of ParserWrapper that uses the catalog.xml to find local OWL models.

