### PR TITLE
Changed OWL document format from Manchester to Turtle.

### DIFF
--- a/minerva-core/src/main/java/org/geneontology/minerva/FileBasedMolecularModelManager.java
+++ b/minerva-core/src/main/java/org/geneontology/minerva/FileBasedMolecularModelManager.java
@@ -17,6 +17,7 @@ import org.semanticweb.owlapi.formats.FunctionalSyntaxDocumentFormat;
 import org.semanticweb.owlapi.formats.ManchesterSyntaxDocumentFormat;
 import org.semanticweb.owlapi.formats.OWLXMLDocumentFormat;
 import org.semanticweb.owlapi.formats.RDFXMLDocumentFormat;
+import org.semanticweb.owlapi.formats.TurtleDocumentFormat;
 import org.semanticweb.owlapi.model.AddImport;
 import org.semanticweb.owlapi.model.IRI;
 import org.semanticweb.owlapi.model.OWLAnnotation;
@@ -54,8 +55,8 @@ public class FileBasedMolecularModelManager<METADATA> extends CoreMolecularModel
 	private final String modelIdPrefix;
 	
 	GafObjectsBuilder builder = new GafObjectsBuilder();
-	// WARNING: Do *NOT* switch to functional syntax until the OWL-API has fixed a bug.
-	OWLDocumentFormat ontologyFormat = new ManchesterSyntaxDocumentFormat();
+	
+	OWLDocumentFormat ontologyFormat = new TurtleDocumentFormat();
 
 	private final List<PreFileSaveHandler> preFileSaveHandlers = new ArrayList<PreFileSaveHandler>();
 	private final List<PostLoadOntologyFilter> postLoadOntologyFilters = new ArrayList<PostLoadOntologyFilter>();


### PR DESCRIPTION
This changes the default format for storing models to RDF Turtle, as suggested in https://github.com/geneontology/noctua-models/issues/14. Consequently it also changes the download format received when using `Model > Export OWL` in the Noctua UI. Should that be Turtle or would users have another expectation?

It sounds like this requires some changes in `epione.js` before merging this, @kltm? Although it seems to work fine with Noctua on my desktop.

Also I guess we should do a bulk translation of the Noctua models GitHub repository. If not, I think this change will transparently migrate files anyway as they are edited.