### PR TITLE
Added stricter handling for IRI creation.

### DIFF
--- a/minerva-converter/src/main/java/org/geneontology/minerva/GafToLegoIndividualTranslator.java
+++ b/minerva-converter/src/main/java/org/geneontology/minerva/GafToLegoIndividualTranslator.java
@@ -10,6 +10,7 @@ import java.util.UUID;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.log4j.Logger;
+import org.geneontology.minerva.MolecularModelManager.UnknownIdentifierException;
 import org.geneontology.minerva.curie.CurieHandler;
 import org.semanticweb.owlapi.model.AddImport;
 import org.semanticweb.owlapi.model.IRI;
@@ -86,8 +87,9 @@ public class GafToLegoIndividualTranslator {
 	 * @param gaf
 	 * @return lego ontology
 	 * @throws OWLException
+	 * @throws UnknownIdentifierException 
 	 */
-	public OWLOntology translate(GafDocument gaf) throws OWLException {
+	public OWLOntology translate(GafDocument gaf) throws OWLException, UnknownIdentifierException {
 		final OWLOntologyManager m = graph.getManager();
 		OWLOntology lego = m.createOntology(IRI.generateDocumentIRI());
 		OWLOntology sourceOntology = graph.getSourceOntology();
@@ -110,8 +112,9 @@ public class GafToLegoIndividualTranslator {
 	 * @param annotations
 	 * @param lego
 	 * @throws OWLException 
+	 * @throws UnknownIdentifierException 
 	 */
-	public void translate(Collection<GeneAnnotation> annotations, final OWLOntology lego) throws OWLException {
+	public void translate(Collection<GeneAnnotation> annotations, final OWLOntology lego) throws OWLException, UnknownIdentifierException {
 		final OWLOntologyManager m = graph.getManager();
 
 		Set<OWLAxiom> axioms = new HashSet<OWLAxiom>();
@@ -127,8 +130,9 @@ public class GafToLegoIndividualTranslator {
 	 * @param annotation
 	 * @param axioms
 	 * @throws OWLException 
+	 * @throws UnknownIdentifierException 
 	 */
-	public void translate(GeneAnnotation annotation, Set<OWLAxiom> axioms) throws OWLException {
+	public void translate(GeneAnnotation annotation, Set<OWLAxiom> axioms) throws OWLException, UnknownIdentifierException {
 		// skip ND annotations
 		if ("ND".equals(annotation.getShortEvidence())) {
 			reportWarn("Skipping ND annotation", annotation);
@@ -192,7 +196,7 @@ public class GafToLegoIndividualTranslator {
 	}
 	
 	
-	private void translate(GeneAnnotation annotation, OWLClassExpression ce, Set<OWLAxiom> axioms) throws OWLException {
+	private void translate(GeneAnnotation annotation, OWLClassExpression ce, Set<OWLAxiom> axioms) throws OWLException, UnknownIdentifierException {
 		final OWLDataFactory f = graph.getDataFactory();
 
 		// # STEP 1 - Bioentity instance
@@ -314,7 +318,7 @@ public class GafToLegoIndividualTranslator {
 		}
 	}
 
-	private OWLClass addBioentityCls(String id, String lbl, String taxon, Set<OWLAxiom> axioms, OWLDataFactory f) {
+	private OWLClass addBioentityCls(String id, String lbl, String taxon, Set<OWLAxiom> axioms, OWLDataFactory f) throws UnknownIdentifierException {
 		IRI iri = curieHandler.getIRI(id);
 		OWLClass cls = f.getOWLClass(iri);
 		boolean add = axioms.add(f.getOWLDeclarationAxiom(cls));

--- a/minerva-converter/src/main/java/org/geneontology/minerva/legacy/AbstractLegoTranslator.java
+++ b/minerva-converter/src/main/java/org/geneontology/minerva/legacy/AbstractLegoTranslator.java
@@ -10,6 +10,7 @@ import java.util.Set;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
+import org.geneontology.minerva.MolecularModelManager.UnknownIdentifierException;
 import org.geneontology.minerva.curie.CurieHandler;
 import org.geneontology.minerva.evidence.FindGoCodes;
 import org.geneontology.minerva.lookup.ExternalLookupService;
@@ -67,7 +68,7 @@ abstract class AbstractLegoTranslator extends LegoModelWalker<AbstractLegoTransl
         goCodes = new FindGoCodes(mapper, curieHandler);
 
         mf = OBOUpperVocabulary.GO_molecular_function.getOWLClass(f);
-        cc = f.getOWLClass(curieHandler.getIRI("GO:0005575"));
+        cc = f.getOWLClass(IRI.create("http://purl.obolibrary.org/obo/GO_0005575"));
         bp = OBOUpperVocabulary.GO_biological_process.getOWLClass(f);
     
         bpSet = new HashSet<>();
@@ -270,7 +271,7 @@ abstract class AbstractLegoTranslator extends LegoModelWalker<AbstractLegoTransl
         return isGoAnnotation;
     }
 
-    public abstract void translate(OWLOntology modelAbox, ExternalLookupService lookup, GafDocument annotations, List<String> additionalRefs);
+    public abstract void translate(OWLOntology modelAbox, ExternalLookupService lookup, GafDocument annotations, List<String> additionalRefs) throws UnknownIdentifierException;
 
     /**
      * Get the type of an enabled by entity, e.g. gene, protein
@@ -297,7 +298,7 @@ abstract class AbstractLegoTranslator extends LegoModelWalker<AbstractLegoTransl
         return "gene";
     }
 
-    protected String getEntityTaxon(OWLClass entity, OWLOntology model) {
+    protected String getEntityTaxon(OWLClass entity, OWLOntology model) throws UnknownIdentifierException {
         if (entity == null) {
             return null;
         }
@@ -305,7 +306,7 @@ abstract class AbstractLegoTranslator extends LegoModelWalker<AbstractLegoTransl
         return tool.getEntityTaxon(curieHandler.getCuri(entity), model);
     }
 
-    public GafDocument translate(String id, OWLOntology modelAbox, ExternalLookupService lookup, List<String> additionalReferences) {
+    public GafDocument translate(String id, OWLOntology modelAbox, ExternalLookupService lookup, List<String> additionalReferences) throws UnknownIdentifierException {
         final GafDocument annotations = new GafDocument(id, null);
         translate(modelAbox, lookup, annotations, additionalReferences);
         return annotations;

--- a/minerva-converter/src/main/java/org/geneontology/minerva/legacy/GafExportTool.java
+++ b/minerva-converter/src/main/java/org/geneontology/minerva/legacy/GafExportTool.java
@@ -10,6 +10,7 @@ import java.util.Set;
 
 import org.apache.commons.io.IOUtils;
 import org.geneontology.minerva.ModelContainer;
+import org.geneontology.minerva.MolecularModelManager.UnknownIdentifierException;
 import org.geneontology.minerva.curie.CurieHandler;
 import org.geneontology.minerva.lookup.ExternalLookupService;
 import org.semanticweb.owlapi.model.OWLOntology;
@@ -47,8 +48,9 @@ public class GafExportTool {
 	 * @param formats set of format names
 	 * @return modelContent
 	 * @throws OWLOntologyCreationException
+	 * @throws UnknownIdentifierException 
 	 */
-	public Map<String, String> exportModelLegacy(ModelContainer model, CurieHandler curieHandler, ExternalLookupService lookup, Set<String> formats) throws OWLOntologyCreationException {
+	public Map<String, String> exportModelLegacy(ModelContainer model, CurieHandler curieHandler, ExternalLookupService lookup, Set<String> formats) throws OWLOntologyCreationException, UnknownIdentifierException {
 		final OWLOntology aBox = model.getAboxOntology();
 		
 		LegoToGeneAnnotationTranslator translator = new LegoToGeneAnnotationTranslator(aBox, curieHandler, ecoMapper);

--- a/minerva-converter/src/main/java/org/geneontology/minerva/legacy/GroupingTranslator.java
+++ b/minerva-converter/src/main/java/org/geneontology/minerva/legacy/GroupingTranslator.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.geneontology.minerva.MolecularModelManager.UnknownIdentifierException;
 import org.geneontology.minerva.curie.CurieHandler;
 import org.geneontology.minerva.lookup.ExternalLookupService;
 import org.geneontology.minerva.util.AnnotationShorthand;
@@ -108,7 +109,7 @@ public class GroupingTranslator {
 		this.addLegoModelId = addLegoModelId;
 	}
 	
-	public void translate(OWLOntology model) {
+	public void translate(OWLOntology model) throws UnknownIdentifierException {
 		// get curie
 		String modelCurie = getModelCurie(model, curieHandler, null);
 		

--- a/minerva-converter/src/main/java/org/geneontology/minerva/legacy/LegoModelWalker.java
+++ b/minerva-converter/src/main/java/org/geneontology/minerva/legacy/LegoModelWalker.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.geneontology.minerva.MolecularModelManager.UnknownIdentifierException;
 import org.geneontology.minerva.lookup.ExternalLookupService;
 import org.geneontology.minerva.util.AnnotationShorthand;
 import org.obolibrary.obo2owl.Obo2OWLConstants;
@@ -109,7 +110,7 @@ abstract class LegoModelWalker<PAYLOAD> {
 		String date = null;
 	}
 
-	public void walkModel(OWLOntology model, ExternalLookupService lookup, Collection<PAYLOAD> allPayloads) {
+	public void walkModel(OWLOntology model, ExternalLookupService lookup, Collection<PAYLOAD> allPayloads) throws UnknownIdentifierException {
 		final OWLGraphWrapper modelGraph = new OWLGraphWrapper(model);
 		
 		String modelId = null;
@@ -377,7 +378,7 @@ abstract class LegoModelWalker<PAYLOAD> {
 		return result;
 	}
 	
-	protected abstract PAYLOAD initPayload(OWLNamedIndividual object, OWLClass objectType, OWLOntology model, OWLGraphWrapper modelGraph, ExternalLookupService lookup);
+	protected abstract PAYLOAD initPayload(OWLNamedIndividual object, OWLClass objectType, OWLOntology model, OWLGraphWrapper modelGraph, ExternalLookupService lookup) throws UnknownIdentifierException;
 	
 	protected abstract boolean handleCC(PAYLOAD payload, OWLClass cls, Metadata metadata, Set<Evidence> evidences, Set<OWLObjectSomeValuesFrom> expressions);
 	

--- a/minerva-converter/src/main/java/org/geneontology/minerva/legacy/LegoToGeneAnnotationTranslator.java
+++ b/minerva-converter/src/main/java/org/geneontology/minerva/legacy/LegoToGeneAnnotationTranslator.java
@@ -4,6 +4,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import org.geneontology.minerva.MolecularModelManager.UnknownIdentifierException;
 import org.geneontology.minerva.curie.CurieHandler;
 import org.geneontology.minerva.lookup.ExternalLookupService;
 import org.semanticweb.owlapi.model.OWLClass;
@@ -28,7 +29,7 @@ public class LegoToGeneAnnotationTranslator extends AbstractLegoTranslator {
 	}
 
 	@Override
-	public void translate(OWLOntology modelAbox, ExternalLookupService lookup, GafDocument annotations, List<String> additionalRefs) {
+	public void translate(OWLOntology modelAbox, ExternalLookupService lookup, GafDocument annotations, List<String> additionalRefs) throws UnknownIdentifierException {
 		Set<Summary> summaries = new HashSet<Summary>();
 		walkModel(modelAbox, lookup, summaries);
 		
@@ -42,7 +43,7 @@ public class LegoToGeneAnnotationTranslator extends AbstractLegoTranslator {
 
 	@Override
 	protected Summary initPayload(OWLNamedIndividual object,
-			OWLClass objectType, OWLOntology model, OWLGraphWrapper modelGraph, ExternalLookupService lookup) {
+			OWLClass objectType, OWLOntology model, OWLGraphWrapper modelGraph, ExternalLookupService lookup) throws UnknownIdentifierException {
 		Summary summary = new Summary();
 		summary.entity = objectType;
 		summary.entityTaxon = getEntityTaxon(objectType, model);

--- a/minerva-converter/src/main/java/org/geneontology/minerva/taxon/FindTaxonTool.java
+++ b/minerva-converter/src/main/java/org/geneontology/minerva/taxon/FindTaxonTool.java
@@ -4,6 +4,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 import org.apache.commons.io.IOUtils;
+import org.geneontology.minerva.MolecularModelManager.UnknownIdentifierException;
 import org.geneontology.minerva.curie.CurieHandler;
 import org.obolibrary.obo2owl.Obo2OWLConstants;
 import org.semanticweb.owlapi.model.IRI;
@@ -32,7 +33,7 @@ public class FindTaxonTool {
 		inTaxon = df.getOWLObjectProperty(IN_TAXON_IRI);
 	}
 	
-	public String getEntityTaxon(String curie, OWLOntology model) {
+	public String getEntityTaxon(String curie, OWLOntology model) throws UnknownIdentifierException {
 		if (curie == null || curie.isEmpty()) {
 			return null;
 		}
@@ -77,7 +78,7 @@ public class FindTaxonTool {
 		return null;
 	}
 	
-	public OWLAxiom createTaxonAxiom(OWLClass entity, String taxon, OWLOntology model, Set<OWLAnnotation> tags) {
+	public OWLAxiom createTaxonAxiom(OWLClass entity, String taxon, OWLOntology model, Set<OWLAnnotation> tags) throws UnknownIdentifierException {
 		OWLDataFactory df = model.getOWLOntologyManager().getOWLDataFactory();
 		OWLClass taxonCls = df.getOWLClass(curieHandler.getIRI(taxon));
 		OWLAxiom axiom = df.getOWLSubClassOfAxiom(entity, df.getOWLObjectSomeValuesFrom(inTaxon, taxonCls), tags);

--- a/minerva-converter/src/test/java/org/geneontology/minerva/evidence/FindGoCodesTest.java
+++ b/minerva-converter/src/test/java/org/geneontology/minerva/evidence/FindGoCodesTest.java
@@ -3,6 +3,7 @@ package org.geneontology.minerva.evidence;
 import static org.junit.Assert.*;
 
 import org.apache.commons.lang3.tuple.Pair;
+import org.geneontology.minerva.MolecularModelManager.UnknownIdentifierException;
 import org.geneontology.minerva.curie.CurieHandler;
 import org.geneontology.minerva.curie.DefaultCurieHandler;
 import org.junit.BeforeClass;
@@ -43,7 +44,7 @@ public class FindGoCodesTest {
 		assertEquals("IC", pair2.getLeft());
 	}
 	
-	private Pair<String, String> lookup(String testId) {
+	private Pair<String, String> lookup(String testId) throws UnknownIdentifierException {
 		IRI testIRI = curieHandler.getIRI(testId);
 		OWLClass testOwlClass = eco.getOWLOntologyManager().getOWLDataFactory().getOWLClass(testIRI);
 		Pair<String, String> pair = codes.findShortEvidence(testOwlClass, testId, eco);

--- a/minerva-converter/src/test/java/org/geneontology/minerva/legacy/LegoToGeneAnnotationTranslatorTest.java
+++ b/minerva-converter/src/test/java/org/geneontology/minerva/legacy/LegoToGeneAnnotationTranslatorTest.java
@@ -13,6 +13,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import org.geneontology.minerva.MolecularModelManager.UnknownIdentifierException;
 import org.geneontology.minerva.curie.CurieHandler;
 import org.geneontology.minerva.curie.DefaultCurieHandler;
 import org.geneontology.minerva.lookup.ExternalLookupService;
@@ -183,7 +184,7 @@ public class LegoToGeneAnnotationTranslatorTest {
 		return model;
 	}
 	
-	private GafDocument translate(OWLOntology model, String id, List<LookupEntry> entities) {
+	private GafDocument translate(OWLOntology model, String id, List<LookupEntry> entities) throws UnknownIdentifierException {
 		LegoToGeneAnnotationTranslator t = new LegoToGeneAnnotationTranslator(model, curieHandler, mapper);
 		ExternalLookupService lookup = null;
 		if (entities != null) {

--- a/minerva-core/src/main/java/org/geneontology/minerva/FileBasedMolecularModelManager.java
+++ b/minerva-core/src/main/java/org/geneontology/minerva/FileBasedMolecularModelManager.java
@@ -12,6 +12,7 @@ import java.util.Set;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.log4j.Logger;
+import org.geneontology.minerva.MolecularModelManager.UnknownIdentifierException;
 import org.geneontology.minerva.util.ReverseChangeGenerator;
 import org.semanticweb.owlapi.formats.FunctionalSyntaxDocumentFormat;
 import org.semanticweb.owlapi.formats.ManchesterSyntaxDocumentFormat;
@@ -167,8 +168,9 @@ public class FileBasedMolecularModelManager<METADATA> extends CoreMolecularModel
 	 * @throws OWLOntologyStorageException
 	 * @throws OWLOntologyCreationException
 	 * @throws IOException 
+	 * @throws UnknownIdentifierException 
 	 */
-	public void saveAllModels(Set<OWLAnnotation> annotations, METADATA metadata) throws OWLOntologyStorageException, OWLOntologyCreationException, IOException {
+	public void saveAllModels(Set<OWLAnnotation> annotations, METADATA metadata) throws OWLOntologyStorageException, OWLOntologyCreationException, IOException, UnknownIdentifierException {
 		for (Entry<IRI, ModelContainer> entry : modelMap.entrySet()) {
 			saveModel(entry.getValue(), annotations, metadata);
 		}
@@ -184,8 +186,9 @@ public class FileBasedMolecularModelManager<METADATA> extends CoreMolecularModel
 	 * @throws OWLOntologyStorageException 
 	 * @throws OWLOntologyCreationException 
 	 * @throws IOException
+	 * @throws UnknownIdentifierException 
 	 */
-	public void saveModel(ModelContainer m, Set<OWLAnnotation> annotations, METADATA metadata) throws OWLOntologyStorageException, OWLOntologyCreationException, IOException {
+	public void saveModel(ModelContainer m, Set<OWLAnnotation> annotations, METADATA metadata) throws OWLOntologyStorageException, OWLOntologyCreationException, IOException, UnknownIdentifierException {
 		IRI modelId = m.getModelId();
 		final OWLOntology ont = m.getAboxOntology();
 		final OWLOntologyManager manager = ont.getOWLOntologyManager();
@@ -229,7 +232,7 @@ public class FileBasedMolecularModelManager<METADATA> extends CoreMolecularModel
 
 	private void saveToFile(final OWLOntology ont, final OWLOntologyManager manager,
 			final File outfile, METADATA metadata)
-			throws OWLOntologyStorageException {
+			throws OWLOntologyStorageException, UnknownIdentifierException {
 		
 		List<OWLOntologyChange> changes = preSaveFileHandler(ont);
 		final IRI outfileIRI = IRI.create(outfile);
@@ -246,7 +249,7 @@ public class FileBasedMolecularModelManager<METADATA> extends CoreMolecularModel
 		}
 	}
 	
-	private List<OWLOntologyChange> preSaveFileHandler(OWLOntology model) {
+	private List<OWLOntologyChange> preSaveFileHandler(OWLOntology model) throws UnknownIdentifierException {
 		List<OWLOntologyChange> allChanges = null;
 		for(PreFileSaveHandler handler : preFileSaveHandlers) {
 			List<OWLOntologyChange> changes = handler.handle(model);
@@ -262,7 +265,7 @@ public class FileBasedMolecularModelManager<METADATA> extends CoreMolecularModel
 	
 	public static interface PreFileSaveHandler {
 		
-		public List<OWLOntologyChange> handle(OWLOntology model);
+		public List<OWLOntologyChange> handle(OWLOntology model) throws UnknownIdentifierException;
 	}
 	
 	public void addPreFileSaveHandler(PreFileSaveHandler handler) {

--- a/minerva-core/src/main/java/org/geneontology/minerva/MolecularModelManager.java
+++ b/minerva-core/src/main/java/org/geneontology/minerva/MolecularModelManager.java
@@ -316,7 +316,7 @@ public class MolecularModelManager<METADATA> extends FileBasedMolecularModelMana
 		return resultSet;
 	}
 	
-	private OWLNamedIndividual getIndividual(String indId, ModelContainer model) {
+	private OWLNamedIndividual getIndividual(String indId, ModelContainer model) throws UnknownIdentifierException {
 		IRI iri = curieHandler.getIRI(indId);
 		return getIndividual(iri, model);
 	}
@@ -329,15 +329,15 @@ public class MolecularModelManager<METADATA> extends FileBasedMolecularModelMana
 		OWLNamedIndividual individual = model.getOWLDataFactory().getOWLNamedIndividual(iri);
 		return individual;
 	}
-	private OWLClass getClass(String cid, ModelContainer model) {
+	private OWLClass getClass(String cid, ModelContainer model) throws UnknownIdentifierException {
 		OWLGraphWrapper graph = new OWLGraphWrapper(model.getAboxOntology());
 		return getClass(cid, graph);
 	}
-	private OWLClass getClass(String cid, OWLGraphWrapper graph) {
+	private OWLClass getClass(String cid, OWLGraphWrapper graph) throws UnknownIdentifierException {
 		IRI iri = curieHandler.getIRI(cid);
 		return graph.getOWLClass(iri);
 	}
-	public OWLObjectProperty getObjectProperty(String pid, ModelContainer model) {
+	public OWLObjectProperty getObjectProperty(String pid, ModelContainer model) throws UnknownIdentifierException {
 		OWLGraphWrapper graph = new OWLGraphWrapper(model.getAboxOntology());
 		IRI iri = curieHandler.getIRI(pid);
 		return graph.getOWLObjectProperty(iri);

--- a/minerva-core/src/main/java/org/geneontology/minerva/curie/CurieHandler.java
+++ b/minerva-core/src/main/java/org/geneontology/minerva/curie/CurieHandler.java
@@ -1,5 +1,6 @@
 package org.geneontology.minerva.curie;
 
+import org.geneontology.minerva.MolecularModelManager.UnknownIdentifierException;
 import org.semanticweb.owlapi.model.IRI;
 import org.semanticweb.owlapi.model.OWLAnnotationProperty;
 import org.semanticweb.owlapi.model.OWLClass;
@@ -21,6 +22,6 @@ public interface CurieHandler {
 	
 	public String getCuri(IRI iri);
 	
-	public IRI getIRI(String curi);
+	public IRI getIRI(String curi) throws UnknownIdentifierException;
 
 }

--- a/minerva-core/src/main/java/org/geneontology/minerva/curie/MappedCurieHandler.java
+++ b/minerva-core/src/main/java/org/geneontology/minerva/curie/MappedCurieHandler.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 
 import org.apache.commons.lang3.StringUtils;
+import org.geneontology.minerva.MolecularModelManager.UnknownIdentifierException;
 import org.semanticweb.owlapi.model.IRI;
 import org.semanticweb.owlapi.model.OWLAnnotationProperty;
 import org.semanticweb.owlapi.model.OWLClass;
@@ -95,7 +96,10 @@ public class MappedCurieHandler implements CurieHandler {
 	}
 
 	@Override
-	public IRI getIRI(String curi) {
+	public IRI getIRI(String curi) throws UnknownIdentifierException {
+		if (!curi.contains(":")) {
+			throw new UnknownIdentifierException("Relative IRIs are not allowed: " + curi);
+		}
 		String[] parts = StringUtils.split(curi, ":", 2);
 		if (parts.length == 2) {
 			String prefix = parts[0];
@@ -104,7 +108,11 @@ public class MappedCurieHandler implements CurieHandler {
 				return IRI.create(longPrefix + curi.substring(prefix.length() + 1));
 			}
 		}
-		return IRI.create(curi);
+		if (curi.startsWith("http:") || curi.startsWith("https:") || curi.startsWith("urn:") || curi.startsWith("mailto:")) {
+			return IRI.create(curi);			
+		} else {
+			throw new UnknownIdentifierException("Unknown URI protocol: " + curi);
+		}
 	}
 
 	/**

--- a/minerva-core/src/main/java/org/geneontology/minerva/util/AnnotationShorthand.java
+++ b/minerva-core/src/main/java/org/geneontology/minerva/util/AnnotationShorthand.java
@@ -1,5 +1,6 @@
 package org.geneontology.minerva.util;
 
+import org.geneontology.minerva.MolecularModelManager.UnknownIdentifierException;
 import org.geneontology.minerva.curie.CurieHandler;
 import org.semanticweb.owlapi.model.IRI;
 import org.semanticweb.owlapi.vocab.OWLRDFVocabulary;
@@ -62,13 +63,20 @@ public enum AnnotationShorthand {
 	
 	public static AnnotationShorthand getShorthand(String name, CurieHandler curieHandler) {
 		if (name != null) {
-			IRI iri = curieHandler.getIRI(name);
 			for (AnnotationShorthand type : AnnotationShorthand.values()) {
 				if (type.name().equals(name) || (type.othername != null && type.othername.equals(name))) {
 					return type;
 				}
-				else if (iri.equals(type.annotationProperty)) {
-					return type;
+				else {
+					final IRI iri;
+					try {
+						iri = curieHandler.getIRI(name);
+						if (iri.equals(type.annotationProperty)) {
+							return type;
+						}
+					} catch (UnknownIdentifierException e) {
+						continue;
+					}
 				}
 			}
 		}

--- a/minerva-core/src/test/java/org/geneontology/minerva/MolecularModelManagerTest.java
+++ b/minerva-core/src/test/java/org/geneontology/minerva/MolecularModelManagerTest.java
@@ -12,6 +12,7 @@ import java.util.Set;
 
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
+import org.geneontology.minerva.MolecularModelManager.UnknownIdentifierException;
 import org.geneontology.minerva.curie.CurieHandler;
 import org.geneontology.minerva.curie.DefaultCurieHandler;
 import org.junit.Rule;
@@ -200,7 +201,7 @@ public class MolecularModelManagerTest extends OWLToolsTestBasics {
 	}
 	
 	private void addPartOf(ModelContainer model, OWLNamedIndividual i1, OWLNamedIndividual i2, 
-			MolecularModelManager<Void> m3) {
+			MolecularModelManager<Void> m3) throws UnknownIdentifierException {
 		IRI partOfIRI = curieHandler.getIRI("BFO:0000050");
 		final OWLObjectProperty partOf = model.getOWLDataFactory().getOWLObjectProperty(partOfIRI);
 		m3.addFact(model, partOf, i1, i2, Collections.<OWLAnnotation>emptySet(), null);

--- a/minerva-core/src/test/java/org/geneontology/minerva/curie/DefaultCurieHandlerTest.java
+++ b/minerva-core/src/test/java/org/geneontology/minerva/curie/DefaultCurieHandlerTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.*;
 
 import java.io.InputStream;
 
+import org.geneontology.minerva.MolecularModelManager.UnknownIdentifierException;
 import org.junit.Test;
 import org.semanticweb.owlapi.apibinding.OWLManager;
 import org.semanticweb.owlapi.model.IRI;
@@ -41,7 +42,7 @@ public class DefaultCurieHandlerTest {
 	}
 
 	@Test
-	public void testConversions() {
+	public void testConversions() throws UnknownIdentifierException {
 		CurieHandler handler = DefaultCurieHandler.getDefaultHandler();
 		final OWLDataFactory f = OWLManager.createOWLOntologyManager().getOWLDataFactory();
 		
@@ -60,7 +61,11 @@ public class DefaultCurieHandlerTest {
 		assertEquals(longPmid, handler.getIRI("PMID:0000"));
 		assertEquals("PMID:0000", handler.getCuri(f.getOWLClass(longPmid)));
 		
-		// test fallback for non existing prefix
-		assertEquals(IRI.create("BLABLA:000001"), handler.getIRI("BLABLA:000001"));
+		// test failure for non existing prefix
+		try {
+			handler.getIRI("BLABLA:000001");
+			fail("Expected an UnknownIdentifierException to be thrown");
+		} catch (UnknownIdentifierException e) {
+		}
 	}
 }

--- a/minerva-server/src/main/java/org/geneontology/minerva/ModelWriterHelper.java
+++ b/minerva-server/src/main/java/org/geneontology/minerva/ModelWriterHelper.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Set;
 
 import org.geneontology.minerva.FileBasedMolecularModelManager.PreFileSaveHandler;
+import org.geneontology.minerva.MolecularModelManager.UnknownIdentifierException;
 import org.geneontology.minerva.curie.CurieHandler;
 import org.geneontology.minerva.json.JsonModel;
 import org.geneontology.minerva.json.MolecularModelJsonRenderer;
@@ -36,12 +37,12 @@ import org.semanticweb.owlapi.model.OWLOntologyChange;
 import org.semanticweb.owlapi.model.OWLOntologyManager;
 import org.semanticweb.owlapi.util.OWLClassExpressionVisitorAdapter;
 
+import owltools.util.OwlHelper;
+import owltools.vocab.OBOUpperVocabulary;
+
 import com.google.common.base.Optional;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
-
-import owltools.util.OwlHelper;
-import owltools.vocab.OBOUpperVocabulary;
 
 public class ModelWriterHelper implements PreFileSaveHandler {
 
@@ -61,7 +62,7 @@ public class ModelWriterHelper implements PreFileSaveHandler {
 		enabledByIRI = OBOUpperVocabulary.GOREL_enabled_by.getIRI();
 	}
 
-	List<OWLOntologyChange> generateLabelsAndIds(OWLOntology model, ExternalLookupService lookupService) {
+	List<OWLOntologyChange> generateLabelsAndIds(OWLOntology model, ExternalLookupService lookupService) throws UnknownIdentifierException {
 		if (curieHandler == null && lookupService == null) {
 			return Collections.emptyList();
 		}
@@ -195,7 +196,7 @@ public class ModelWriterHelper implements PreFileSaveHandler {
 	}
 
 	@Override
-	public List<OWLOntologyChange> handle(OWLOntology model) {
+	public List<OWLOntologyChange> handle(OWLOntology model) throws UnknownIdentifierException {
 		List<OWLOntologyChange> allChanges = generateLabelsAndIds(model, lookupService);
 		model.getOWLOntologyManager().applyChanges(allChanges);
 		return allChanges;

--- a/minerva-server/src/main/java/org/geneontology/minerva/generate/ModelSeeding.java
+++ b/minerva-server/src/main/java/org/geneontology/minerva/generate/ModelSeeding.java
@@ -11,6 +11,7 @@ import java.util.Set;
 
 import org.geneontology.minerva.ModelContainer;
 import org.geneontology.minerva.MolecularModelManager;
+import org.geneontology.minerva.MolecularModelManager.UnknownIdentifierException;
 import org.geneontology.minerva.curie.CurieHandler;
 import org.geneontology.minerva.util.AnnotationShorthand;
 import org.geneontology.reasoner.ExpressionMaterializingReasoner;
@@ -175,7 +176,7 @@ public class ModelSeeding<METADATA> {
 		return groups;
 	}
 	
-	private Map<String, List<GeneAnnotation>> removeRedundants(Map<String, List<GeneAnnotation>> groups, final OWLDataFactory f) {
+	private Map<String, List<GeneAnnotation>> removeRedundants(Map<String, List<GeneAnnotation>> groups, final OWLDataFactory f) throws UnknownIdentifierException {
 		// calculate all ancestors for each group
 		Map<String, Set<String>> allAncestors = new HashMap<String, Set<String>>();
 		for(String cls : groups.keySet()) {
@@ -280,7 +281,12 @@ public class ModelSeeding<METADATA> {
 			}
 		}
 		if (ecoId != null) {
-			IRI ecoIRI = curieHandler.getIRI(ecoId);
+			IRI ecoIRI;
+			try {
+				ecoIRI = curieHandler.getIRI(ecoId);
+			} catch (UnknownIdentifierException e) {
+				ecoIRI = null;
+			}
 			if (ecoIRI != null) {
 				result = model.getOWLDataFactory().getOWLClass(ecoIRI);
 			}

--- a/minerva-server/src/main/java/org/geneontology/minerva/server/handler/ModelCreator.java
+++ b/minerva-server/src/main/java/org/geneontology/minerva/server/handler/ModelCreator.java
@@ -134,7 +134,7 @@ abstract class ModelCreator {
 		return result;
 	}
 	
-	Map<OWLDataProperty, Set<OWLLiteral>> extractDataProperties(JsonAnnotation[] values, ModelContainer model) {
+	Map<OWLDataProperty, Set<OWLLiteral>> extractDataProperties(JsonAnnotation[] values, ModelContainer model) throws UnknownIdentifierException {
 		Map<OWLDataProperty, Set<OWLLiteral>> result = new HashMap<OWLDataProperty, Set<OWLLiteral>>();
 		
 		if (values != null && values.length > 0) {

--- a/minerva-server/src/main/java/org/geneontology/minerva/server/handler/OperationsImpl.java
+++ b/minerva-server/src/main/java/org/geneontology/minerva/server/handler/OperationsImpl.java
@@ -634,7 +634,7 @@ abstract class OperationsImpl extends ModelCreator {
 		response.data.exportModel = exportModel;
 	}
 	
-	private void exportLegacy(M3BatchResponse response, ModelContainer model, String format, String userId) throws IOException, OWLOntologyCreationException {
+	private void exportLegacy(M3BatchResponse response, ModelContainer model, String format, String userId) throws IOException, OWLOntologyCreationException, UnknownIdentifierException {
 		final GafExportTool exportTool = GafExportTool.getInstance();
 		if (format == null) {
 			format = "gaf"; // set a default format, if necessary

--- a/minerva-server/src/test/java/org/geneontology/minerva/server/handler/BatchModelHandlerTest.java
+++ b/minerva-server/src/test/java/org/geneontology/minerva/server/handler/BatchModelHandlerTest.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.geneontology.minerva.MolecularModelManager.UnknownIdentifierException;
 import org.geneontology.minerva.UndoAwareMolecularModelManager;
 import org.geneontology.minerva.curie.CurieHandler;
 import org.geneontology.minerva.curie.CurieMappings;
@@ -73,7 +74,7 @@ public class BatchModelHandlerTest {
 		init(new ParserWrapper());
 	}
 
-	static void init(ParserWrapper pw) throws OWLOntologyCreationException, IOException {
+	static void init(ParserWrapper pw) throws OWLOntologyCreationException, IOException, UnknownIdentifierException {
 		Runtime runtime = Runtime.getRuntime();
 		long maxMemory = runtime.maxMemory();
 		double maxMemoryGB = (double)maxMemory / (double)(1024L*1024L*1024L);
@@ -108,7 +109,7 @@ public class BatchModelHandlerTest {
 		JsonOrJsonpBatchHandler.VALIDATE_BEFORE_SAVE = true;
 	}
 
-	private static ExternalLookupService createTestProteins(CurieHandler curieHandler) {
+	private static ExternalLookupService createTestProteins(CurieHandler curieHandler) throws UnknownIdentifierException {
 		List<LookupEntry> testEntries = new ArrayList<LookupEntry>();
 		testEntries.add(new LookupEntry(curieHandler.getIRI("UniProtKB:P0000"),
 				"P0000", "protein", "fake-taxon-id"));


### PR DESCRIPTION
This addresses #58. Tests pass on my machine, except for two reasoner tests that hit out of memory errors. These changes will throw an error if someone tries to enter a non-prefixed IRI or a prefixed IRI for which we don't have a prefix mapping. Noctua presents the error but it is a stack trace. Should this be made friendlier on the Minerva side?