### PR TITLE
Implemented support for 'provided-by' annotation (user groups).

### DIFF
--- a/minerva-core/src/main/java/org/geneontology/minerva/util/AnnotationShorthand.java
+++ b/minerva-core/src/main/java/org/geneontology/minerva/util/AnnotationShorthand.java
@@ -26,6 +26,7 @@ public enum AnnotationShorthand {
 	// DC recommends http://www.w3.org/TR/NOTE-datetime, one example format is YYYY-MM-DD
 	source(IRI.create("http://purl.org/dc/elements/1.1/source")), // arbitrary string, such as PMID:000000
 	contributor(IRI.create("http://purl.org/dc/elements/1.1/contributor")), // who contributed to the annotation
+	providedBy(IRI.create("http://purl.org/pav/providedBy")), // organization supporting the annotation
 	title(IRI.create("http://purl.org/dc/elements/1.1/title")), // title (of the model)
 	deprecated(OWLRDFVocabulary.OWL_DEPRECATED.getIRI()), // model annotation to indicate deprecated models
 	templatestate(IRI.create("http://geneontology.org/lego/templatestate"), "template"), // designate a model as a template

--- a/minerva-server/src/main/java/org/geneontology/minerva/server/handler/JsonOrJsonpBatchHandler.java
+++ b/minerva-server/src/main/java/org/geneontology/minerva/server/handler/JsonOrJsonpBatchHandler.java
@@ -7,6 +7,7 @@ import static org.geneontology.minerva.server.handler.OperationsTools.requireNot
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.lang.reflect.Type;
+import java.util.Collections;
 import java.util.Set;
 
 import org.apache.commons.lang3.StringUtils;
@@ -69,25 +70,25 @@ public class JsonOrJsonpBatchHandler extends OperationsImpl implements M3BatchHa
 	@Override
 	@JSONP(callback = JSONP_DEFAULT_CALLBACK, queryParam = JSONP_DEFAULT_OVERWRITE)
 	public M3BatchResponse m3BatchGet(String intention, String packetId, String requestString, String useReasoner) {
-		return m3Batch(null, intention, packetId, requestString, useReasoner, false);
+		return m3Batch(null, Collections.emptySet(), intention, packetId, requestString, useReasoner, false);
 	}
 	
 	@Override
 	@JSONP(callback = JSONP_DEFAULT_CALLBACK, queryParam = JSONP_DEFAULT_OVERWRITE)
-	public M3BatchResponse m3BatchGetPrivileged(String uid, String intention, String packetId, String requestString, String useReasoner) {
-		return m3Batch(uid, intention, packetId, requestString, useReasoner, true);
+	public M3BatchResponse m3BatchGetPrivileged(String uid, Set<String> providerGroups, String intention, String packetId, String requestString, String useReasoner) {
+		return m3Batch(uid, providerGroups, intention, packetId, requestString, useReasoner, true);
 	}
 
 	@Override
 	@JSONP(callback = JSONP_DEFAULT_CALLBACK, queryParam = JSONP_DEFAULT_OVERWRITE)
 	public M3BatchResponse m3BatchPost(String intention, String packetId, String requestString, String useReasoner) {
-		return m3Batch(null, intention, packetId, requestString, useReasoner, false);
+		return m3Batch(null, Collections.emptySet(), intention, packetId, requestString, useReasoner, false);
 	}
 	
 	@Override
 	@JSONP(callback = JSONP_DEFAULT_CALLBACK, queryParam = JSONP_DEFAULT_OVERWRITE)
-	public M3BatchResponse m3BatchPostPrivileged(String uid, String intention, String packetId, String requestString, String useReasoner) {
-		return m3Batch(uid, intention, packetId, requestString, useReasoner, true);
+	public M3BatchResponse m3BatchPostPrivileged(String uid, Set<String> providerGroups, String intention, String packetId, String requestString, String useReasoner) {
+		return m3Batch(uid, providerGroups, intention, packetId, requestString, useReasoner, true);
 	}
 
 	private static String checkPacketId(String packetId) {
@@ -98,13 +99,13 @@ public class JsonOrJsonpBatchHandler extends OperationsImpl implements M3BatchHa
 	}
 	
 	@Override
-	public M3BatchResponse m3Batch(String uid, String intention, String packetId, M3Request[] requests, boolean useReasoner, boolean isPrivileged) {
-		M3BatchResponse response = new M3BatchResponse(uid, intention, checkPacketId(packetId));
+	public M3BatchResponse m3Batch(String uid, Set<String> providerGroups, String intention, String packetId, M3Request[] requests, boolean useReasoner, boolean isPrivileged) {
+		M3BatchResponse response = new M3BatchResponse(uid, providerGroups, intention, checkPacketId(packetId));
 		if (requests == null) {
 			return error(response, "The batch contains no requests: null value for request array", null);
 		}
 		try {
-			return m3Batch(response, requests, uid, useReasoner, isPrivileged);
+			return m3Batch(response, requests, uid, providerGroups, useReasoner, isPrivileged);
 		} catch (InsufficientPermissionsException e) {
 			return error(response, e.getMessage(), null);
 		} catch (Exception e) {
@@ -115,20 +116,20 @@ public class JsonOrJsonpBatchHandler extends OperationsImpl implements M3BatchHa
 		}
 	}
 	
-	private M3BatchResponse m3Batch(String uid, String intention, String packetId, String requestString, String useReasonerString, boolean isPrivileged) {
+	private M3BatchResponse m3Batch(String uid, Set<String> providerGroups, String intention, String packetId, String requestString, String useReasonerString, boolean isPrivileged) {
 		boolean useReasoner = false;
 		if (inferenceProviderCreator != null) {
 			useReasonerString = StringUtils.trimToNull(useReasonerString);
 			useReasoner = "true".equalsIgnoreCase(useReasonerString);
 		}
-		M3BatchResponse response = new M3BatchResponse(uid, intention, checkPacketId(packetId));
+		M3BatchResponse response = new M3BatchResponse(uid, providerGroups, intention, checkPacketId(packetId));
 		requestString = StringUtils.trimToNull(requestString);
 		if (requestString == null) {
 			return error(response, "The batch contains no requests: null value for request", null);
 		}
 		try {
 			M3Request[] requests = MolecularModelJsonRenderer.parseFromJson(requestString, requestType);
-			return m3Batch(response, requests, uid, useReasoner, isPrivileged);
+			return m3Batch(response, requests, uid, providerGroups, useReasoner, isPrivileged);
 		} catch (Exception e) {
 			return error(response, "Could not successfully handle batch request.", e);
 		} catch (Throwable t) {
@@ -137,7 +138,7 @@ public class JsonOrJsonpBatchHandler extends OperationsImpl implements M3BatchHa
 		}
 	}
 	
-	private M3BatchResponse m3Batch(M3BatchResponse response, M3Request[] requests, String userId, boolean useReasoner, boolean isPrivileged) throws InsufficientPermissionsException, Exception {
+	private M3BatchResponse m3Batch(M3BatchResponse response, M3Request[] requests, String userId, Set<String> providerGroups, boolean useReasoner, boolean isPrivileged) throws InsufficientPermissionsException, Exception {
 		userId = normalizeUserId(userId);
 		UndoMetadata token = new UndoMetadata(userId);
 		
@@ -152,21 +153,21 @@ public class JsonOrJsonpBatchHandler extends OperationsImpl implements M3BatchHa
 
 			// individual
 			if (Entity.individual == entity) {
-				String error = handleRequestForIndividual(request, operation, userId, token, values);
+				String error = handleRequestForIndividual(request, operation, userId, providerGroups, token, values);
 				if (error != null) {
 					return error(response, error, null);
 				}
 			}
 			// edge
 			else if (Entity.edge == entity) {
-				String error = handleRequestForEdge(request, operation, userId, token, values);
+				String error = handleRequestForEdge(request, operation, userId, providerGroups, token, values);
 				if (error != null) {
 					return error(response, error, null);
 				}
 			}
 			//model
 			else if (Entity.model == entity) {
-				String error = handleRequestForModel(request, response, operation, userId, token, values);
+				String error = handleRequestForModel(request, response, operation, userId, providerGroups, token, values);
 				if (error != null) {
 					return error(response, error, null);
 				}
@@ -178,7 +179,7 @@ public class JsonOrJsonpBatchHandler extends OperationsImpl implements M3BatchHa
 						// can only be used with other "meta" operations in batch mode, otherwise it would lead to conflicts in the returned signal
 						return error(response, "Get meta entity can only be combined with other meta operations.", null);
 					}
-					getMeta(response, userId);
+					getMeta(response, userId, providerGroups);
 				} else if (Operation.exportAll == operation) {
 					exportAllModels();
 					response.message = "Dumped all models to folder";

--- a/minerva-server/src/main/java/org/geneontology/minerva/server/handler/M3BatchHandler.java
+++ b/minerva-server/src/main/java/org/geneontology/minerva/server/handler/M3BatchHandler.java
@@ -2,6 +2,7 @@ package org.geneontology.minerva.server.handler;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import javax.ws.rs.Consumes;
 import javax.ws.rs.FormParam;
@@ -144,8 +145,8 @@ public interface M3BatchHandler {
 		 * @param intention
 		 * @param packetId
 		 */
-		public M3BatchResponse(String uid, String intention, String packetId) {
-			super(uid, intention, packetId);
+		public M3BatchResponse(String uid, Set<String> providerGroups, String intention, String packetId) {
+			super(uid, providerGroups, intention, packetId);
 		}
 		
 	}
@@ -162,7 +163,7 @@ public interface M3BatchHandler {
 	 * @param isPrivileged true, if the access is privileged
 	 * @return response object, never null
 	 */
-	public M3BatchResponse m3Batch(String uid, String intention, String packetId, M3Request[] requests, boolean useReasoner, boolean isPrivileged);
+	public M3BatchResponse m3Batch(String uid, Set<String> providerGroups, String intention, String packetId, M3Request[] requests, boolean useReasoner, boolean isPrivileged);
 	
 	/**
 	 * Jersey REST method for POST with three form parameters.
@@ -186,6 +187,7 @@ public interface M3BatchHandler {
 	 * Jersey REST method for POST with three form parameters with privileged rights.
 	 * 
 	 * @param uid user id, JSONP relevant
+	 * @param providerGroups user groups, JSONP relevant
 	 * @param intention JSONP relevant
 	 * @param packetId
 	 * @param requests JSON string of the batch request
@@ -197,6 +199,7 @@ public interface M3BatchHandler {
 	@Consumes("application/x-www-form-urlencoded")
 	public M3BatchResponse m3BatchPostPrivileged(
 			@FormParam("uid") String uid,
+			@FormParam("provided-by") Set<String> providerGroups,
 			@FormParam("intention") String intention,
 			@FormParam("packet-id") String packetId,
 			@FormParam("requests") String requests,
@@ -223,6 +226,7 @@ public interface M3BatchHandler {
 	 * Jersey REST method for GET with three query parameters with privileged rights.
 	 * 
 	 * @param uid user id, JSONP relevant
+	 * @param providerGroups user groups, JSONP relevant
 	 * @param intention JSONP relevant
 	 * @param packetId 
 	 * @param requests JSON string of the batch request
@@ -233,6 +237,7 @@ public interface M3BatchHandler {
 	@GET
 	public M3BatchResponse m3BatchGetPrivileged(
 			@QueryParam("uid") String uid,
+			@QueryParam("provided-by") Set<String> providerGroups,
 			@QueryParam("intention") String intention,
 			@QueryParam("packet-id") String packetId,
 			@QueryParam("requests") String requests,

--- a/minerva-server/src/main/java/org/geneontology/minerva/server/handler/M3SeedHandler.java
+++ b/minerva-server/src/main/java/org/geneontology/minerva/server/handler/M3SeedHandler.java
@@ -1,5 +1,7 @@
 package org.geneontology.minerva.server.handler;
 
+import java.util.Set;
+
 import javax.ws.rs.Consumes;
 import javax.ws.rs.FormParam;
 import javax.ws.rs.GET;
@@ -53,8 +55,8 @@ public interface M3SeedHandler {
 		 * @param intention
 		 * @param packetId
 		 */
-		public SeedResponse(String uid, String intention, String packetId) {
-			super(uid, intention, packetId);
+		public SeedResponse(String uid, Set<String> providerGroups, String intention, String packetId) {
+			super(uid, providerGroups, intention, packetId);
 		}
 	}
 	
@@ -78,6 +80,7 @@ public interface M3SeedHandler {
 	 * Jersey REST method for POST with three form parameters with privileged rights.
 	 * 
 	 * @param uid user id, JSONP relevant
+	 * @param providerGroups user groups, JSONP relevant
 	 * @param intention JSONP relevant
 	 * @param packetId
 	 * @param requestString seed request
@@ -88,6 +91,7 @@ public interface M3SeedHandler {
 	@Consumes("application/x-www-form-urlencoded")
 	public SeedResponse fromProcessPostPrivileged(
 			@FormParam("uid") String uid,
+			@FormParam("provided-by") Set<String> providerGroups,
 			@FormParam("intention") String intention,
 			@FormParam("packet-id") String packetId,
 			@FormParam("requests") String requestString);
@@ -112,6 +116,7 @@ public interface M3SeedHandler {
 	 * Jersey REST method for GET with three query parameters with privileged rights.
 	 * 
 	 * @param uid user id, JSONP relevant
+	 * @param providerGroups user groups, JSONP relevant
 	 * @param intention JSONP relevant
 	 * @param packetId 
 	 * @param requestString seed request
@@ -121,6 +126,7 @@ public interface M3SeedHandler {
 	@GET
 	public SeedResponse fromProcessGetPrivileged(
 			@QueryParam("uid") String uid,
+			@QueryParam("provided-by") Set<String> providerGroups,
 			@QueryParam("intention") String intention,
 			@QueryParam("packet-id") String packetId,
 			@QueryParam("requests") String requestString);

--- a/minerva-server/src/main/java/org/geneontology/minerva/server/handler/MinervaResponse.java
+++ b/minerva-server/src/main/java/org/geneontology/minerva/server/handler/MinervaResponse.java
@@ -1,5 +1,8 @@
 package org.geneontology.minerva.server.handler;
 
+import java.util.Collections;
+import java.util.Set;
+
 import com.google.gson.annotations.SerializedName;
 
 public abstract class MinervaResponse<DATA> {
@@ -7,6 +10,8 @@ public abstract class MinervaResponse<DATA> {
 	@SerializedName("packet-id")
 	final String packetId; // generated or pass-through
 	final String uid; // pass-through
+	@SerializedName("provided-by")
+	final Set<String> providerGroups; // pass-through
 	
 	@SerializedName("is-reasoned")
 	boolean isReasoned = false;
@@ -49,8 +54,13 @@ public abstract class MinervaResponse<DATA> {
 	 * @param intention
 	 * @param packetId
 	 */
-	public MinervaResponse(String uid, String intention, String packetId) {
+	public MinervaResponse(String uid, Set<String> providerGroups, String intention, String packetId) {
 		this.uid = uid;
+		if (providerGroups != null) {
+			this.providerGroups = providerGroups;	
+		} else {
+			this.providerGroups =  Collections.emptySet();
+		}
 		this.intention = intention;
 		this.packetId = packetId;
 	}

--- a/minerva-server/src/test/java/org/geneontology/minerva/server/handler/BatchModelHandlerTest.java
+++ b/minerva-server/src/test/java/org/geneontology/minerva/server/handler/BatchModelHandlerTest.java
@@ -70,6 +70,7 @@ public class BatchModelHandlerTest {
 	private final static DateGenerator dateGenerator = new DateGenerator();
 
 	static final String uid = "test-user";
+	static final Set<String> providedBy = Collections.singleton("test-provider"); 
 	static final String intention = "test-intention";
 	private static final String packetId = "foo-packet-id";
 
@@ -294,8 +295,9 @@ public class BatchModelHandlerTest {
 		final JsonAnnotation[] annotations1 = getModelAnnotations(modelId);
 		// creation date
 		// user id
+		// providedBy
 		// model state
-		assertEquals(3, annotations1.length);
+		assertEquals(4, annotations1.length);
 		
 		// create annotations
 		final M3Request r1 = new M3Request();
@@ -316,7 +318,7 @@ public class BatchModelHandlerTest {
 		
 		final JsonAnnotation[] annotations2 = getModelAnnotations(modelId);
 		assertNotNull(annotations2);
-		assertEquals(5, annotations2.length);
+		assertEquals(6, annotations2.length);
 		
 		
 		// remove one annotation
@@ -335,7 +337,7 @@ public class BatchModelHandlerTest {
 		
 		final JsonAnnotation[] annotations3 = getModelAnnotations(modelId);
 		assertNotNull(annotations3);
-		assertEquals(4, annotations3.length);
+		assertEquals(5, annotations3.length);
 	}
 	
 	@Test
@@ -344,8 +346,9 @@ public class BatchModelHandlerTest {
 		final JsonAnnotation[] annotations1 = getModelAnnotations(modelId);
 		// creation date
 		// user id
+		// providedBy
 		// model state
-		assertEquals(3, annotations1.length);
+		assertEquals(4, annotations1.length);
 		
 		// create template annotation
 		final M3Request r1 = new M3Request();
@@ -363,7 +366,7 @@ public class BatchModelHandlerTest {
 		
 		final JsonAnnotation[] annotations2 = getModelAnnotations(modelId);
 		assertNotNull(annotations2);
-		assertEquals(4, annotations2.length);
+		assertEquals(5, annotations2.length);
 		
 		// remove one annotation
 		final M3Request r2 = new M3Request();
@@ -392,7 +395,7 @@ public class BatchModelHandlerTest {
 		
 		final JsonAnnotation[] annotations3 = getModelAnnotations(modelId);
 		assertNotNull(annotations3);
-		assertEquals(4, annotations3.length);
+		assertEquals(5, annotations3.length);
 		String foundModelState = null;
 		for (JsonAnnotation annotation : annotations3) {
 			if (AnnotationShorthand.modelstate.getShorthand().equals(annotation.key)) {
@@ -451,7 +454,7 @@ public class BatchModelHandlerTest {
 		r.operation = Operation.get;
 		batch1.add(r);
 		
-		M3BatchResponse response = handler.m3Batch(uid, intention, packetId, batch1.toArray(new M3Request[batch1.size()]), false, true);
+		M3BatchResponse response = handler.m3Batch(uid, providedBy, intention, packetId, batch1.toArray(new M3Request[batch1.size()]), false, true);
 		assertEquals(uid, response.uid);
 		assertEquals(intention, response.intention);
 		
@@ -887,7 +890,7 @@ public class BatchModelHandlerTest {
 		batch[0].operation = Operation.storeModel;
 		batch[0].arguments = new M3Argument();
 		batch[0].arguments.modelId = modelId;
-		M3BatchResponse resp1 = handler.m3Batch(uid, intention, packetId, batch, false, true);
+		M3BatchResponse resp1 = handler.m3Batch(uid, providedBy, intention, packetId, batch, false, true);
 		assertEquals("This operation must fail as the model has no title or individuals", M3BatchResponse.MESSAGE_TYPE_ERROR, resp1.messageType);
 		assertNotNull(resp1.commentary);
 		assertTrue(resp1.commentary.contains("title"));
@@ -899,7 +902,7 @@ public class BatchModelHandlerTest {
 		batch[0] = new M3Request();
 		batch[0].entity = Entity.model;
 		batch[0].operation = Operation.add;
-		M3BatchResponse resp1 = handler.m3Batch(uid, intention, packetId, batch, false, false);
+		M3BatchResponse resp1 = handler.m3Batch(uid, providedBy, intention, packetId, batch, false, false);
 		assertEquals(M3BatchResponse.MESSAGE_TYPE_ERROR, resp1.messageType);
 		assertTrue(resp1.message.contains("Insufficient"));
 	}
@@ -1274,7 +1277,7 @@ public class BatchModelHandlerTest {
 		batch[4].arguments.predicate = "BFO:0000066"; // occurs_in
 		batch[4].arguments.object = "cc";
 
-		M3BatchResponse response = handler.m3Batch(uid, intention, packetId, batch, false, true);
+		M3BatchResponse response = handler.m3Batch(uid, providedBy, intention, packetId, batch, false, true);
 		assertEquals(uid, response.uid);
 		assertEquals(intention, response.intention);
 		assertEquals(response.message, M3BatchResponse.MESSAGE_TYPE_SUCCESS, response.messageType);
@@ -1353,7 +1356,7 @@ public class BatchModelHandlerTest {
 		batch[1].arguments.predicate = "BFO:0000050"; // part_of
 		batch[1].arguments.object = "foo";
 
-		M3BatchResponse response = handler.m3Batch(uid, intention, packetId, batch, false, true);
+		M3BatchResponse response = handler.m3Batch(uid, providedBy, intention, packetId, batch, false, true);
 		assertEquals(uid, response.uid);
 		assertEquals(intention, response.intention);
 		assertEquals("The operation should fail with an unknown identifier exception", 
@@ -1430,7 +1433,8 @@ public class BatchModelHandlerTest {
 		BatchTestTools.setExpressionClass(batch1[0].arguments, "GO:0003674"); // molecular function
 		
 		String uid1 = "1";
-		M3BatchResponse response1 = handler.m3Batch(uid1, intention, packetId, batch1, false, true);
+		Set<String> providedBy1 = Collections.singleton("provider1");
+		M3BatchResponse response1 = handler.m3Batch(uid1, providedBy1, intention, packetId, batch1, false, true);
 		assertEquals(uid1, response1.uid);
 		assertEquals(intention, response1.intention);
 		assertEquals(response1.message, M3BatchResponse.MESSAGE_TYPE_SUCCESS, response1.messageType);
@@ -1463,7 +1467,8 @@ public class BatchModelHandlerTest {
 		BatchTestTools.setExpressionClass(batch2[0].arguments, "GO:0003674"); // molecular function
 		
 		String uid2 = "2";
-		M3BatchResponse response2 = handler.m3Batch(uid2, intention, packetId, batch2, false, true);
+		Set<String> providedBy2 = Collections.singleton("provider2");
+		M3BatchResponse response2 = handler.m3Batch(uid2, providedBy2, intention, packetId, batch2, false, true);
 		assertEquals(uid2, response2.uid);
 		assertEquals(intention, response2.intention);
 		assertEquals(response2.message, M3BatchResponse.MESSAGE_TYPE_SUCCESS, response2.messageType);
@@ -1495,7 +1500,8 @@ public class BatchModelHandlerTest {
 		BatchTestTools.setExpressionClass(batch3[0].arguments, "GO:0003674"); // molecular function
 		
 		String uid3 = "3";
-		M3BatchResponse response3 = handler.m3Batch(uid3, intention, packetId, batch3, false, true);
+		Set<String> providedBy3 = Collections.singleton("provider3");
+		M3BatchResponse response3 = handler.m3Batch(uid3, providedBy3, intention, packetId, batch3, false, true);
 		assertEquals(uid3, response3.uid);
 		assertEquals(intention, response3.intention);
 		assertEquals(response3.message, M3BatchResponse.MESSAGE_TYPE_SUCCESS, response3.messageType);
@@ -1564,7 +1570,7 @@ public class BatchModelHandlerTest {
 			batch1[2].arguments.predicate = "BFO:0000050"; // part_of
 			batch1[2].arguments.object = "bp";
 			
-			M3BatchResponse response1 = handler.m3Batch(uid, intention, packetId, batch1, false, true);
+			M3BatchResponse response1 = handler.m3Batch(uid, providedBy, intention, packetId, batch1, false, true);
 			assertEquals(uid, response1.uid);
 			assertEquals(intention, response1.intention);
 			assertEquals(response1.message, M3BatchResponse.MESSAGE_TYPE_SUCCESS, response1.messageType);
@@ -1621,7 +1627,7 @@ public class BatchModelHandlerTest {
 			batch2[0].arguments.object = bp;
 			batch2[0].arguments.values = BatchTestTools.singleAnnotation(AnnotationShorthand.comment, "foo");
 			
-			M3BatchResponse response2 = handler.m3Batch(uid, intention, packetId, batch2, false, true);
+			M3BatchResponse response2 = handler.m3Batch(uid, providedBy, intention, packetId, batch2, false, true);
 			assertEquals(uid, response2.uid);
 			assertEquals(intention, response2.intention);
 			assertEquals(response2.message, M3BatchResponse.MESSAGE_TYPE_SUCCESS, response2.messageType);
@@ -1655,7 +1661,7 @@ public class BatchModelHandlerTest {
 			batch3[0].arguments.object = bp;
 			batch3[0].arguments.values = BatchTestTools.singleAnnotation(AnnotationShorthand.comment, "foo");
 			
-			M3BatchResponse response3 = handler.m3Batch(uid, intention, packetId, batch3, false, true);
+			M3BatchResponse response3 = handler.m3Batch(uid, providedBy, intention, packetId, batch3, false, true);
 			assertEquals(uid, response3.uid);
 			assertEquals(intention, response3.intention);
 			assertEquals(response3.message, M3BatchResponse.MESSAGE_TYPE_SUCCESS, response3.messageType);
@@ -1718,7 +1724,7 @@ public class BatchModelHandlerTest {
 			batch4[0].arguments.individual = individualId;
 			BatchTestTools.setExpressionClass(batch4[0].arguments, "GO:0003674");
 			
-			M3BatchResponse response4 = handler.m3Batch(uid, intention, packetId, batch4, false, true);
+			M3BatchResponse response4 = handler.m3Batch(uid, providedBy, intention, packetId, batch4, false, true);
 			assertEquals(uid, response4.uid);
 			assertEquals(intention, response4.intention);
 			assertEquals(response4.message, M3BatchResponse.MESSAGE_TYPE_SUCCESS, response4.messageType);
@@ -1750,7 +1756,7 @@ public class BatchModelHandlerTest {
 			batch5[0].arguments.individual = individualId;
 			BatchTestTools.setExpressionClass(batch5[0].arguments, "GO:0003674");
 			
-			M3BatchResponse response5 = handler.m3Batch(uid, intention, packetId, batch5, false, true);
+			M3BatchResponse response5 = handler.m3Batch(uid, providedBy, intention, packetId, batch5, false, true);
 			assertEquals(uid, response5.uid);
 			assertEquals(intention, response5.intention);
 			assertEquals(response5.message, M3BatchResponse.MESSAGE_TYPE_SUCCESS, response5.messageType);
@@ -2055,7 +2061,7 @@ public class BatchModelHandlerTest {
 		M3BatchResponse response;
 		try {
 			handler.CHECK_LITERAL_IDENTIFIERS = true;
-			response = handler.m3Batch(uid, intention, packetId, batch1.toArray(new M3Request[batch1.size()]), false, true);
+			response = handler.m3Batch(uid, providedBy, intention, packetId, batch1.toArray(new M3Request[batch1.size()]), false, true);
 		}
 		finally {
 			handler.CHECK_LITERAL_IDENTIFIERS = defaultIdPolicy;
@@ -2136,7 +2142,7 @@ public class BatchModelHandlerTest {
 	}
 	
 	private M3BatchResponse executeBatch(List<M3Request> batch, String uid, boolean useReasoner) {
-		M3BatchResponse response = handler.m3Batch(uid, intention, packetId, batch.toArray(new M3Request[batch.size()]), useReasoner, true);
+		M3BatchResponse response = handler.m3Batch(uid, providedBy, intention, packetId, batch.toArray(new M3Request[batch.size()]), useReasoner, true);
 		assertEquals(uid, response.uid);
 		assertEquals(intention, response.intention);
 		assertEquals(response.message, M3BatchResponse.MESSAGE_TYPE_SUCCESS, response.messageType);

--- a/minerva-server/src/test/java/org/geneontology/minerva/server/handler/BatchTestTools.java
+++ b/minerva-server/src/test/java/org/geneontology/minerva/server/handler/BatchTestTools.java
@@ -192,7 +192,7 @@ public class BatchTestTools {
 		batch[0] = new M3Request();
 		batch[0].entity = Entity.model;
 		batch[0].operation = Operation.add;
-		M3BatchResponse resp = handler.m3Batch(BatchModelHandlerTest.uid, BatchModelHandlerTest.intention, null, batch, false, true);
+		M3BatchResponse resp = handler.m3Batch(BatchModelHandlerTest.uid, BatchModelHandlerTest.providedBy, BatchModelHandlerTest.intention, null, batch, false, true);
 		assertEquals(resp.message, M3BatchResponse.MESSAGE_TYPE_SUCCESS, resp.messageType);
 		assertNotNull(resp.packetId);
 		String modelId = responseId(resp);
@@ -205,7 +205,7 @@ public class BatchTestTools {
 		batch[0] = new M3Request();
 		batch[0].entity = Entity.meta;
 		batch[0].operation = Operation.get;
-		M3BatchResponse resp = handler.m3Batch(BatchModelHandlerTest.uid, BatchModelHandlerTest.intention, null, batch, false, true);
+		M3BatchResponse resp = handler.m3Batch(BatchModelHandlerTest.uid, BatchModelHandlerTest.providedBy, BatchModelHandlerTest.intention, null, batch, false, true);
 		assertEquals(resp.message, M3BatchResponse.MESSAGE_TYPE_SUCCESS, resp.messageType);
 		assertNotNull(resp.packetId);
 		assertNotNull(resp.data);
@@ -220,7 +220,7 @@ public class BatchTestTools {
 		batch[0].operation = Operation.get;
 		batch[0].arguments = new M3Argument();
 		batch[0].arguments.modelId = modelId;
-		M3BatchResponse resp = handler.m3Batch(BatchModelHandlerTest.uid, BatchModelHandlerTest.intention, null, batch, useReasoner, true);
+		M3BatchResponse resp = handler.m3Batch(BatchModelHandlerTest.uid, BatchModelHandlerTest.providedBy, BatchModelHandlerTest.intention, null, batch, useReasoner, true);
 		assertEquals(resp.message, M3BatchResponse.MESSAGE_TYPE_SUCCESS, resp.messageType);
 		assertNotNull(resp.packetId);
 		return resp;

--- a/minerva-server/src/test/java/org/geneontology/minerva/server/handler/DataPropertyTest.java
+++ b/minerva-server/src/test/java/org/geneontology/minerva/server/handler/DataPropertyTest.java
@@ -209,7 +209,7 @@ public class DataPropertyTest {
 		String uid = "foo-user";
 		String intention = "generated";
 		String packetId = "0";
-		M3BatchResponse response = handler.m3Batch(uid, intention, packetId, requests.toArray(new M3Request[requests.size()]), false, true);
+		M3BatchResponse response = handler.m3Batch(uid, Collections.emptySet(), intention, packetId, requests.toArray(new M3Request[requests.size()]), false, true);
 		assertEquals(uid, response.uid);
 		assertEquals(intention, response.intention);
 		assertEquals(packetId, response.packetId);

--- a/minerva-server/src/test/java/org/geneontology/minerva/server/handler/ModelEditTest.java
+++ b/minerva-server/src/test/java/org/geneontology/minerva/server/handler/ModelEditTest.java
@@ -198,7 +198,7 @@ public class ModelEditTest {
 	}
 
 	private M3BatchResponse executeBatch(List<M3Request> batch) {
-		M3BatchResponse response = handler.m3Batch("test-user", "test-intention", "foo-packet-id",
+		M3BatchResponse response = handler.m3Batch("test-user", Collections.emptySet(), "test-intention", "foo-packet-id",
 				batch.toArray(new M3Request[batch.size()]), false, true);
 		assertEquals("test-user", response.uid);
 		assertEquals("test-intention", response.intention);

--- a/minerva-server/src/test/java/org/geneontology/minerva/server/handler/ModelReasonerTest.java
+++ b/minerva-server/src/test/java/org/geneontology/minerva/server/handler/ModelReasonerTest.java
@@ -125,7 +125,7 @@ public class ModelReasonerTest {
 	}
 	
 	private M3BatchResponse executeBatch(List<M3Request> batch) {
-		M3BatchResponse response = handler.m3Batch("test-user", "test-intention", "foo-packet-id",
+		M3BatchResponse response = handler.m3Batch("test-user", Collections.emptySet(), "test-intention", "foo-packet-id",
 				batch.toArray(new M3Request[batch.size()]), true, true);
 		assertEquals("test-user", response.uid);
 		assertEquals("test-intention", response.intention);

--- a/minerva-server/src/test/java/org/geneontology/minerva/server/handler/ParallelModelReasonerTest.java
+++ b/minerva-server/src/test/java/org/geneontology/minerva/server/handler/ParallelModelReasonerTest.java
@@ -229,7 +229,7 @@ public class ParallelModelReasonerTest {
 	}
 	
 	private M3BatchResponse executeBatch(List<M3Request> batch) {
-		M3BatchResponse response = handler.m3Batch("test-user", "test-intention", "foo-packet-id",
+		M3BatchResponse response = handler.m3Batch("test-user", Collections.emptySet(), "test-intention", "foo-packet-id",
 				batch.toArray(new M3Request[batch.size()]), true, true);
 		return response;
 	}

--- a/minerva-server/src/test/java/org/geneontology/minerva/server/handler/SeedHandlerTest.java
+++ b/minerva-server/src/test/java/org/geneontology/minerva/server/handler/SeedHandlerTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertNotNull;
 
 import java.net.URI;
 import java.util.Collections;
+import java.util.Set;
 
 import org.geneontology.minerva.ModelContainer;
 import org.geneontology.minerva.UndoAwareMolecularModelManager;
@@ -20,7 +21,6 @@ import org.geneontology.minerva.server.handler.M3SeedHandler.SeedResponse;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
-import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 import owltools.gaf.eco.EcoMapperFactory;
@@ -38,6 +38,7 @@ public class SeedHandlerTest {
 	private static UndoAwareMolecularModelManager models = null;
 	
 	private static final String uid = "test-user";
+	private static final Set<String> providedBy = Collections.singleton("test-provider");
 	private static final String intention = "test-intention";
 	private static final String packetId = "foo-packet-id";
 	
@@ -100,7 +101,7 @@ public class SeedHandlerTest {
 	
 	private SeedResponse seed(SeedRequest request) {
 		String json = MolecularModelJsonRenderer.renderToJson(new SeedRequest[]{request}, false);
-		SeedResponse response = handler.fromProcessGetPrivileged(uid, intention, packetId, json);
+		SeedResponse response = handler.fromProcessGetPrivileged(uid, providedBy, intention, packetId, json);
 		assertEquals(uid, response.uid);
 		assertEquals(intention, response.intention);
 		assertEquals(response.message, M3BatchResponse.MESSAGE_TYPE_SUCCESS, response.messageType);


### PR DESCRIPTION
This adds support for a list of user groups in requests, for https://github.com/geneontology/noctua/issues/350. It is not heavily tested so far, but I wanted to get it out to coordinate with Noctua UI development. The JSON property and HTTP parameter are both currently named `provided-by` (sound okay, @kltm?). I *believe* you provide multiple values simply by putting the same parameter into the query string multiple times, with different values.