### PR TITLE
Added command for running SPARQL update on an offline database.

### DIFF
--- a/minerva-core/src/main/java/org/geneontology/minerva/util/BlazegraphMutationCounter.java
+++ b/minerva-core/src/main/java/org/geneontology/minerva/util/BlazegraphMutationCounter.java
@@ -1,0 +1,34 @@
+package org.geneontology.minerva.util;
+
+import com.bigdata.rdf.changesets.IChangeLog;
+import com.bigdata.rdf.changesets.IChangeRecord;
+
+public class BlazegraphMutationCounter implements IChangeLog {
+	
+	private int records = 0;
+	
+	public int mutationCount() {
+		return records;
+	}
+
+	@Override
+	public void changeEvent(IChangeRecord record) {
+		records++;
+	}
+
+	@Override
+	public void close() {}
+
+	@Override
+	public void transactionAborted() {}
+
+	@Override
+	public void transactionBegin() {}
+
+	@Override
+	public void transactionCommited(long commitTime) {}
+
+	@Override
+	public void transactionPrepare() {}
+
+}


### PR DESCRIPTION
This would be run after first stopping the Minerva server. Then you can use  Minerva to update the journal by specifying a file containing a SPARQL update:

```bash
./bin/minerva-cli.sh --sparql-update -j blazegraph.jnl -f delete_json.rq
```

or directly with the jar:

```bash
java -jar minerva-cli.jar --sparql-update -j blazegraph.jnl -f delete_json.rq
```