### PR TITLE
Support for use of Arachne as live reasoner in Noctua editor

### DIFF
--- a/minerva-server/src/main/java/org/geneontology/minerva/server/inferences/CachingInferenceProviderCreatorImpl.java
+++ b/minerva-server/src/main/java/org/geneontology/minerva/server/inferences/CachingInferenceProviderCreatorImpl.java
@@ -7,7 +7,9 @@ import java.util.concurrent.ConcurrentHashMap;
 import org.geneontology.minerva.ModelContainer;
 import org.geneontology.minerva.ModelContainer.ModelChangeListener;
 import org.geneontology.minerva.json.InferenceProvider;
+import org.geneontology.rules.util.ArachneOWLReasonerFactory;
 import org.semanticweb.elk.owlapi.ElkReasonerFactory;
+import org.semanticweb.owlapi.model.OWLOntology;
 import org.semanticweb.owlapi.model.OWLOntologyChange;
 import org.semanticweb.owlapi.model.OWLOntologyCreationException;
 import org.semanticweb.owlapi.reasoner.OWLReasonerFactory;
@@ -39,6 +41,10 @@ public class CachingInferenceProviderCreatorImpl extends InferenceProviderCreato
 	public static InferenceProviderCreator createHermiT(int maxConcurrent) {
 		return new CachingInferenceProviderCreatorImpl(new org.semanticweb.HermiT.ReasonerFactory(),
 				maxConcurrent, true, "Caching Hermit-SLME");
+	}
+	
+	public static InferenceProviderCreator createArachne(OWLOntology ontology) {
+		return new CachingInferenceProviderCreatorImpl(new ArachneOWLReasonerFactory(ontology), 1, false, "Caching Arachne");
 	}
 
 	@Override

--- a/minerva-server/src/test/java/org/geneontology/minerva/server/handler/LocalServerTest.java
+++ b/minerva-server/src/test/java/org/geneontology/minerva/server/handler/LocalServerTest.java
@@ -78,7 +78,7 @@ public class LocalServerTest {
 		models = new UndoAwareMolecularModelManager(graph, curieHandler, modelIdPrefix, folder.newFile().getAbsolutePath(), null);
 		
 		MinervaStartUpConfig conf = new MinervaStartUpConfig();
-		conf.inferenceProviderCreator = CachingInferenceProviderCreatorImpl.createElk(false);
+		conf.reasonerOpt = "elk";
 		conf.useRequestLogging = true;
 		conf.checkLiteralIds = false;
 		conf.lookupService = null;

--- a/pom.xml
+++ b/pom.xml
@@ -344,7 +344,7 @@
 			<dependency>
 				<groupId>org.geneontology</groupId>
 				<artifactId>arachne_2.11</artifactId>
-				<version>0.0.4-SNAPSHOT</version>
+				<version>0.0.4</version>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.jena</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -344,7 +344,7 @@
 			<dependency>
 				<groupId>org.geneontology</groupId>
 				<artifactId>arachne_2.11</artifactId>
-				<version>0.0.3</version>
+				<version>0.0.4-SNAPSHOT</version>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.jena</groupId>


### PR DESCRIPTION
To use Arachne instead of ELK, replace `--slme-elk` with `--arachne` in the startup command line.