### PR TITLE
Remove has-part from whitelist

### DIFF
--- a/minerva-converter/src/main/resources/org/geneontology/minerva/legacy/sparql/gpad-extensions.rq
+++ b/minerva-converter/src/main/resources/org/geneontology/minerva/legacy/sparql/gpad-extensions.rq
@@ -16,7 +16,6 @@ WHERE {
 # seeded with someValuesFrom relations used in go-plus
 VALUES ?extension_rel {
 <http://purl.obolibrary.org/obo/BFO_0000050>
-<http://purl.obolibrary.org/obo/BFO_0000051>
 <http://purl.obolibrary.org/obo/BFO_0000062>
 <http://purl.obolibrary.org/obo/BFO_0000063>
 <http://purl.obolibrary.org/obo/BFO_0000066>


### PR DESCRIPTION
Would we ever want has_part in annotation extensions?