### PR TITLE
Allow passing of custom JSON-LD context to StartUpTool.

### DIFF
--- a/minerva-cli/src/main/java/org/geneontology/minerva/cli/MinervaCommandRunner.java
+++ b/minerva-cli/src/main/java/org/geneontology/minerva/cli/MinervaCommandRunner.java
@@ -436,7 +436,7 @@ public class MinervaCommandRunner extends JsCommandRunner {
 		OWLOntology ontology = OWLManager.createOWLOntologyManager().loadOntology(IRI.create(ontologyIRI));
 		BlazegraphMolecularModelManager<Void> m3 = new BlazegraphMolecularModelManager<>(new OWLGraphWrapper(ontology), modelIdPrefix, inputDB, null);
 		CurieMappings localMappings = new CurieMappings.SimpleCurieMappings(Collections.singletonMap(modelIdcurie, modelIdPrefix));
-		CurieHandler curieHandler = new MappedCurieHandler(DefaultCurieHandler.getMappings(), localMappings);
+		CurieHandler curieHandler = new MappedCurieHandler(DefaultCurieHandler.loadDefaultMappings(), localMappings);
 		for (IRI modelIRI : m3.getAvailableModelIds()) {
 			String gpad = new GPADSPARQLExport(curieHandler, null, m3.getLegacyRelationShorthandIndex()).exportGPAD(m3.createInferredModel(modelIRI));
 			String fileName = StringUtils.replaceOnce(modelIRI.toString(), modelIdPrefix, "") + ".gpad";
@@ -526,7 +526,7 @@ public class MinervaCommandRunner extends JsCommandRunner {
 		}
 		// create curie handler
 		CurieMappings localMappings = new CurieMappings.SimpleCurieMappings(Collections.singletonMap(modelIdcurie, modelIdPrefix));
-		CurieHandler curieHandler = new MappedCurieHandler(DefaultCurieHandler.getMappings(), localMappings);
+		CurieHandler curieHandler = new MappedCurieHandler(DefaultCurieHandler.loadDefaultMappings(), localMappings);
 		
 		ExternalLookupService lookup= null;
 

--- a/minerva-server/src/main/java/org/geneontology/minerva/server/StartUpTool.java
+++ b/minerva-server/src/main/java/org/geneontology/minerva/server/StartUpTool.java
@@ -1,5 +1,6 @@
 package org.geneontology.minerva.server;
 
+import java.io.File;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
@@ -87,6 +88,8 @@ public class StartUpTool {
 		public boolean useRequestLogging = false;
 		
 		public boolean useGolrUrlLogging = false;
+		
+		public String prefixesFile = null;
 	}
 	
 	public static void main(String[] args) throws Exception {
@@ -187,6 +190,9 @@ public class StartUpTool {
 			else if (opts.nextEq("--use-golr-url-logging|--golr-url-logging")) {
 				conf.useGolrUrlLogging = true;
 			}
+			else if (opts.nextEq("--prefix-mappings")) {
+				conf.prefixesFile = opts.nextOpt();
+			}
 			else {
 				break;
 			}
@@ -205,11 +211,14 @@ public class StartUpTool {
 		}
 		
 		// set curie handler
-		CurieMappings defaultMappings = DefaultCurieHandler.getMappings();
+		final CurieMappings mappings;
+		if (conf.prefixesFile != null) {
+			mappings = DefaultCurieHandler.loadMappingsFromFile(new File(conf.prefixesFile));
+		} else {
+			mappings = DefaultCurieHandler.loadDefaultMappings();	
+		}
 		CurieMappings localMappings = new CurieMappings.SimpleCurieMappings(Collections.singletonMap(conf.modelIdcurie, conf.modelIdPrefix));
-		
-		// TODO make the modules configurable
-		conf.curieHandler = new MappedCurieHandler(defaultMappings, localMappings);
+		conf.curieHandler = new MappedCurieHandler(mappings, localMappings);
 
 		// wrap the Golr service with a cache
 		if (conf.golrUrl != null) {

--- a/minerva-server/src/test/java/org/geneontology/minerva/ModelDecorationTest.java
+++ b/minerva-server/src/test/java/org/geneontology/minerva/ModelDecorationTest.java
@@ -37,7 +37,7 @@ public class ModelDecorationTest {
 		OWLOntologyManager m = OWLManager.createOWLOntologyManager();
 		OWLDataFactory f = m.getOWLDataFactory();
 		
-		CurieMappings defaultMappings = DefaultCurieHandler.getMappings();
+		CurieMappings defaultMappings = DefaultCurieHandler.loadDefaultMappings();
 		CurieMappings localMappings = new CurieMappings.SimpleCurieMappings(Collections.singletonMap("http://testmodel.geneontology.org/","testmodel"));
 		CurieHandler curieHandler = new MappedCurieHandler(defaultMappings, localMappings);
 		
@@ -91,4 +91,5 @@ public class ModelDecorationTest {
 		String s = outputStream.toString();
 		return s;
 	}
+	
 }

--- a/minerva-server/src/test/java/org/geneontology/minerva/server/handler/BatchModelHandlerTest.java
+++ b/minerva-server/src/test/java/org/geneontology/minerva/server/handler/BatchModelHandlerTest.java
@@ -96,7 +96,7 @@ public class BatchModelHandlerTest {
 		final String modelIdcurie = "gomodel";
 		final String modelIdPrefix = "http://model.geneontology.org/";
 		final CurieMappings localMappings = new CurieMappings.SimpleCurieMappings(Collections.singletonMap(modelIdcurie, modelIdPrefix));
-		curieHandler = new MappedCurieHandler(DefaultCurieHandler.getMappings(), localMappings);
+		curieHandler = new MappedCurieHandler(DefaultCurieHandler.loadDefaultMappings(), localMappings);
 		InferenceProviderCreator ipc = CachingInferenceProviderCreatorImpl.createElk(false);
 		models = new UndoAwareMolecularModelManager(graph, curieHandler, modelIdPrefix, folder.newFile().getAbsolutePath(), null);
 		lookupService = createTestProteins(curieHandler);

--- a/minerva-server/src/test/java/org/geneontology/minerva/server/handler/LocalServerTest.java
+++ b/minerva-server/src/test/java/org/geneontology/minerva/server/handler/LocalServerTest.java
@@ -74,7 +74,7 @@ public class LocalServerTest {
 		final String modelIdcurie = "gomodel";
 		final String modelIdPrefix = "http://model.geneontology.org/";
 		final CurieMappings localMappings = new CurieMappings.SimpleCurieMappings(Collections.singletonMap(modelIdcurie, modelIdPrefix));
-		curieHandler = new MappedCurieHandler(DefaultCurieHandler.getMappings(), localMappings);
+		curieHandler = new MappedCurieHandler(DefaultCurieHandler.loadDefaultMappings(), localMappings);
 		models = new UndoAwareMolecularModelManager(graph, curieHandler, modelIdPrefix, folder.newFile().getAbsolutePath(), null);
 		
 		MinervaStartUpConfig conf = new MinervaStartUpConfig();

--- a/minerva-server/src/test/java/org/geneontology/minerva/server/handler/ModelEditTest.java
+++ b/minerva-server/src/test/java/org/geneontology/minerva/server/handler/ModelEditTest.java
@@ -65,7 +65,7 @@ public class ModelEditTest {
 		final String modelIdcurie = "gomodel";
 		final String modelIdPrefix = "http://model.geneontology.org/";
 		final CurieMappings localMappings = new CurieMappings.SimpleCurieMappings(Collections.singletonMap(modelIdcurie, modelIdPrefix));
-		curieHandler = new MappedCurieHandler(DefaultCurieHandler.getMappings(), localMappings);
+		curieHandler = new MappedCurieHandler(DefaultCurieHandler.loadDefaultMappings(), localMappings);
 
 		models = new UndoAwareMolecularModelManager(graph, curieHandler, modelIdPrefix, folder.newFile().getAbsolutePath(), null);
 		InferenceProviderCreator ipc = null;

--- a/minerva-server/src/test/java/org/geneontology/minerva/server/handler/ModelReasonerTest.java
+++ b/minerva-server/src/test/java/org/geneontology/minerva/server/handler/ModelReasonerTest.java
@@ -59,7 +59,7 @@ public class ModelReasonerTest {
 		final String modelIdcurie = "gomodel";
 		final String modelIdPrefix = "http://model.geneontology.org/";
 		final CurieMappings localMappings = new CurieMappings.SimpleCurieMappings(Collections.singletonMap(modelIdcurie, modelIdPrefix));
-		curieHandler = new MappedCurieHandler(DefaultCurieHandler.getMappings(), localMappings);
+		curieHandler = new MappedCurieHandler(DefaultCurieHandler.loadDefaultMappings(), localMappings);
 		
 		models = new UndoAwareMolecularModelManager(graph, curieHandler, modelIdPrefix, folder.newFile().getAbsolutePath(), null);
 		InferenceProviderCreator ipc = CachingInferenceProviderCreatorImpl.createElk(false);

--- a/minerva-server/src/test/java/org/geneontology/minerva/server/handler/ParallelModelReasonerTest.java
+++ b/minerva-server/src/test/java/org/geneontology/minerva/server/handler/ParallelModelReasonerTest.java
@@ -56,7 +56,7 @@ public class ParallelModelReasonerTest {
 		final String modelIdcurie = "gomodel";
 		final String modelIdPrefix = "http://model.geneontology.org/";
 		final CurieMappings localMappings = new CurieMappings.SimpleCurieMappings(Collections.singletonMap(modelIdcurie, modelIdPrefix));
-		curieHandler = new MappedCurieHandler(DefaultCurieHandler.getMappings(), localMappings);
+		curieHandler = new MappedCurieHandler(DefaultCurieHandler.loadDefaultMappings(), localMappings);
 		
 		models = new UndoAwareMolecularModelManager(graph, curieHandler, modelIdPrefix, folder.newFile().getAbsolutePath(), null);
 		ipc = new CountingCachingInferenceProvider(false);

--- a/minerva-server/src/test/java/org/geneontology/minerva/server/handler/SeedHandlerTest.java
+++ b/minerva-server/src/test/java/org/geneontology/minerva/server/handler/SeedHandlerTest.java
@@ -53,7 +53,7 @@ public class SeedHandlerTest {
 		final String modelIdcurie = "gomodel";
 		final String modelIdPrefix = "http://model.geneontology.org/";
 		final CurieMappings localMappings = new CurieMappings.SimpleCurieMappings(Collections.singletonMap(modelIdcurie, modelIdPrefix));
-		curieHandler = new MappedCurieHandler(DefaultCurieHandler.getMappings(), localMappings);
+		curieHandler = new MappedCurieHandler(DefaultCurieHandler.loadDefaultMappings(), localMappings);
 		models = new UndoAwareMolecularModelManager(graph, curieHandler, modelIdPrefix, folder.newFile().getAbsolutePath(), null);
 		SimpleEcoMapper ecoMapper = EcoMapperFactory.createSimple();
 		handler = new JsonOrJsonpSeedHandler(models, "unknown", golr, ecoMapper) {


### PR DESCRIPTION
Fixes #113.

Assumes that someone using a custom JSON-LD context will prepare a single file to pass to Minerva.