### PR TITLE
Improve handling of empty lookup results

### DIFF
--- a/minerva-lookup/src/main/java/org/geneontology/minerva/lookup/CachingExternalLookupService.java
+++ b/minerva-lookup/src/main/java/org/geneontology/minerva/lookup/CachingExternalLookupService.java
@@ -1,10 +1,12 @@
 package org.geneontology.minerva.lookup;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
+import org.apache.log4j.Logger;
 import org.semanticweb.owlapi.model.IRI;
 
 import com.google.common.cache.CacheBuilder;
@@ -17,6 +19,8 @@ public class CachingExternalLookupService implements ExternalLookupService {
 	
 	private final LoadingCache<IRI, List<LookupEntry>> cache;
 	private final ExternalLookupService service;
+	
+	private final static Logger LOG = Logger.getLogger(CachingExternalLookupService.class);
 	
 	public CachingExternalLookupService(ExternalLookupService service, int size, long duration, TimeUnit unit) {
 		this.service = service;
@@ -45,11 +49,14 @@ public class CachingExternalLookupService implements ExternalLookupService {
 		try {
 			return cache.get(id);
 		} catch (ExecutionException e) {
-			return null;
+			LOG.error("Could not lookup IRI: " + id, e);
+			return Collections.emptyList();
 		} catch (UncheckedExecutionException e) {
-			return null;
+			LOG.error("Could not lookup IRI: " + id, e);
+			return Collections.emptyList();
 		} catch (ExecutionError e) {
-			return null;
+			LOG.error("Could not lookup IRI: " + id, e);
+			return Collections.emptyList();
 		}
 	}
 

--- a/minerva-lookup/src/main/java/org/geneontology/minerva/lookup/CachingExternalLookupService.java
+++ b/minerva-lookup/src/main/java/org/geneontology/minerva/lookup/CachingExternalLookupService.java
@@ -27,11 +27,7 @@ public class CachingExternalLookupService implements ExternalLookupService {
 
 					@Override
 					public List<LookupEntry> load(IRI key) throws Exception {
-						List<LookupEntry> lookup = CachingExternalLookupService.this.service.lookup(key);
-						if (lookup == null || lookup.isEmpty()) {
-							throw new Exception("No legal value for key.");
-						}
-						return lookup;
+						return CachingExternalLookupService.this.service.lookup(key);
 					}
 				});
 	}

--- a/minerva-lookup/src/main/java/org/geneontology/minerva/lookup/GolrExternalLookupService.java
+++ b/minerva-lookup/src/main/java/org/geneontology/minerva/lookup/GolrExternalLookupService.java
@@ -3,6 +3,7 @@ package org.geneontology.minerva.lookup;
 import java.io.IOException;
 import java.net.URI;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import org.apache.log4j.Logger;
@@ -88,7 +89,7 @@ public class GolrExternalLookupService implements ExternalLookupService {
 			if (LOG.isDebugEnabled()) {
 				LOG.debug("Error during retrieval for id: "+id+" GOLR-URL: "+golrUrl, exception);
 			}
-			return null;
+			return Collections.emptyList();
 		}
 		catch (Throwable exception) {
 			LOG.warn("Unexpected problem during Golr lookup for id: "+id, exception);


### PR DESCRIPTION
This fixes some cases where an empty list should be returned instead of null. This allows GAF export to complete in the face of missing information in external lookups, to address https://github.com/geneontology/noctua/issues/391.