### PR TITLE
DO NOT MERGE Doc fixes, /status endpoint, use of catalog.xml during tests.

### DIFF
--- a/INSTRUCTIONS.md
+++ b/INSTRUCTIONS.md
@@ -11,6 +11,12 @@
 	- [Running Tests](#running-tests)
 		- [Failing Tests](#failing-tests)
 		- [Quick Test via `curl`](#quick-test-via-curl)
+	- [Minerva Configuration](#minerva-configuration)
+		- [If one of the maven repos is offline, use a cached version.](#if-one-of-the-maven-repos-is-offline-use-a-cached-version)
+		- [Avoid downloading OWL files, use the cache.](#avoid-downloading-owl-files-use-the-cache)
+	- [Obtaining the supporting model and data files](#obtaining-the-supporting-model-and-data-files)
+		- [Getting the Noctua, GO and LEGO data](#getting-the-noctua-go-and-lego-data)
+		- [Updating the `ontology/extensions/catalog-v001.xml` catalog](#updating-the-ontologyextensionscatalog-v001xml-catalog)
 	- [Obtaining `owl-models` and `go-lego.owl`](#obtaining-owl-models-and-go-legoowl)
 		- [Useful source files for learning](#useful-source-files-for-learning)
 
@@ -18,14 +24,15 @@
 
 # About this document
 
-This is a quick overview on how to setup a Java server for the MolecularModelManager (Minerva).
+This is a brief overview on how to setup and test the Minerva server. This includes the building of the server, obtaining the required model and data files, configuration, and testing.
 
 ## Building the server
 
 ### Prerequisites to build the code
 
- * Java (JDK 1.7 or later) as compiler
- * Maven (3.0.x) Build-Tool
+ * Java as compiler. Check with `java -version`. JDK 1.7 or higher is required. JDK 1.8 is recommended.
+ * Maven Build-Tool. Check with `mvn --version`. 3.0.x required; 3.3.x or higher is recommended.
+
 
 ### Building the Minerva Server
 
@@ -95,12 +102,124 @@ This assumes you are in the `minerva/` directory, which is the parent of `minerv
 curl localhost:6800/`cat minerva-server/src/test/resources/server-test/long-get.txt`
 ```
 
+This should result in output that concludes with something similar to:
+
+```
+{"id":"ECO:0001177","label":"RNA dot blot assay evidence used in manual assertion"},{"id":"ECO:0000087","label":"immunolocalization evidence"},{"id":"ECO:0001056","label":"induced mutation evidence"},{"id":"ECO:0005531","label":"motif discovery evidence"},{"id":"ECO:0001176","label":"DNA laddering assay evidence used in manual assertion"},{"id":"ECO:0000088","label":"biological system reconstruction evidence"},{"id":"ECO:0001055","label":"immunohistochemistry evidence"},{"id":"ECO:0005530","label":"random mutagenesis evidence used in manual assertion"}]}}}
+```
+
+## Minerva Configuration
+
+There are some non-default environment variables that are useful in some situations, especially in poor network conditions.
+
+### If one of the maven repos is offline, use a cached version.
+
+```
+export MINERVA_MAVEN_OPTS="--offline --no-snapshot-updates"
+```
+
+### Avoid downloading OWL files, use the cache.
+
+```
+export GENEONTOLOGY_CATALOG=`pwd`/../models/ontology/extensions/catalog-v001.xml
+```
+
+## Obtaining the supporting model and data files
+
+Some developers of Minerva may already have downloaded the various models and data files that describe the GO, LEGO and related structures. The instructions below are an attempt to provide a systematic way for developers to obtain the data. These instructions gather all of the model data under a `models/` root directory that is a sibling of the `minerva/` directory. When running Noctua or Minerva, there will be configuration (`startup.yaml`) or environment variables (e.g., `GENEONTOLOGY_CATALOG`) that point to files and directories within this `models/` tree
+
+### Getting the Noctua, GO and LEGO data
+
+These instructions assume you are located in your `minerva/` directory that contains this document.
+
+```
+cd ../ 				# Move up the directory containing minerva
+mkdir models/
+cd models/
+git clone https://github.com/geneontology/noctua-models.git
+git clone https://github.com/geneontology/go-site.git
+svn --ignore-externals co svn://ext.geneontology.org/trunk/ontology
+```
+
+### Updating the `ontology/extensions/catalog-v001.xml` catalog
+
+The file `models/ontology/extensions/catalog-v001.xml` has been constructed so that the component OWL models are loaded via a local cache, which dramatically improves performance. For example, the catalog has an Import Resolution entry which uses the cached copy `models/ontology/extensions/gorel.owl` when the resource `http://purl.obolibrary.org/obo/go/extensions/gorel.owl` is requested:
+
+```
+<uri
+	id="User Entered Import Resolution"
+	name="http://purl.obolibrary.org/obo/go/extensions/gorel.owl"
+	uri="gorel.owl"/>
+```
+
+Unfortunately, the default repository at `svn://ext.geneontology.org/trunk/ontology` does not contain cached versions of several important and large OWL models:
+
+- [wbphenotype.owl](http://purl.obolibrary.org/obo/wbphenotype.owl)
+- [taxslim.owl](http://purl.obolibrary.org/obo/ncbitaxon/subsets/taxslim.owl)
+- [taxslim-disjoint-over-in-taxon.owl](http://purl.obolibrary.org/obo/ncbitaxon/subsets/taxslim-disjoint-over-in-taxon.owl)
+- [eco.owl](http://purl.obolibrary.org/obo/eco.owl)
+- [wbbt.owl](http://purl.obolibrary.org/obo/wbbt.owl)
+- [neo.owl](http://purl.obolibrary.org/obo/go/noctua/neo.owl)
+
+It is worth the trouble of updating the `models/` directory and the `catalog-v001.xml` catalog to avoid unnecessary downloads, especially if you are in a network-challenged environment. If you have `owltools` installed, you can adapt the following script to update your `models/` and catalog files:
+
+```
+#
+# This should be turned into a useful script and placed in Git
+# But for now, it may be helpful as-is
+#
+export CACHEDIR=./cache-supplemental
+export CATALOG=./catalog-v001-supplemental.xml
+export OWLTOOLS=~/MI/owltools/OWLTools-Runner/bin/owltools
+
+echo "" > $CATALOG
+
+for F in \
+	http://purl.obolibrary.org/obo/wbphenotype.owl \
+	http://purl.obolibrary.org/obo/ncbitaxon/subsets/taxslim.owl \
+	http://purl.obolibrary.org/obo/ncbitaxon/subsets/taxslim-disjoint-over-in-taxon.owl \
+	http://purl.obolibrary.org/obo/eco.owl \
+	http://purl.obolibrary.org/obo/wbbt.owl \
+	http://purl.obolibrary.org/obo/go/noctua/neo.owl
+do
+	TMPCATALOG="./catalog-tmp.xml"
+
+	echo "# Processing $F"
+	$OWLTOOLS \
+		$F \
+		--slurp-import-closure \
+		-d $CACHEDIR \
+		-c $TMPCATALOG \
+		--merge-imports-closure \
+		-o $CACHEDIR/merged.owl
+	echo "# Adding $CACHEDIR/$TMPCATALOG"
+	cat $CACHEDIR/$TMPCATALOG >> $CATALOG
+done
+```
+
+The result of this should be a subdirectory of `./cache-supplemental` called `purl.obolibrary.org` which contains a tree of OWL files, and a catalog file called `./catalog-v001-supplemental.xml`. The `purl.obolibrary.org` directory should be placed in the same directory as the *official* catalog file (e.g., `models/ontology/extensions/catalog-v001.xml`). The *official* catalog file should be extended by extracting the URI information from the above generated file and pasting it into near the end.
+
+For example, after executing the above script, the following URI information should be pasted into the official catalog:
+
+
+```
+  <uri name="http://purl.obolibrary.org/obo/wbphenotype.owl" uri="purl.obolibrary.org/obo/wbphenotype.owl"/>
+  <uri name="http://purl.obolibrary.org/obo/ncbitaxon/subsets/taxslim.owl" uri="purl.obolibrary.org/obo/ncbitaxon/subsets/taxslim.owl"/>
+  <uri name="http://purl.obolibrary.org/obo/ncbitaxon/subsets/taxslim-disjoint-over-in-taxon.owl" uri="purl.obolibrary.org/obo/ncbitaxon/subsets/taxslim-disjoint-over-in-taxon.owl"/>
+  <uri name="http://purl.obolibrary.org/obo/ncbitaxon/subsets/taxslim.owl" uri="purl.obolibrary.org/obo/ncbitaxon/subsets/taxslim.owl"/>
+  <uri name="http://purl.obolibrary.org/obo/eco.owl" uri="purl.obolibrary.org/obo/eco.owl"/>
+  <uri name="http://purl.obolibrary.org/obo/wbbt.owl" uri="purl.obolibrary.org/obo/wbbt.owl"/>
+  <uri name="http://purl.obolibrary.org/obo/go/noctua/neo.owl" uri="purl.obolibrary.org/obo/go/noctua/neo.owl"/>
+```
+
+
 ## Obtaining `owl-models` and `go-lego.owl`
 
 See [Monarch Ontology](https://github.com/monarch-initiative/monarch-ontology) and use the instructions there to generate a `catalog-v001.xml`.
 
 - ftp://ftp.geneontology.org/pub/go//experimental/lego/server/owl-models
 - ftp://ftp.geneontology.org/pub/go//ontology/extensions/go-lego.owl
+
 
 ### Useful source files for learning
 

--- a/build-cli.sh
+++ b/build-cli.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
-mvn clean package -am -pl minerva-cli -DskipTests -Dmaven.javadoc.skip=true -Dsource.skip=true
+# export MINERVA_MAVEN_OPTS="--offline --no-snapshot-updates"
+mvn clean package ${MINERVA_MAVEN_OPTS} -am -pl minerva-cli -DskipTests -Dmaven.javadoc.skip=true -Dsource.skip=true
 

--- a/build-server.sh
+++ b/build-server.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
-mvn clean package -am -pl minerva-server -DskipTests -Dmaven.javadoc.skip=true -Dsource.skip=true
+# export MINERVA_MAVEN_OPTS="--offline --no-snapshot-updates"
+mvn clean package ${MINERVA_MAVEN_OPTS} -am -pl minerva-server -DskipTests -Dmaven.javadoc.skip=true -Dsource.skip=true
 

--- a/minerva-cli/src/main/resources/log4j.properties
+++ b/minerva-cli/src/main/resources/log4j.properties
@@ -10,5 +10,8 @@ log4j.appender.console.layout.ConversionPattern=%d %-5p (%c{1}:%L) %m\n
 log4j.logger.org.semanticweb.elk = ERROR
 log4j.logger.org.obolibrary.obo2owl = ERROR
 
+# uncomment to enable GOLR lookup request messages
+#log4j.logger.org.geneontology.minerva.server.external.GolrExternalLookupService=DEBUG
+
 log4j.rootLogger=INFO, console
 

--- a/minerva-converter/src/test/java/org/geneontology/minerva/evidence/FindGoCodesTest.java
+++ b/minerva-converter/src/test/java/org/geneontology/minerva/evidence/FindGoCodesTest.java
@@ -12,6 +12,7 @@ import org.semanticweb.owlapi.model.OWLClass;
 import org.semanticweb.owlapi.model.OWLOntology;
 
 import owltools.io.ParserWrapper;
+import owltools.io.CatalogXmlIRIMapper;
 
 public class FindGoCodesTest {
 	
@@ -24,6 +25,13 @@ public class FindGoCodesTest {
 		curieHandler = DefaultCurieHandler.getDefaultHandler();
 		codes = new FindGoCodes(curieHandler);
 		ParserWrapper pw = new ParserWrapper();
+
+		// if available, set catalog
+        String envCatalog = System.getenv().get("GENEONTOLOGY_CATALOG");
+        if (envCatalog != null) {
+        	pw.addIRIMapper(new CatalogXmlIRIMapper(envCatalog));
+        }
+
 		eco = pw.parseOWL(IRI.create("http://purl.obolibrary.org/obo/eco.owl"));
 	}
 

--- a/minerva-converter/src/test/java/org/geneontology/minerva/legacy/LegoToGeneAnnotationTranslatorTest.java
+++ b/minerva-converter/src/test/java/org/geneontology/minerva/legacy/LegoToGeneAnnotationTranslatorTest.java
@@ -31,6 +31,7 @@ import owltools.gaf.GeneAnnotation;
 import owltools.gaf.eco.EcoMapperFactory;
 import owltools.gaf.eco.SimpleEcoMapper;
 import owltools.io.ParserWrapper;
+import owltools.io.CatalogXmlIRIMapper;
 
 public class LegoToGeneAnnotationTranslatorTest {
 	
@@ -42,6 +43,13 @@ public class LegoToGeneAnnotationTranslatorTest {
 	@BeforeClass
 	public static void beforeClass() throws Exception {
 		pw = new ParserWrapper();
+
+		// if available, set catalog
+        String envCatalog = System.getenv().get("GENEONTOLOGY_CATALOG");
+        if (envCatalog != null) {
+        	pw.addIRIMapper(new CatalogXmlIRIMapper(envCatalog));
+        }
+
 		mapper = EcoMapperFactory.createSimple();
 	}
 

--- a/minerva-converter/src/test/java/org/geneontology/minerva/taxon/FindTaxonToolTest.java
+++ b/minerva-converter/src/test/java/org/geneontology/minerva/taxon/FindTaxonToolTest.java
@@ -12,6 +12,7 @@ import org.semanticweb.owlapi.model.OWLDataFactory;
 import org.semanticweb.owlapi.model.OWLOntology;
 
 import owltools.io.ParserWrapper;
+import owltools.io.CatalogXmlIRIMapper;
 
 public class FindTaxonToolTest {
 	
@@ -21,6 +22,13 @@ public class FindTaxonToolTest {
 	@BeforeClass
 	public static void beforeClass() throws Exception {
 		ParserWrapper pw = new ParserWrapper();
+
+		// if available, set catalog
+        String envCatalog = System.getenv().get("GENEONTOLOGY_CATALOG");
+        if (envCatalog != null) {
+        	pw.addIRIMapper(new CatalogXmlIRIMapper(envCatalog));
+        }
+
 		NEO = pw.parse("http://purl.obolibrary.org/obo/go/noctua/neo.owl");
 		curieHandler  = DefaultCurieHandler.getDefaultHandler();
 	}

--- a/minerva-core/src/main/java/org/geneontology/minerva/FileBasedMolecularModelManager.java
+++ b/minerva-core/src/main/java/org/geneontology/minerva/FileBasedMolecularModelManager.java
@@ -321,7 +321,6 @@ public class FileBasedMolecularModelManager<METADATA> extends CoreMolecularModel
 		Set<IRI> allModelIds = new HashSet<>();
 		File modelFolder = new File(pathTo);
 		File[] modelFiles = modelFolder.listFiles(new FilenameFilter() {
-			
 			@Override
 			public boolean accept(File dir, String name) {
 				return isLocalUnique(name);

--- a/minerva-core/src/main/java/org/geneontology/minerva/util/ParserWrapper.java
+++ b/minerva-core/src/main/java/org/geneontology/minerva/util/ParserWrapper.java
@@ -7,8 +7,6 @@ public class ParserWrapper extends owltools.io.ParserWrapper {
 	public ParserWrapper() throws IOException
 	{
 		super();
-
-        addIRIMapper(new CatalogXmlIRIMapper("../cache/catalog-v001.xml"));
 	}
 }
 

--- a/minerva-core/src/test/java/org/geneontology/minerva/MolecularModelManagerTest.java
+++ b/minerva-core/src/test/java/org/geneontology/minerva/MolecularModelManagerTest.java
@@ -26,6 +26,7 @@ import org.semanticweb.owlapi.model.OWLOntologyCreationException;
 import owltools.OWLToolsTestBasics;
 import owltools.graph.OWLGraphWrapper;
 import owltools.io.ParserWrapper;
+import owltools.io.CatalogXmlIRIMapper;
 
 public class MolecularModelManagerTest extends OWLToolsTestBasics {
 
@@ -46,6 +47,13 @@ public class MolecularModelManagerTest extends OWLToolsTestBasics {
 	@Test
 	public void testDeleteIndividual() throws Exception {
 		ParserWrapper pw = new ParserWrapper();
+
+		// if available, set catalog
+        String envCatalog = System.getenv().get("GENEONTOLOGY_CATALOG");
+        if (envCatalog != null) {
+        	pw.addIRIMapper(new CatalogXmlIRIMapper(envCatalog));
+        }
+
 		OWLGraphWrapper g = pw.parseToOWLGraph(getResourceIRIString("go-mgi-signaling-test.obo"));
 
 		// GO:0038024 ! cargo receptor activity
@@ -79,6 +87,13 @@ public class MolecularModelManagerTest extends OWLToolsTestBasics {
 	@Test
 	public void testExportImport() throws Exception {
 		ParserWrapper pw = new ParserWrapper();
+
+		// if available, set catalog
+        String envCatalog = System.getenv().get("GENEONTOLOGY_CATALOG");
+        if (envCatalog != null) {
+        	pw.addIRIMapper(new CatalogXmlIRIMapper(envCatalog));
+        }
+
 		OWLGraphWrapper g = pw.parseToOWLGraph(getResourceIRIString("go-mgi-signaling-test.obo"));
 
 		// GO:0038024 ! cargo receptor activity
@@ -124,6 +139,13 @@ public class MolecularModelManagerTest extends OWLToolsTestBasics {
 	public void testSaveModel() throws Exception {
 		final File saveFolder = folder.newFolder();
 		final ParserWrapper pw1 = new ParserWrapper();
+
+		// if available, set catalog
+        String envCatalog = System.getenv().get("GENEONTOLOGY_CATALOG");
+        if (envCatalog != null) {
+        	pw1.addIRIMapper(new CatalogXmlIRIMapper(envCatalog));
+        }
+
 		OWLGraphWrapper g = pw1.parseToOWLGraph(getResourceIRIString("go-mgi-signaling-test.obo"));
 
 		MolecularModelManager<Void> mmm = createM3(g);
@@ -152,6 +174,12 @@ public class MolecularModelManagerTest extends OWLToolsTestBasics {
 		mmm = null;
 		
 		final ParserWrapper pw2 = new ParserWrapper();
+
+		// if available, set catalog
+        if (envCatalog != null) {
+        	pw2.addIRIMapper(new CatalogXmlIRIMapper(envCatalog));
+        }
+
 		g = pw2.parseToOWLGraph(getResourceIRIString("go-mgi-signaling-test.obo"));
 		
 		
@@ -177,6 +205,13 @@ public class MolecularModelManagerTest extends OWLToolsTestBasics {
 	@Test
 	public void testInferredType() throws Exception {
 		ParserWrapper pw = new ParserWrapper();
+
+		// if available, set catalog
+        String envCatalog = System.getenv().get("GENEONTOLOGY_CATALOG");
+        if (envCatalog != null) {
+        	pw.addIRIMapper(new CatalogXmlIRIMapper(envCatalog));
+        }
+
 		OWLGraphWrapper g = pw.parseToOWLGraph(getResourceIRIString("go-mgi-signaling-test.obo"));
 
 		// GO:0038024 ! cargo receptor activity

--- a/minerva-core/src/test/java/org/geneontology/minerva/UndoAwareMolecularModelManagerTest.java
+++ b/minerva-core/src/test/java/org/geneontology/minerva/UndoAwareMolecularModelManagerTest.java
@@ -21,6 +21,7 @@ import org.semanticweb.owlapi.model.OWLNamedIndividual;
 import owltools.OWLToolsTestBasics;
 import owltools.graph.OWLGraphWrapper;
 import owltools.io.ParserWrapper;
+import owltools.io.CatalogXmlIRIMapper;
 
 public class UndoAwareMolecularModelManagerTest extends OWLToolsTestBasics {
 
@@ -31,6 +32,13 @@ public class UndoAwareMolecularModelManagerTest extends OWLToolsTestBasics {
 	@BeforeClass
 	public static void beforeClass() throws Exception {
 		ParserWrapper pw = new ParserWrapper();
+
+		// if available, set catalog
+        String envCatalog = System.getenv().get("GENEONTOLOGY_CATALOG");
+        if (envCatalog != null) {
+        	pw.addIRIMapper(new CatalogXmlIRIMapper(envCatalog));
+        }
+
 		g = pw.parseToOWLGraph(getResourceIRIString("go-mgi-signaling-test.obo"));
 		m3 = new UndoAwareMolecularModelManager(g, curieHandler, "http://testmodel.geneontology.org/");
 	}

--- a/minerva-core/src/test/java/org/geneontology/minerva/json/MolecularModelJsonRendererTest.java
+++ b/minerva-core/src/test/java/org/geneontology/minerva/json/MolecularModelJsonRendererTest.java
@@ -37,6 +37,7 @@ import org.semanticweb.owlapi.model.OWLOntologyManager;
 
 import owltools.graph.OWLGraphWrapper;
 import owltools.io.ParserWrapper;
+import owltools.io.CatalogXmlIRIMapper;
 
 public class MolecularModelJsonRendererTest {
 
@@ -49,6 +50,13 @@ public class MolecularModelJsonRendererTest {
 	@BeforeClass
 	public static void setUpBeforeClass() throws Exception {
 		ParserWrapper pw = new ParserWrapper();
+
+		// if available, set catalog
+        String envCatalog = System.getenv().get("GENEONTOLOGY_CATALOG");
+        if (envCatalog != null) {
+        	pw.addIRIMapper(new CatalogXmlIRIMapper(envCatalog));
+        }
+
 		File file = new File("src/test/resources/mgi-go.obo").getCanonicalFile();
 		OWLOntology ont = pw.parseOWL(IRI.create(file));
 		g = new OWLGraphWrapper(ont);

--- a/minerva-server/pom.xml
+++ b/minerva-server/pom.xml
@@ -15,6 +15,7 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
 				<configuration>
+					<verbose>true</verbose>
 					<excludes>
 						<!-- exclude due to use of external servers, which may not be available -->
 						<exclude>**/GolrExternalLookupServiceTest.java</exclude>

--- a/minerva-server/src/main/java/org/geneontology/minerva/server/handler/JsonOrJsonpBatchHandler.java
+++ b/minerva-server/src/main/java/org/geneontology/minerva/server/handler/JsonOrJsonpBatchHandler.java
@@ -31,15 +31,15 @@ public class JsonOrJsonpBatchHandler extends OperationsImpl implements M3BatchHa
 
 	public static final String JSONP_DEFAULT_CALLBACK = "jsonp";
 	public static final String JSONP_DEFAULT_OVERWRITE = "json.wrf";
-	
-	
+
+
 	public static boolean VALIDATE_BEFORE_SAVE = true;
 	public boolean CHECK_LITERAL_IDENTIFIERS = true; // TODO remove the temp work-around
-	
+
 	private static final Logger logger = Logger.getLogger(JsonOrJsonpBatchHandler.class);
-	
+
 	private final InferenceProviderCreator inferenceProviderCreator;
-	
+
 	public JsonOrJsonpBatchHandler(UndoAwareMolecularModelManager models,
 			String defaultModelState,
 			InferenceProviderCreator inferenceProviderCreator,
@@ -53,9 +53,9 @@ public class JsonOrJsonpBatchHandler extends OperationsImpl implements M3BatchHa
 
 		// generated
 		private static final long serialVersionUID = 5452629810143143422L;
-		
+
 	}.getType();
-	
+
 	@Override
 	boolean checkLiteralIdentifiers() {
 		return CHECK_LITERAL_IDENTIFIERS;
@@ -71,7 +71,7 @@ public class JsonOrJsonpBatchHandler extends OperationsImpl implements M3BatchHa
 	public M3BatchResponse m3BatchGet(String intention, String packetId, String requestString, String useReasoner) {
 		return m3Batch(null, intention, packetId, requestString, useReasoner, false);
 	}
-	
+
 	@Override
 	@JSONP(callback = JSONP_DEFAULT_CALLBACK, queryParam = JSONP_DEFAULT_OVERWRITE)
 	public M3BatchResponse m3BatchGetPrivileged(String uid, String intention, String packetId, String requestString, String useReasoner) {
@@ -83,7 +83,7 @@ public class JsonOrJsonpBatchHandler extends OperationsImpl implements M3BatchHa
 	public M3BatchResponse m3BatchPost(String intention, String packetId, String requestString, String useReasoner) {
 		return m3Batch(null, intention, packetId, requestString, useReasoner, false);
 	}
-	
+
 	@Override
 	@JSONP(callback = JSONP_DEFAULT_CALLBACK, queryParam = JSONP_DEFAULT_OVERWRITE)
 	public M3BatchResponse m3BatchPostPrivileged(String uid, String intention, String packetId, String requestString, String useReasoner) {
@@ -96,7 +96,7 @@ public class JsonOrJsonpBatchHandler extends OperationsImpl implements M3BatchHa
 		}
 		return packetId;
 	}
-	
+
 	@Override
 	public M3BatchResponse m3Batch(String uid, String intention, String packetId, M3Request[] requests, boolean useReasoner, boolean isPrivileged) {
 		M3BatchResponse response = new M3BatchResponse(uid, intention, checkPacketId(packetId));
@@ -114,7 +114,7 @@ public class JsonOrJsonpBatchHandler extends OperationsImpl implements M3BatchHa
 			return error(response, "An internal error occured at the server level.", t);
 		}
 	}
-	
+
 	private M3BatchResponse m3Batch(String uid, String intention, String packetId, String requestString, String useReasonerString, boolean isPrivileged) {
 		boolean useReasoner = false;
 		if (inferenceProviderCreator != null) {
@@ -136,11 +136,11 @@ public class JsonOrJsonpBatchHandler extends OperationsImpl implements M3BatchHa
 			return error(response, "An internal error occured at the server level.", t);
 		}
 	}
-	
+
 	private M3BatchResponse m3Batch(M3BatchResponse response, M3Request[] requests, String userId, boolean useReasoner, boolean isPrivileged) throws InsufficientPermissionsException, Exception {
 		userId = normalizeUserId(userId);
 		UndoMetadata token = new UndoMetadata(userId);
-		
+
 		final BatchHandlerValues values = new BatchHandlerValues();
 		for (M3Request request : requests) {
 			requireNotNull(request, "request");
@@ -226,7 +226,7 @@ public class JsonOrJsonpBatchHandler extends OperationsImpl implements M3BatchHa
 			response.data.annotations = MolecularModelJsonRenderer.renderModelAnnotations(values.model.getAboxOntology(), curieHandler);
 			response.data.modelId = curieHandler.getCuri(values.model.getModelId());
 		}
-		
+
 		// add other infos to data
 		if (!isConsistent) {
 			response.data.inconsistentFlag =  Boolean.TRUE;
@@ -246,7 +246,7 @@ public class JsonOrJsonpBatchHandler extends OperationsImpl implements M3BatchHa
 		data.facts = jsonModel.facts;
 		data.annotations = jsonModel.annotations;
 	}
-	
+
 	/*
 	 * commentary is now to be a string, not an unknown multi-leveled object.
 	 */
@@ -260,13 +260,13 @@ public class JsonOrJsonpBatchHandler extends OperationsImpl implements M3BatchHa
 			if( ename != null ){
 				state.message = state.message + " Exception: " + ename + ".";
 			}
-			
+
 			// And the exception message.
 			String emsg = e.getMessage();
 			if( emsg != null ){
 				state.message = state.message + " " + emsg;
 			}
-			
+
 			// Add the stack trace as commentary.
 			StringWriter stacktrace = new StringWriter();
 			e.printStackTrace(new PrintWriter(stacktrace));
@@ -289,9 +289,9 @@ public class JsonOrJsonpBatchHandler extends OperationsImpl implements M3BatchHa
 			}
 		}
 	}
-	
+
 	static class InsufficientPermissionsException extends Exception {
-		
+
 		private static final long serialVersionUID = -3751573576960618428L;
 
 		InsufficientPermissionsException(String msg) {

--- a/minerva-server/src/main/java/org/geneontology/minerva/server/handler/M3BatchHandler.java
+++ b/minerva-server/src/main/java/org/geneontology/minerva/server/handler/M3BatchHandler.java
@@ -24,114 +24,111 @@ public interface M3BatchHandler {
 	public static class M3Request extends MinervaRequest<Operation, Entity, M3Argument> {
 		// wrapper to conform to minerva request standard
 	}
-	
+
 	public static enum Entity {
 		individual,
 		edge,
 		model,
 		meta;
 	}
-	
+
 	public static enum Operation {
 		// generic operations
 		get,
-		
+
 		@SerializedName("add-type")
 		addType,
-		
+
 		@SerializedName("remove-type")
 		removeType,
-		
+
 		add,
-		
+
 		remove,
-		
+
 		@SerializedName("add-annotation")
 		addAnnotation,
-		
+
 		@SerializedName("remove-annotation")
 		removeAnnotation,
-		
+
 		// model specific operations
 		@SerializedName("export")
 		exportModel,
-		
+
 		@SerializedName("export-legacy")
 		exportModelLegacy,
-		
+
 		@SerializedName("import")
 		importModel,
-		
+
 		@SerializedName("store")
 		storeModel,
-		
+
 		@SerializedName("update-imports")
 		updateImports,
-		
+
 		// undo operations for models
 		undo, // undo the latest op
 		redo, // redo the latest undo
 		@SerializedName("get-undo-redo")
 		getUndoRedo, // get a list of all currently available undo and redo for a model
-		
+
 	}
-	
+
 	public static class M3Argument extends MinervaRequest.MinervaArgument {
-		
+
 		 @SerializedName("model-id")
 		String modelId;
 		String subject;
 		String object;
 		String predicate;
 		String individual;
-		
+
 		@SerializedName("individual-iri")
 		String individualIRI;
-		
+
 		@SerializedName("taxon-id")
 		String taxonId;
-		
+
 		@SerializedName("import-model")
 		String importModel;
 		String format;
-		
+
 		@SerializedName("assign-to-variable")
 		String assignToVariable;
-		
+
 		JsonOwlObject[] expressions;
 		JsonAnnotation[] values;
 	}
-	
+
 	public static class M3BatchResponse extends MinervaResponse<M3BatchResponse.ResponseData>{
-		
 		public static class ResponseData extends JsonModel {
-			
 			@SerializedName("inconsistent-p")
 			public Boolean inconsistentFlag;
-			
+
 			@SerializedName("modified-p")
 			public Boolean modifiedFlag;
-			
 			public Object undo;
 			public Object redo;
-			
+
 			@SerializedName("export-model")
 			public String exportModel;
-			
+
 			public MetaResponse meta;
 		}
-		
+
 		public static class MetaResponse {
 			public JsonRelationInfo[] relations;
-			
+
 			@SerializedName("data-properties")
 			public JsonRelationInfo[] dataProperties;
-			
+
 			public JsonEvidenceInfo[] evidence;
-			
+
 			@SerializedName("models-meta")
 			public Map<String,List<JsonAnnotation>> modelsMeta;
-			
+
 			@SerializedName("models-meta-read-only")
 			public Map<String, Map<String,Object>> modelsReadOnly;
 		}
@@ -144,13 +141,13 @@ public interface M3BatchHandler {
 		public M3BatchResponse(String uid, String intention, String packetId) {
 			super(uid, intention, packetId);
 		}
-		
+
 	}
-	
-	
+
+
 	/**
 	 * Process a batch request. The parameters uid and intention are round-tripped for the JSONP.
-	 * 
+	 *
 	 * @param uid user id, JSONP relevant
 	 * @param intention JSONP relevant
 	 * @param packetId response relevant, may be null
@@ -160,10 +157,10 @@ public interface M3BatchHandler {
 	 * @return response object, never null
 	 */
 	public M3BatchResponse m3Batch(String uid, String intention, String packetId, M3Request[] requests, boolean useReasoner, boolean isPrivileged);
-	
+
 	/**
 	 * Jersey REST method for POST with three form parameters.
-	 * 
+	 *
 	 * @param intention JSONP relevant
 	 * @param packetId
 	 * @param requests JSON string of the batch request
@@ -178,10 +175,10 @@ public interface M3BatchHandler {
 			@FormParam("packet-id") String packetId,
 			@FormParam("requests") String requests,
 			@FormParam("use-reasoner") String useReasoner);
-	
+
 	/**
 	 * Jersey REST method for POST with three form parameters with privileged rights.
-	 * 
+	 *
 	 * @param uid user id, JSONP relevant
 	 * @param intention JSONP relevant
 	 * @param packetId
@@ -198,13 +195,13 @@ public interface M3BatchHandler {
 			@FormParam("packet-id") String packetId,
 			@FormParam("requests") String requests,
 			@FormParam("use-reasoner") String useReasoner);
-	
-	
+
+
 	/**
 	 * Jersey REST method for GET with three query parameters.
-	 * 
+	 *
 	 * @param intention JSONP relevant
-	 * @param packetId 
+	 * @param packetId
 	 * @param requests JSON string of the batch request
 	 * @param useReasoner
 	 * @return response convertible to JSON(P)
@@ -218,10 +215,10 @@ public interface M3BatchHandler {
 			@QueryParam("use-reasoner") String useReasoner);
 	/**
 	 * Jersey REST method for GET with three query parameters with privileged rights.
-	 * 
+	 *
 	 * @param uid user id, JSONP relevant
 	 * @param intention JSONP relevant
-	 * @param packetId 
+	 * @param packetId
 	 * @param requests JSON string of the batch request
 	 * @param useReasoner
 	 * @return response convertible to JSON(P)
@@ -234,5 +231,4 @@ public interface M3BatchHandler {
 			@QueryParam("packet-id") String packetId,
 			@QueryParam("requests") String requests,
 			@QueryParam("use-reasoner") String useReasoner);
-
 }

--- a/minerva-server/src/main/java/org/geneontology/minerva/server/handler/StatusHandler.java
+++ b/minerva-server/src/main/java/org/geneontology/minerva/server/handler/StatusHandler.java
@@ -1,0 +1,130 @@
+package org.geneontology.minerva.server.handler;
+
+import java.util.List;
+import java.util.Map;
+
+import java.io.InputStream;
+import java.io.InputStreamReader;
+
+import javax.print.attribute.standard.Media;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.FormParam;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.QueryParam;
+
+import org.geneontology.minerva.json.JsonAnnotation;
+import org.geneontology.minerva.json.JsonEvidenceInfo;
+import org.geneontology.minerva.json.JsonOwlFact;
+import org.geneontology.minerva.json.JsonOwlIndividual;
+import org.geneontology.minerva.json.JsonOwlObject;
+import org.geneontology.minerva.json.JsonRelationInfo;
+
+import com.google.gson.annotations.SerializedName;
+
+@Path("/")
+public class StatusHandler {
+	public StatusHandler() {
+	}
+
+	public static class OfferingEntry {
+		String 		name;
+		String 		value;
+	}
+
+	public static class StatusResponse {
+
+		String				message;
+		String 				name;
+		Boolean				okay;
+		String 				location;
+		String 				listening;
+
+		@SerializedName("public")
+		String 				publicLocation;
+
+		OfferingEntry		offerings[];
+	}
+
+	@GET
+	@Path("status")
+	@Produces({MediaType.APPLICATION_JSON + ";charset=utf-8", "text/json"})
+	public Response status(InputStream incomingData) {
+ 		Runtime runtime = Runtime.getRuntime();
+
+		StatusResponse	statusResponse = new StatusResponse();
+		statusResponse.message = "/status";
+		statusResponse.okay = true;
+		statusResponse.name = "Minerva";
+		statusResponse.location = null;
+		statusResponse.publicLocation = null;
+		OfferingEntry 		o1 = new OfferingEntry();
+		o1.name = "calls";
+		o1.value = "0";
+		statusResponse.offerings = new OfferingEntry[1];
+		statusResponse.offerings[0] = o1;
+
+		// return HTTP response 200 in case of success
+		return Response.status(200).entity(statusResponse).build();
+	}
+
+	@GET
+	@Path("status/memory")
+	@Produces({MediaType.APPLICATION_JSON + ";charset=utf-8", "text/json"})
+	public Response memstatus(InputStream incomingData) {
+ 		Runtime runtime = Runtime.getRuntime();
+
+		// From https://en.wikipedia.org/wiki/Mebibyte
+		// 	1 MiB = 220 bytes = 1024 kibibytes = 1048576bytes
+ 		long 			bytesPerMebibyte = 1048576;
+
+ 		long 			availableProcessors = runtime.availableProcessors();
+
+ 		long 			maxMemoryBefore = runtime.maxMemory() / bytesPerMebibyte;
+ 		long 			freeMemoryBefore = runtime.freeMemory() / bytesPerMebibyte;
+ 		long 			totalMemoryBefore = runtime.totalMemory() / bytesPerMebibyte;
+
+ 		runtime.gc();
+
+ 		long 			maxMemoryAfter = runtime.maxMemory() / bytesPerMebibyte;
+ 		long 			freeMemoryAfter = runtime.freeMemory() / bytesPerMebibyte;
+ 		long 			totalMemoryAfter = runtime.totalMemory() / bytesPerMebibyte;
+
+ 		String statusText = "";
+ 		statusText += " availableProcessors: " + availableProcessors + "\n";
+ 		statusText += " maxMemory, pre-gc :           " + maxMemoryBefore + " MiB\n";
+ 		statusText += " freeMemory, pre-gc :          " + freeMemoryBefore + " MiB\n";
+ 		statusText += " totalMemory, pre-gc :         " + totalMemoryBefore + " MiB\n";
+
+ 		statusText += " maxMemory, post-gc:           " + maxMemoryAfter + " MiB delta:" +
+ 			(maxMemoryAfter - maxMemoryBefore) + " MiB\n";
+ 		statusText += " freeMemory, post-gc:          " + freeMemoryAfter + " MiB delta:" +
+ 			(freeMemoryAfter - freeMemoryBefore) + " MiB\n";
+ 		statusText += " totalMemory, post-gc:         " + totalMemoryAfter + " MiB delta:" +
+ 			(totalMemoryAfter - totalMemoryBefore) + " MiB\n";
+
+		StatusResponse	statusResponse = new StatusResponse();
+		statusResponse.message = statusText;
+		statusResponse.okay = true;
+		statusResponse.name = "Minerva";
+		statusResponse.location = null;
+		statusResponse.publicLocation = null;
+		// OfferingEntry 		o1 = new OfferingEntry();
+		// o1.name = "calls";
+		// o1.value = "0";
+		// statusResponse.offerings = new OfferingEntry[1];
+		// statusResponse.offerings[0] = o1;
+
+		// return HTTP response 200 in case of success
+		return Response.status(200).entity(statusResponse).build();
+	}
+}

--- a/minerva-server/src/main/resources/log4j.properties
+++ b/minerva-server/src/main/resources/log4j.properties
@@ -11,7 +11,8 @@ log4j.logger.org.semanticweb.elk = ERROR
 log4j.logger.org.obolibrary.obo2owl = ERROR
 
 # uncomment to enable GOLR lookup request messages
-#log4j.logger.org.geneontology.minerva.server.external.GolrExternalLookupService=DEBUG
+# log4j.logger.org.geneontology.minerva.server.external.GolrExternalLookupService=DEBUG
+# log4j.logger.org.geneontology.minerva.server.external.JsonOrJsonpBatchHandler=DEBUG
 
 log4j.rootLogger=INFO, console
 

--- a/minerva-server/src/test/java/org/geneontology/minerva/server/handler/BatchModelHandlerTest.java
+++ b/minerva-server/src/test/java/org/geneontology/minerva/server/handler/BatchModelHandlerTest.java
@@ -48,6 +48,7 @@ import org.semanticweb.owlapi.model.OWLOntologyCreationException;
 
 import owltools.graph.OWLGraphWrapper;
 import owltools.io.ParserWrapper;
+import owltools.io.CatalogXmlIRIMapper;
 
 @SuppressWarnings("unchecked")
 public class BatchModelHandlerTest {
@@ -69,7 +70,14 @@ public class BatchModelHandlerTest {
 
 	@BeforeClass
 	public static void setUpBeforeClass() throws Exception {
-		init(new ParserWrapper());
+		// if available, set catalog
+        String envCatalog = System.getenv().get("GENEONTOLOGY_CATALOG");
+        ParserWrapper pw = new ParserWrapper();
+
+        if (envCatalog != null) {
+        	pw.addIRIMapper(new CatalogXmlIRIMapper(envCatalog));
+        }
+		init(pw);
 	}
 
 	static void init(ParserWrapper pw) throws OWLOntologyCreationException, IOException {

--- a/minerva-server/src/test/java/org/geneontology/minerva/server/handler/LocalServerTest.java
+++ b/minerva-server/src/test/java/org/geneontology/minerva/server/handler/LocalServerTest.java
@@ -41,6 +41,7 @@ import com.google.gson.GsonBuilder;
 
 import owltools.graph.OWLGraphWrapper;
 import owltools.io.ParserWrapper;
+import owltools.io.CatalogXmlIRIMapper;
 
 public class LocalServerTest {
 
@@ -56,7 +57,15 @@ public class LocalServerTest {
 
 	@BeforeClass
 	public static void setUpBeforeClass() throws Exception {
-		init(new ParserWrapper());
+		ParserWrapper pw = new ParserWrapper();
+
+		// if available, set catalog
+        String envCatalog = System.getenv().get("GENEONTOLOGY_CATALOG");
+        if (envCatalog != null) {
+        	pw.addIRIMapper(new CatalogXmlIRIMapper(envCatalog));
+        }
+
+		init(pw);
 	}
 	
 	@AfterClass

--- a/minerva-server/src/test/java/org/geneontology/minerva/server/handler/ModelEditTest.java
+++ b/minerva-server/src/test/java/org/geneontology/minerva/server/handler/ModelEditTest.java
@@ -44,6 +44,7 @@ import org.semanticweb.owlapi.model.OWLOntologyCreationException;
 
 import owltools.graph.OWLGraphWrapper;
 import owltools.io.ParserWrapper;
+import owltools.io.CatalogXmlIRIMapper;
 
 public class ModelEditTest {
 
@@ -53,7 +54,15 @@ public class ModelEditTest {
 	
 	@BeforeClass
 	public static void setUpBeforeClass() throws Exception {
-		init(new ParserWrapper());
+		ParserWrapper pw = new ParserWrapper();
+
+		// if available, set catalog
+        String envCatalog = System.getenv().get("GENEONTOLOGY_CATALOG");
+        if (envCatalog != null) {
+        	pw.addIRIMapper(new CatalogXmlIRIMapper(envCatalog));
+        }
+
+		init(pw);
 	}
 	
 	static void init(ParserWrapper pw) throws OWLOntologyCreationException, IOException {

--- a/minerva-server/src/test/java/org/geneontology/minerva/server/handler/ModelReasonerTest.java
+++ b/minerva-server/src/test/java/org/geneontology/minerva/server/handler/ModelReasonerTest.java
@@ -35,6 +35,7 @@ import org.semanticweb.owlapi.model.OWLOntologyCreationException;
 
 import owltools.graph.OWLGraphWrapper;
 import owltools.io.ParserWrapper;
+import owltools.io.CatalogXmlIRIMapper;
 
 public class ModelReasonerTest {
 
@@ -44,7 +45,15 @@ public class ModelReasonerTest {
 	
 	@BeforeClass
 	public static void setUpBeforeClass() throws Exception {
-		init(new ParserWrapper());
+		ParserWrapper pw = new ParserWrapper();
+
+		// if available, set catalog
+        String envCatalog = System.getenv().get("GENEONTOLOGY_CATALOG");
+        if (envCatalog != null) {
+        	pw.addIRIMapper(new CatalogXmlIRIMapper(envCatalog));
+        }
+
+		init(pw);
 	}
 	
 	static void init(ParserWrapper pw) throws OWLOntologyCreationException, IOException {

--- a/minerva-server/src/test/java/org/geneontology/minerva/server/handler/ParallelModelReasonerTest.java
+++ b/minerva-server/src/test/java/org/geneontology/minerva/server/handler/ParallelModelReasonerTest.java
@@ -30,6 +30,7 @@ import org.semanticweb.owlapi.model.OWLOntologyCreationException;
 
 import owltools.graph.OWLGraphWrapper;
 import owltools.io.ParserWrapper;
+import owltools.io.CatalogXmlIRIMapper;
 
 public class ParallelModelReasonerTest {
 
@@ -40,7 +41,15 @@ public class ParallelModelReasonerTest {
 	
 	@BeforeClass
 	public static void setUpBeforeClass() throws Exception {
-		init(new ParserWrapper());
+		ParserWrapper pw = new ParserWrapper();
+
+		// if available, set catalog
+        String envCatalog = System.getenv().get("GENEONTOLOGY_CATALOG");
+        if (envCatalog != null) {
+        	pw.addIRIMapper(new CatalogXmlIRIMapper(envCatalog));
+        }
+
+		init(pw);
 	}
 	
 	static void init(ParserWrapper pw) throws OWLOntologyCreationException, IOException {

--- a/minerva-server/src/test/java/org/geneontology/minerva/server/handler/SeedHandlerTest.java
+++ b/minerva-server/src/test/java/org/geneontology/minerva/server/handler/SeedHandlerTest.java
@@ -25,6 +25,7 @@ import owltools.gaf.eco.EcoMapperFactory;
 import owltools.gaf.eco.SimpleEcoMapper;
 import owltools.graph.OWLGraphWrapper;
 import owltools.io.ParserWrapper;
+import owltools.io.CatalogXmlIRIMapper;
 
 public class SeedHandlerTest {
 
@@ -38,7 +39,15 @@ public class SeedHandlerTest {
 	
 	@BeforeClass
 	public static void setUpBeforeClass() throws Exception {
-		init(new ParserWrapper(), "http://golr.geneontology.org/solr");
+		ParserWrapper pw = new ParserWrapper();
+
+		// if available, set catalog
+        String envCatalog = System.getenv().get("GENEONTOLOGY_CATALOG");
+        if (envCatalog != null) {
+        	pw.addIRIMapper(new CatalogXmlIRIMapper(envCatalog));
+        }
+
+		init(pw, "http://golr.geneontology.org/solr");
 	}
 
 	static void init(ParserWrapper pw, String golr) throws Exception {

--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,8 @@
 				<artifactId>maven-surefire-plugin</artifactId>
 				<version>2.18.1</version>
 				<configuration>
-					<argLine>-Xmx5G</argLine>
+  					<verbose>true</verbose>
+  					<argLine>-Xmx5000M</argLine>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/scripts/importSupplemental.sh
+++ b/scripts/importSupplemental.sh
@@ -1,0 +1,39 @@
+# See: https://github.com/owlcollab/owltools/wiki/Import-Chain-Mirroring
+
+export CACHEDIR=./cache-supplemental
+export CATALOG=./catalog-v001-supplemental.xml
+export OWLTOOLS=~/MI/owltools/OWLTools-Runner/bin/owltools
+
+echo "" > $CATALOG
+
+for F in \
+	http://purl.obolibrary.org/obo/wbphenotype.owl \
+	http://purl.obolibrary.org/obo/ncbitaxon/subsets/taxslim.owl \
+	http://purl.obolibrary.org/obo/ncbitaxon/subsets/taxslim-disjoint-over-in-taxon.owl \
+	http://purl.obolibrary.org/obo/eco.owl \
+	http://purl.obolibrary.org/obo/wbbt.owl \
+	http://purl.obolibrary.org/obo/go/noctua/neo.owl
+do
+	TMPCATALOG="./catalog-tmp.xml"
+
+	echo "# Processing $F"
+	$OWLTOOLS \
+		$F \
+		--slurp-import-closure \
+		-d $CACHEDIR \
+		-c $TMPCATALOG \
+		--merge-imports-closure \
+		-o $CACHEDIR/merged.owl
+	echo "# Adding $CACHEDIR/$TMPCATALOG"
+	cat $CACHEDIR/$TMPCATALOG >> $CATALOG
+done
+
+cat  $CATALOG
+exit
+
+# $OWLTOOLS http://purl.obolibrary.org/obo/wbphenotype.owl --slurp-import-closure -d $CACHEDIR -c $CATALOG --merge-imports-closure -o $CACHEDIR/merged.owl
+# $OWLTOOLS http://purl.obolibrary.org/obo/ncbitaxon/subsets/taxslim.owl --slurp-import-closure -d $CACHEDIR -c $CATALOG --merge-imports-closure -o $CACHEDIR/merged.owl
+# $OWLTOOLS http://purl.obolibrary.org/obo/ncbitaxon/subsets/taxslim-disjoint-over-in-taxon.owl --slurp-import-closure -d $CACHEDIR -c $CATALOG --merge-imports-closure -o $CACHEDIR/merged.owl
+# $OWLTOOLS http://purl.obolibrary.org/obo/eco.owl --slurp-import-closure -d $CACHEDIR -c $CATALOG --merge-imports-closure -o $CACHEDIR/merged.owl
+# $OWLTOOLS http://purl.obolibrary.org/obo/wbbt.owl --slurp-import-closure -d $CACHEDIR -c $CATALOG --merge-imports-closure -o $CACHEDIR/merged.owl
+# $OWLTOOLS http://purl.obolibrary.org/obo/go/noctua/neo.owl --slurp-import-closure -d $CACHEDIR -c $CATALOG --merge-imports-closure -o $CACHEDIR/merged.owl

--- a/scripts/installModels.sh
+++ b/scripts/installModels.sh
@@ -1,0 +1,5 @@
+mkdir -p models/
+cd models/
+git clone https://github.com/geneontology/noctua-models.git
+git clone https://github.com/geneontology/go-site.git
+svn --ignore-externals co svn://ext.geneontology.org/trunk/ontology

--- a/scripts/ngExample.html
+++ b/scripts/ngExample.html
@@ -1,0 +1,412 @@
+<!doctype html>
+
+<!--
+This HTML file contains an entire single-page AngularJS web application,
+including the following components:
+  - HTML for layout and UI
+  - JavaScript for behavior
+  - AngularJS for templating, MVC and reactive programming
+  - Twitter Bootstrap for styles and components
+  - AngularUI Bootstrap for Angular-specific Bootstrap implementations.
+  - json-formatter is an Angular directive that makes presenting JSON fun
+All of the above resources are pulled into the browser via CDN, except for
+json-formatter which I'm pulling directly from one of the author's example pages.
+
+This single-file format is pretty useful for educational and illustrative
+purposes, but is impractical for most real applications. Another advantage of
+SFSPWA (Single-File Single-Page Web Application) which makes them ideal for blogging
+and experimentation is that they don't require a web server. Simply opening
+the file in a web browser will be sufficient with Chrome, Safari and Firefox.
+-->
+
+<!--
+This particular application exercises some of the Minerva endpoints
+-->
+
+
+<!-- This is all pretty-standard HTML prefix text -->
+
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+
+  <title>Minerva Tests</title>
+  <meta name="description" content="Simple Long Get Minerva Test">
+  <meta name="author" content="DoctorBud">
+
+  <!-- Include JS and CSS Resources from CDNs -->
+  <!-- We are using AngularJS, AngularUI Bootstrap, and Twitter Bootstrap -->
+
+  <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.4.5/angular.min.js"></script>
+  <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.4.5/angular-resource.js"></script>
+
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/angular-ui-bootstrap/1.0.3/ui-bootstrap-tpls.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/angular-ui-bootstrap/1.0.3/ui-bootstrap-tpls.js"></script>
+  <script src="http://azimi.me/json-formatter/dist/json-formatter.min.js"></script>
+
+  <link
+    rel="stylesheet"
+    href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css"
+    integrity="sha384-1q8mTJOASx8j1Au+a5WDVnPi2lkFfwwEAa8hDDdjZlpLegxhjVME1fgjWPGmkzs7"
+    crossorigin="anonymous">
+  <link
+    rel="stylesheet"
+    href="https://maxcdn.bootstrapcdn.com/bootswatch/3.3.6/readable/bootstrap.min.css"
+    crossorigin="anonymous">
+  <link
+    rel="stylesheet"
+    href="http://azimi.me/json-formatter/dist/json-formatter.min.css"
+    crossorigin="anonymous">
+
+<!--
+Here's our main Angular app definition and the definition of our controllers
+-->
+
+<!--
+So far, there is only one controller we are using, and it's called QueryController
+for lack of a better name.
+-->
+
+  <script>
+"use strict";   // This lets us use modern JS features.
+
+// We are in JavaScript now. So we use JS comments.
+// We are relying upon ES6 for the class/constructor capability. If you are using
+// Firefox, you must have the developer edition, or wait until March 2016 when the
+// default FF will support ES6. Because this file does not rely upon a preprocessor
+// like Babel, we assume a modern ES6 browser.
+//
+
+class QueryController {
+  constructor($resource, $timeout) {
+    this.$resource = $resource;
+    this.$timeout = $timeout;
+    this.minervaServerUrl = 'http://localhost:6800';
+    this.statusRequest = undefined;
+    this.statusResponse = undefined;
+    this.noctuaLandingResponse = undefined;
+    this.response = undefined;
+    var that = this;
+    //
+    // Uncomment the timeout code below if you want to auto-exec a function on
+    // page load.
+    //
+
+    // $timeout(
+    //   function () {
+    //     that.performShortGet();
+    //   },
+    //   200);
+  }
+
+
+  performStatusTest() {
+    this.statusRequest = "/status";
+    this.statusResponse = null;
+
+    var that = this;
+    var requestUrl = this.minervaServerUrl + this.statusRequest;
+    var q = this.$resource(
+                requestUrl,
+                {
+                  // default parameters
+                },
+                {
+                  get: {
+                    method:'GET',
+                    isArray: false,
+                    responseType: "json"
+                  }
+                }).get();
+    q.$promise.then(function(d) {
+      delete d.$promise;
+      delete d.$resolved;
+      that.statusResponse = d;
+    });
+  }
+
+  performStatusMemoryTest() {
+    this.statusRequest = "/status/memory";
+    this.statusResponse = null;
+
+    var that = this;
+    var requestUrl = this.minervaServerUrl + this.statusRequest;
+    var q = this.$resource(
+                requestUrl,
+                {
+                  // default parameters
+                },
+                {
+                  get: {
+                    method:'GET',
+                    isArray: false,
+                    responseType: "json"
+                  }
+                }).get();
+    q.$promise.then(function(d) {
+      delete d.$promise;
+      delete d.$resolved;
+      that.statusResponse = d;
+    });
+  }
+
+/*
+  performStatusMemoryTestText() {
+    var simpleGet = "/status/memory";
+
+    var that = this;
+    var requestUrl = this.minervaServerUrl + simpleGet;
+    var q = this.$resource(
+                requestUrl,
+                {
+                  // default parameters
+                },
+                {
+                  get: {
+                    method:'GET',
+                    isArray: true,
+                    responseType: "text",
+                    transformResponse: function(data, headers){
+                      console.log('TR:', data, headers);
+                      return [data];
+                    }
+                  }
+                }).get();
+    q.$promise.then(function(d) {
+      that.statusResponse = d[0];
+    });
+  }
+*/
+
+  performShortGet() {
+    var shortGet = `/m3Batch?intention=query&requests=%5B%7B%22entity%22%3A%22meta%22%2C%22operation%22%3A%22get%22%2C%22arguments%22%3A%7B%7D%7D%2C%7B%22entity%22%3A%22meta%22%2C%22operation%22%3A%22get%22%2C%22arguments%22%3A%7B%7D%7D%2C%7B%22entity%22%3A%22meta%22%2C%22operation%22%3A%22get%22%2C%22arguments%22%3A%7B%7D%7D%2C%7B%22entity%22%3A%22meta%22%2C%22operation%22%3A%22get%22%2C%22arguments%22%3A%7B%7D%7D%2C%7B%22entity%22%3A%22meta%22%2C%22operation%22%3A%22get%22%2C%22arguments%22%3A%7B%7D%7D%2C%7B%22entity%22%3A%22meta%22%2C%22operation%22%3A%22get%22%2C%22arguments%22%3A%7B%7D%7D%5D&uid=`;
+    var that = this;
+    this.response = null;
+    var requestUrl = this.minervaServerUrl + shortGet;
+    var q = this.$resource(
+                requestUrl,
+                {
+                  // default parameters
+                },
+                {
+                  get: {
+                    method:'GET',
+                    isArray: false,
+                    responseType: "json"
+                  }
+                }).get();
+    q.$promise.then(function(d) {
+      that.response = {
+        commentary: d.commentary,
+        data: d.data,
+        intention: d.intention,
+        'is-reasoned': d['is-reasoned'],
+        message: d.message,
+        'message-type': d['message-type'],
+        'packet-id': d['packet-id'],
+        signal: d.signal
+      };
+    });
+  }
+
+  performNoctuaLandingRequest() {
+    var shortGet = `/m3Batch`;
+    var that = this;
+    this.noctuaLandingResponse = null;
+    var requestUrl = this.minervaServerUrl + shortGet;
+    var params = {
+                    intention: 'query',
+
+                    // This is funky. The requests in /m3Batch are
+                    // stringified
+                    requests: JSON.stringify([
+                      {
+                        entity: 'meta',
+                        operation: 'get',
+                        arguments: {}
+                      }]),
+                    uid: null
+                  };
+
+    var q = this.$resource(
+                requestUrl,
+                {
+                  // params
+                },
+                {
+                  get: {
+                    method:'GET',
+                    isArray: false,
+                    responseType: 'json',
+                    params: params
+                  }
+                }).get();
+    q.$promise.then(function(d) {
+      that.noctuaLandingResponse = {
+        commentary: d.commentary,
+        data: d.data,
+        intention: d.intention,
+        'is-reasoned': d['is-reasoned'],
+        message: d.message,
+        'message-type': d['message-type'],
+        'packet-id': d['packet-id'],
+        signal: d.signal
+      };
+    });
+  }
+}
+
+var app = angular.module('SimpleApp', ['jsonFormatter', 'ngResource', 'ui.bootstrap']);
+app.config(function (JSONFormatterConfigProvider) {
+    JSONFormatterConfigProvider.hoverPreviewEnabled = true;
+  });
+
+app.controller(
+  'QueryController',
+  function ($resource, $timeout) {
+    return new QueryController($resource, $timeout);
+  });
+  </script>
+
+</head>
+
+
+<!--
+We are switching back to HTML now, and we're in the body section.
+-->
+
+<body
+  ng-app="SimpleApp">
+
+  <div
+    class="container container-fluid"
+    ng-controller="QueryController as qc">
+
+    <div class="row">
+
+      <!-- Single button -->
+      <div class="col-xs-6 btn-group" uib-dropdown is-open="status.isopen">
+        <button id="single-button" type="button" class="btn btn-primary btn-block btn-sm" uib-dropdown-toggle ng-disabled="disabled">
+          Select Minerva Server <span class="caret"></span>
+        </button>
+        <ul uib-dropdown-menu role="menu" aria-labelledby="single-button">
+          <li>
+            <a
+              ng-click="qc.minervaServerUrl='http://localhost:6800'">
+              http://localhost:6800
+            </a>
+          </li>
+          <li>
+            <a
+              ng-click="qc.minervaServerUrl='http://poole.monarchinitiative.org:3400/api/minerva_monarch_dev'">
+              http://poole.monarchinitiative.org:3400/api/minerva_monarch_dev
+            </a>
+          </li>
+        </ul>
+      </div>
+
+      <div class="col-xs-6">
+        <h5>Minerva Server: {{qc.minervaServerUrl}}</h5>
+      </div>
+    </div>
+
+    <div class="row">
+
+      <div class="panel panel-default">
+        <div class="panel-heading">
+          <h3 class="panel-title">Simple Get Test</h3>
+        </div>
+        <div class="panel-body">
+          <p>
+          This test exercises the ability to make a simple Minerva <strong>/status</strong>
+          request. For some reason, the public Minerva instance does not allow this request, yet.
+          I'm guessing that it's because the production instance is out of date and doesn't
+          yet support <strong>/status</strong>, which is quite new.
+          </p>
+
+          <button
+            class="btn btn-info btn-sm"
+            ng-click="qc.performStatusTest()">
+          Exercise <strong>GET</strong> against the Minerva
+          <strong>{{qc.minervaServerUrl}}/status</strong> endpoint
+          </button>
+
+          <button
+            class="btn btn-info btn-sm"
+            ng-click="qc.performStatusMemoryTest()">
+          Exercise <strong>GET</strong> against the Minerva
+          <strong>{{qc.minervaServerUrl}}/status/memory</strong> endpoint.
+          </button>
+
+          <div
+            class="well"
+            ng-if="qc.statusResponse"
+            style="font-size:0.7em;font-weight:500;">
+            <h4>{{qc.minervaServerUrl}}{{qc.statusRequest}}</h4>
+            <json-formatter open="3" json="qc.statusResponse">
+            </json-formatter>
+          </div>
+        </div>
+      </div>
+
+      <div class="panel panel-default">
+        <div class="panel-heading">
+          <h3 class="panel-title">Short Get Test</h3>
+        </div>
+        <div class="panel-body">
+          <p>
+          This test exercises the ability to make an <strong>m3Batch</strong> request.
+          The request is based upon the file
+          <strong>./minerva-server/src/test/resources/server-test/long-get.txt</strong>,
+          but has been shortened so that it passes through whatever nginx/apache/firewall
+          configuration is limiting the use of the full <strong>long-get</strong>.
+          </p>
+
+          <button
+            class="btn btn-primary btn-sm"
+            ng-click="qc.performShortGet()">
+          Perform Short GET Test against <strong>{{qc.minervaServerUrl}}</strong>
+          </button>
+
+          <div
+            class="well"
+            ng-if="qc.response"
+            style="font-size:0.7em;font-weight:500;">
+            <json-formatter open="3" json="qc.response">
+            </json-formatter>
+          </div>
+        </div>
+      </div>
+
+      <div class="panel panel-default">
+        <div class="panel-heading">
+          <h3 class="panel-title">Noctua Landing Test</h3>
+        </div>
+        <div class="panel-body">
+          <p>
+          This test exercises the same request that is causing an error in Noctua.
+          </p>
+
+          <button
+            class="btn btn-primary btn-sm"
+            ng-click="qc.performNoctuaLandingRequest()">
+          Perform the buggy request that Noctua is making on load. I'm debugging this.
+          </button>
+
+          <div
+            class="well"
+            ng-if="qc.noctuaLandingResponse"
+            style="font-size:0.7em;font-weight:500;">
+            <json-formatter open="3" json="qc.noctuaLandingResponse">
+            </json-formatter>
+          </div>
+        </div>
+      </div>
+
+    </div>
+  </div>
+
+</body>
+</html>
+
+

--- a/scripts/startServerExample.sh
+++ b/scripts/startServerExample.sh
@@ -1,26 +1,36 @@
-mvn package -am -pl minerva-server -Dmaven.javadoc.skip=true -Dsource.skip=true -DskipTests
+mvn package ${MINERVA_MAVEN_OPTS} -am -pl minerva-server -Dmaven.javadoc.skip=true -Dsource.skip=true -DskipTests
 
 echo "------------------"
 echo "------------------"
 echo "------------------"
 
-export MINERVA_MEMORY=2G
+# java -Xmx4G -cp ./java/lib/minerva-cli.jar org.geneontology.minerva.server.StartUpTool --use-golr-url-logging --use-request-logging --slme-elk -g http://purl.obolibrary.org/obo/go/extensions/go-lego.owl --set-important-relation-parent http://purl.obolibrary.org/obo/LEGOREL_0000000 --golr-labels http://noctua-golr.berkeleybop.org/ --golr-seed http://golr.berkeleybop.org/ -c ~/MI/models/ontology/extensions/catalog-v001.xml -f ~MI/models/noctua-models/models/ --port 6800
+export MINERVA_MEMORY=5G
 export MINERVA_PORT=6800
-export GO_ROOT=./cache
-export NOCTUA_MODELS=../noctua-models/models
 export MINERVA_SERVER=./minerva-server/bin/minerva-server.jar
+export MODELSLOC=../models
+export NOCTUA_MODELS=$MODELSLOC/noctua-models/models
+export GO_ROOT=$MODELSLOC/ontology/extensions/
+export GFLAG=http://purl.obolibrary.org/obo/upheno/monarch.owl 	# ${GO_ROOT}/go-lego.owl
+export CATALOG=../amigo/monarchOntologyCore/cached-models/catalog.xml
+# export GOLR_NEO_LOOKUP_URL=http://noctua-golr.berkeleybop.org/
+# export GOLR_LOOKUP_URL=http://golr.berkeleybop.org/
+export GOLR_NEO_LOOKUP_URL=http://solr-dev.monarchinitiative.org/solr/ontology
+export GOLR_LOOKUP_URL=http://solr-dev.monarchinitiative.org/solr/ontology
 
 java \
 	-Xmx${MINERVA_MEMORY} \
 	-jar ${MINERVA_SERVER} \
-	-g ${GO_ROOT}/merged.owl \
+	-g ${GFLAG} \
 	-f ${NOCTUA_MODELS} \
 	--port ${MINERVA_PORT} \
-	-c ${GO_ROOT}/catalog-v001.xml \
-	--use-golr-url-logging \
+	-c ${CATALOG} \
 	--slme-elk \
 	--use-golr-url-logging \
-	--use-golr-url-logging \
+	--set-important-relation-parent http://purl.obolibrary.org/obo/LEGOREL_0000000 \
+	--golr-labels ${GOLR_NEO_LOOKUP_URL} \
+	--golr-seed ${GOLR_LOOKUP_URL}
+
 exit
 
 


### PR DESCRIPTION
 - Added env variable detection for GENEONTOLOGY_CATALOG and
  MINERVA_MAVEN_OPTS to deal with faster cached behavior and offline
code.berkeleybop.org during unit tests. Production versions of Minerva get their configuration via the command-line options still.
- Added some scripts that might be helpful to future Minerva-nauts.
- Ensure that the tests respect the GENEONTOLOGY_CATALOG env var, which
  massively speeds up unit tests.
- Adds --help and --version commands to CLI.
- Adds /status and /memstatus endpoint, both of which do the same thing right now.
- Adds single-file webpage test for Minerva.
- fixes NOCTUA_MODELS defn for startServerExample.sh.