### PR TITLE
Extend GPAD generation codes to support negations in the qualifier field of GPAD.

### DIFF
--- a/minerva-converter/src/main/java/org/geneontology/minerva/legacy/sparql/BasicGPADData.java
+++ b/minerva-converter/src/main/java/org/geneontology/minerva/legacy/sparql/BasicGPADData.java
@@ -4,25 +4,34 @@ import org.apache.jena.graph.Node;
 import org.semanticweb.owlapi.model.IRI;
 
 public class BasicGPADData {
-
 	private final Node objectNode;
 	private final IRI object;
+	private GPADOperatorStatus operator;
 	private final IRI qualifier;
 	private final Node ontologyClassNode;
 	private final IRI ontologyClass;
 	
 	public BasicGPADData(Node objectNode, IRI object, IRI qualifier, Node ontologyClassNode, IRI ontologyClass) {
 		this.object = object;
+		this.operator = GPADOperatorStatus.NONE;
 		this.qualifier = qualifier;
 		this.ontologyClass = ontologyClass;
 		this.objectNode = objectNode;
 		this.ontologyClassNode = ontologyClassNode;
 	}
-
+	
 	public IRI getObject() {
 		return this.object;
 	}
 
+	public void setOperator(GPADOperatorStatus operator) {
+		this.operator = operator;
+	}
+	
+	public GPADOperatorStatus getOperator() {
+		return operator;
+	}
+	
 	public IRI getQualifier() {
 		return this.qualifier;
 	}
@@ -46,6 +55,7 @@ public class BasicGPADData {
 		else {
 			BasicGPADData otherData = (BasicGPADData)other;
 			return this.getObject().equals(otherData.getObject())
+					&& this.getOperator().equals(otherData.getOperator())
 					&& this.getQualifier().equals(otherData.getQualifier())
 					&& this.getOntologyClass().equals(otherData.getOntologyClass())
 					&& this.getObjectNode().equals(otherData.getObjectNode())
@@ -57,6 +67,7 @@ public class BasicGPADData {
 	public int hashCode() {
 		int result = 17;
 		result = 37 * result + this.getObject().hashCode();
+		result = 37 * result + this.getOperator().hashCode();
 		result = 37 * result + this.getQualifier().hashCode();
 		result = 37 * result + this.getOntologyClass().hashCode();
 		result = 37 * result + this.getObjectNode().hashCode();
@@ -66,7 +77,6 @@ public class BasicGPADData {
 	
 	@Override
 	public String toString() {
-		return this.object.toString() + this.qualifier.toString() + this.ontologyClass.toString();
+		return this.object.toString() + ", " + this.operator.toString() + "," + this.qualifier.toString() + ", " + this.ontologyClass.toString();
 	}
-
 }

--- a/minerva-converter/src/main/java/org/geneontology/minerva/legacy/sparql/DefaultGPADData.java
+++ b/minerva-converter/src/main/java/org/geneontology/minerva/legacy/sparql/DefaultGPADData.java
@@ -9,6 +9,7 @@ import org.semanticweb.owlapi.model.IRI;
 public class DefaultGPADData implements GPADData {
 
 	private final IRI object;
+	private GPADOperatorStatus operator;	
 	private final IRI qualifier;
 	private final IRI ontologyClass;
 	private final Set<ConjunctiveExpression> annotationExtensions;
@@ -40,7 +41,16 @@ public class DefaultGPADData implements GPADData {
 	public IRI getObject() {
 		return this.object;
 	}
-
+	
+	public void setOperator(GPADOperatorStatus operator) {
+		this.operator = operator;
+	}
+	
+	@Override
+	public GPADOperatorStatus getOperator() {
+		return operator;
+	}
+	
 	@Override
 	public IRI getQualifier() {
 		return this.qualifier;
@@ -99,6 +109,7 @@ public class DefaultGPADData implements GPADData {
 		else {
 			DefaultGPADData otherData = (DefaultGPADData)other;
 			return this.getObject().equals(otherData.getObject())
+					&& this.getOperator().equals(otherData.getOperator())
 					&& this.getQualifier().equals(otherData.getQualifier())
 					&& this.getOntologyClass().equals(otherData.getOntologyClass())
 					&& this.getAnnotationExtensions().equals(otherData.getAnnotationExtensions())
@@ -116,6 +127,7 @@ public class DefaultGPADData implements GPADData {
 	public int hashCode() {
 		int result = 17;
 		result = 37 * result + this.getObject().hashCode();
+		result = 37 * result + this.getOperator().hashCode();
 		result = 37 * result + this.getQualifier().hashCode();
 		result = 37 * result + this.getOntologyClass().hashCode();
 		result = 37 * result + this.getAnnotationExtensions().hashCode();
@@ -129,5 +141,4 @@ public class DefaultGPADData implements GPADData {
 		result = 37 * result + this.getAnnotations().hashCode();
 		return result;
 	}
-
 }

--- a/minerva-converter/src/main/java/org/geneontology/minerva/legacy/sparql/GPADData.java
+++ b/minerva-converter/src/main/java/org/geneontology/minerva/legacy/sparql/GPADData.java
@@ -11,7 +11,7 @@ import org.semanticweb.owlapi.model.IRI;
 /**
  * Standard data needed to render a GPAD file at IRI level.
  * Adding labels or curie transformations can build from this.
- * This is not meant to be a fully general represenation of GPAD; 
+ * This is not meant to be a fully general representation of GPAD; 
  * just the information expected to be provided for a GPAD annotation
  * extraction from a LEGO model.
  */
@@ -20,6 +20,9 @@ public interface GPADData {
 	@Nonnull
 	public IRI getObject();
 
+	@Nonnull
+	public GPADOperatorStatus getOperator();
+	
 	@Nonnull
 	public IRI getQualifier();
 
@@ -57,5 +60,4 @@ public interface GPADData {
 		public IRI getFiller();
 
 	}
-
 }

--- a/minerva-converter/src/main/java/org/geneontology/minerva/legacy/sparql/GPADOperatorStatus.java
+++ b/minerva-converter/src/main/java/org/geneontology/minerva/legacy/sparql/GPADOperatorStatus.java
@@ -1,0 +1,8 @@
+package org.geneontology.minerva.legacy.sparql;
+
+/* See also: http://www.geneontology.org/page/gene-product-association-data-gpad-format */
+public enum GPADOperatorStatus {
+	NONE, 
+	NOT,
+	ALWAYS;
+}

--- a/minerva-converter/src/main/java/org/geneontology/minerva/legacy/sparql/GPADSPARQLExport.java
+++ b/minerva-converter/src/main/java/org/geneontology/minerva/legacy/sparql/GPADSPARQLExport.java
@@ -34,6 +34,7 @@ import org.apache.jena.sparql.engine.binding.BindingMap;
 import org.apache.jena.vocabulary.OWL;
 import org.apache.jena.vocabulary.RDF;
 import org.apache.log4j.Logger;
+import org.eclipse.jetty.util.log.Log;
 import org.geneontology.minerva.curie.CurieHandler;
 import org.geneontology.minerva.legacy.sparql.GPADData.ConjunctiveExpression;
 import org.geneontology.rules.engine.Explanation;
@@ -43,10 +44,9 @@ import org.semanticweb.owlapi.model.IRI;
 
 import scala.collection.JavaConverters;
 
+/* 	 Note: the example GPAD files are available at this link: http://www.informatics.jax.org/downloads/reports/mgi.gpa.gz */
 public class GPADSPARQLExport {
-
 	private static final Logger LOG = Logger.getLogger(GPADSPARQLExport.class);
-
 	private static final String ND = "http://purl.obolibrary.org/obo/ECO_0000307";
 	private static final String MF = "http://purl.obolibrary.org/obo/GO_0003674";
 	private static final String BP = "http://purl.obolibrary.org/obo/GO_0008150";
@@ -85,27 +85,41 @@ public class GPADSPARQLExport {
 		this.relationShorthandIndex = shorthandIndex;
 	}
 
-	/*
-	 * This is a bit convoluted in order to minimize redundant queries, for performance reasons.
-	 */
+	/* This is a bit convoluted in order to minimize redundant queries, for performance reasons. */
 	public String exportGPAD(WorkingMemory wm) {
+		/* The first step of constructing GPAD records is to construct candidate/basic GPAD records by running gpad-basic.rq. */ 
 		Model model = ModelFactory.createDefaultModel();
 		model.add(JavaConverters.setAsJavaSetConverter(wm.facts()).asJava().stream().map(t -> model.asStatement(Bridge.jenaFromTriple(t))).collect(Collectors.toList()));
 		QueryExecution qe = QueryExecutionFactory.create(mainQuery, model);
 		Set<GPADData> annotations = new HashSet<>();
 		String modelID = model.listResourcesWithProperty(RDF.type, OWL.Ontology).mapWith(r -> curieHandler.getCuri(IRI.create(r.getURI()))).next();
 		ResultSet results = qe.execSelect();
-		Set<BasicGPADData> basicAnnotations = new HashSet<>();
+		Set<BasicGPADData> basicAnnotations = new HashSet<>();		
 		while (results.hasNext()) {
 			QuerySolution qs = results.next();
-			basicAnnotations.add(new BasicGPADData(qs.getResource("pr").asNode(), IRI.create(qs.getResource("pr_type").getURI()), IRI.create(qs.getResource("rel").getURI()), qs.getResource("target").asNode(), IRI.create(qs.getResource("target_type").getURI())));
+			BasicGPADData basicGPADData = new BasicGPADData(qs.getResource("pr").asNode(), IRI.create(qs.getResource("pr_type").getURI()), IRI.create(qs.getResource("rel").getURI()), qs.getResource("target").asNode(), IRI.create(qs.getResource("target_type").getURI()));			
+			
+			/* See whether the query answer contains not-null blank nodes, which are only set if the matching subgraph 
+			 * contains the property ComplementOf.  If we see such cases, we set the operator field as NOT so that NOT value 
+			 * can be printed in GPAD. */ 
+			if (qs.getResource("blank_comp") != null) basicGPADData.setOperator(GPADOperatorStatus.NOT);
+			basicAnnotations.add(basicGPADData);
 		}
 		qe.close();
+		
+		/* The bindings of ?pr_type, ?rel, ?target_type are candidate mappings or values for the final GPAD records 
+		 * (i.e. not every mapping is used for building the final records of GPAD file; many of them are filtered out later).
+		 * The mappings are 
+		 * 		?pr_type: DB Object ID (2nd in GPAD), ?rel: Qualifier(3rd), ?target_type: GO ID(4th) 
+		 * The rest of fields in GPAD are then constructed by joining the candidate mappings with mappings describing evidences and so on.
+		 * If the output of this exporter (i.e. GPAD files) does not contain the values you expect, 
+		 * dump the above "QuerySolution qs" variable and see whether they are included in the dump. */
 		Set<AnnotationExtension> possibleExtensions = possibleExtensions(basicAnnotations, model);
 		Set<Triple> statementsToExplain = new HashSet<>();
 		basicAnnotations.forEach(ba -> statementsToExplain.add(Triple.create(ba.getObjectNode(), NodeFactory.createURI(ba.getQualifier().toString()), ba.getOntologyClassNode())));
 		possibleExtensions.forEach(ae -> statementsToExplain.add(ae.getTriple()));
 		Map<Triple, Set<Explanation>> allExplanations = statementsToExplain.stream().collect(Collectors.toMap(Function.identity(), s -> toJava(wm.explain(Bridge.tripleFromJena(s)))));
+
 		Map<Triple, Set<GPADEvidence>> allEvidences = evidencesForFacts(allExplanations.values().stream().flatMap(es -> es.stream()).flatMap(e -> toJava(e.facts()).stream().map(t -> Bridge.jenaFromTriple(t))).collect(Collectors.toSet()), model, modelID);
 		for (BasicGPADData annotation : basicAnnotations) {
 			for (Explanation explanation : allExplanations.get(Triple.create(annotation.getObjectNode(), NodeFactory.createURI(annotation.getQualifier().toString()), annotation.getOntologyClassNode()))) {
@@ -131,13 +145,17 @@ public class GPADSPARQLExport {
 								}
 							}
 						}
+
 						final boolean rootViolation;
 						if (rootTerms.contains(annotation.getOntologyClass().toString())) {
 							rootViolation = !ND.equals(currentEvidence.getEvidence().toString());
 						} else { rootViolation = false; }
+
 						if (!rootViolation) {
-							annotations.add(new DefaultGPADData(annotation.getObject(), annotation.getQualifier(), annotation.getOntologyClass(), goodExtensions, 
-									reference, currentEvidence.getEvidence(), currentEvidence.getWithOrFrom(), Optional.empty(), currentEvidence.getDate(), "GO_Noctua", currentEvidence.getAnnotations()));	
+							DefaultGPADData defaultGPADData = new DefaultGPADData(annotation.getObject(), annotation.getQualifier(), annotation.getOntologyClass(), goodExtensions, 
+									reference, currentEvidence.getEvidence(), currentEvidence.getWithOrFrom(), Optional.empty(), currentEvidence.getDate(), "GO_Noctua", currentEvidence.getAnnotations());
+							defaultGPADData.setOperator(annotation.getOperator());
+							annotations.add(defaultGPADData);
 						}
 					});
 				}
@@ -146,6 +164,21 @@ public class GPADSPARQLExport {
 		return new GPADRenderer(curieHandler, relationShorthandIndex).renderAll(annotations);
 	}
 
+	/**
+	 * Given a set of triples extracted/generated from the result/answer of query gpad-basic.rq, we find matching evidence subgraphs. 
+	 * In other words, if there are no matching evidence (i.e. no bindings for evidence_type), we discard (basic) GPAD instance.
+	 * 
+	 * The parameter "facts" consists of triples <?subject, ?predicate, ?object> constructed from a binding of ?pr, ?rel, ?target in gpad_basic.rq. 
+	 * (The codes that constructing these triples are executed right before this method is called).
+	 * 
+	 * These triples are then decomposed into values used as the parameters/bindings for objects of the following patterns.
+	 * 		?axiom owl:annotatedSource   ?subject (i.e. ?pr in gpad_basic.rq) 
+	 * 		?axiom owl:annotatedProperty ?predicate (i.e., ?rel in gpad_basic.rq, which denotes qualifier in GPAD) 
+	 * 		?axiom owl:annotatedTarget    ?object (i.e., ?target in gpad_basic.rq)
+	 * 
+	 * If we find the bindings of ?axioms and the values of these bindings have some rdf:type triples, we proceed. (If not, we discard).
+	 * The bindings of the query gpad-relation-evidence-multiple.rq are then used for filling up fields in GPAD records/tuples.
+	 */
 	private Map<Triple, Set<GPADEvidence>> evidencesForFacts(Set<Triple> facts, Model model, String modelID) {
 		Query query = QueryFactory.create(multipleEvidenceQuery);
 		Var subject = Var.alloc("subject");
@@ -220,7 +253,6 @@ public class GPADSPARQLExport {
 	}
 
 	private static class DefaultConjunctiveExpression implements ConjunctiveExpression {
-
 		private final IRI relation;
 		private final IRI filler;
 
@@ -238,7 +270,5 @@ public class GPADSPARQLExport {
 		public IRI getFiller() {
 			return filler;
 		}
-
 	}
-
 }

--- a/minerva-converter/src/main/resources/org/geneontology/minerva/legacy/sparql/gpad-basic.rq
+++ b/minerva-converter/src/main/resources/org/geneontology/minerva/legacy/sparql/gpad-basic.rq
@@ -21,45 +21,75 @@ PREFIX BFO: <http://purl.obolibrary.org/obo/BFO_>
 PREFIX CHEBI: <http://purl.obolibrary.org/obo/CHEBI_>
 PREFIX PR: <http://purl.obolibrary.org/obo/PR_>
 
-SELECT DISTINCT ?pr ?pr_type ?rel ?target ?target_type
+SELECT DISTINCT ?pr ?pr_type ?rel ?target ?blank_comp ?target_type
 WHERE {
-    # Annotation relations between gene product and GO term instance (?target)
-    VALUES ?rel { 
+	# ?pr, ?target: some instances/individuals? 
+    # ?rel: qualifier in GPAD.
+    # ?pr_type: DB object ID in GPAD, e.g., <http://www.informatics.jax.org/accession/MGI:MGI:1925503>
+    # ?target_type: GO ID, i.e., the GO identifier for the term attributed to the DB object ID, e.g., <http://purl.obolibrary.org/obo/GO_0005200>.
+    
+    ?pr ?rel ?target .
+	?pr rdf:type ?pr_type .
+    
+	# Not sure what this filter is for. I believe this filter was designed to handle some triples generated from reasoning.
+	FILTER NOT EXISTS {
+        ?pr ?other_rel ?target .
+        ?other_rel rdfs:subPropertyOf ?rel .
+        FILTER(?other_rel != ?rel) 
+	}
+	
+	# The value of ?rel should be either one of these values.
+	VALUES ?rel { 
         enables:
         involved_in: 
         part_of: 
         acts_upstream_of: 
         acts_upstream_of_or_within: 
         contributes_to:
-    }
-    # The main annotation relation
-    ?pr ?rel ?target .
-    #?pr rdf:type CHEBI:23367 .
-    # Exclude redundant links between gene product and target
-    FILTER NOT EXISTS {
-        ?pr ?other_rel ?target .
-        ?other_rel rdfs:subPropertyOf ?rel .
-        FILTER(?other_rel != ?rel) 
-    }
-    # Only get asserted types for the annotation target (for now, until we can exclude redundant types with reasonable performance)
-    ?target rdf:type ?target_type .
-    FILTER NOT EXISTS {
-        ?target <http://arachne.geneontology.org/indirect_type> ?target_type .
-    }
-    FILTER(isIRI(?target_type))
-    FILTER(?target_type NOT IN (rdfs:Resource, owl:Thing, owl:NamedIndividual, BFO:0000002, BFO:0000003, BFO:0000004, BFO:0000015, BFO:0000040))
-    # Only get asserted types for the gene product (these will be e.g. gene IDs)
-    ?pr rdf:type ?pr_type . 
-    FILTER(isIRI(?pr_type))
-    FILTER NOT EXISTS {
-        ?pr <http://arachne.geneontology.org/indirect_type> ?pr_type .
-    }
-    FILTER(?pr_type NOT IN (rdfs:Resource, owl:Thing, owl:NamedIndividual, BFO:0000002, BFO:0000003, BFO:0000004, BFO:0000015, BFO:0000040))
-    FILTER(!STRSTARTS(STR(?pr_type), "http://purl.obolibrary.org/obo/GO_")) # would be better to do this semantically but expensive to add NEO tbox to model
-    FILTER(!STRSTARTS(STR(?pr_type), "http://purl.obolibrary.org/obo/PO_")) # would be better to do this semantically but expensive to add NEO tbox to model
-    FILTER(!STRSTARTS(STR(?pr_type), "http://purl.obolibrary.org/obo/UBERON_")) # would be better to do this semantically but expensive to add NEO tbox to model
-    FILTER(!STRSTARTS(STR(?pr_type), "http://purl.obolibrary.org/obo/CL_")) # would be better to do this semantically but expensive to add NEO tbox to model
-    FILTER(!STRSTARTS(STR(?pr_type), "http://purl.obolibrary.org/obo/EMAPA_")) # would be better to do this semantically but expensive to add NEO tbox to model
-    # Only find GO terms as targets
-    FILTER(STRSTARTS(STR(?target_type), "http://purl.obolibrary.org/obo/GO_")) # would be better to do this via isDefinedBy
+	}
+	
+	# the value of ?pr_type should be IRI.
+	FILTER(isIRI(?pr_type)) 
+	
+	# The value of ?pr_type should not be the values in this list, i.e. filter out meaningless nodes.
+	FILTER(?pr_type NOT IN (rdfs:Resource, owl:Thing, owl:NamedIndividual, BFO:0000002, BFO:0000003, BFO:0000004, BFO:0000015, BFO:0000040))
+	
+	# The value of ?pr_type should not begin with these values, e.g., GO ID.
+	FILTER(!STRSTARTS(STR(?pr_type), "http://purl.obolibrary.org/obo/GO_")) # would be better to do this semantically but expensive to add NEO tbox to model
+	FILTER(!STRSTARTS(STR(?pr_type), "http://purl.obolibrary.org/obo/PO_")) # would be better to do this semantically but expensive to add NEO tbox to model
+	FILTER(!STRSTARTS(STR(?pr_type), "http://purl.obolibrary.org/obo/UBERON_")) # would be better to do this semantically but expensive to add NEO tbox to model
+	FILTER(!STRSTARTS(STR(?pr_type), "http://purl.obolibrary.org/obo/CL_")) # would be better to do this semantically but expensive to add NEO tbox to model
+	FILTER(!STRSTARTS(STR(?pr_type), "http://purl.obolibrary.org/obo/EMAPA_")) # would be better to do this semantically but expensive to add NEO tbox to model
+	
+	FILTER NOT EXISTS {
+        	?pr <http://arachne.geneontology.org/indirect_type> ?pr_type .
+	}
+    # the value of ?target_type should be IRI.
+	FILTER(isIRI(?target_type))
+
+	# The object of complementOf should be also GO terms
+	FILTER(STRSTARTS(STR(?target_type), "http://purl.obolibrary.org/obo/GO_"))
+
+	FILTER NOT EXISTS {
+		?target <http://arachne.geneontology.org/indirect_type> ?target_type .
+	}
+	
+	FILTER(?target_type NOT IN (rdfs:Resource, owl:Thing, owl:NamedIndividual, BFO:0000002, BFO:0000003, BFO:0000004, BFO:0000015, BFO:0000040))
+		
+	{
+	    # Case 1. This union branch contains the triple patterns that retrieve only GO terms as targets (without negations)
+		?target rdf:type ?target_type .
+	} UNION {
+		# Case 2. this union branch covers the negation case represented using ComplementOf. 
+		# This negation is represented triples connected by a blank node.
+    	# E.g., the following patterns captures the graph pattern, e.g., 
+    	# :5993df9e00000100 rdf:type _:b0
+    	# _:b0 owl:complementOf :GO_0044108
+    	
+		?target rdf:type ?blank_comp .
+    	?blank_comp owl:complementOf ?target_type
+
+		# the value mapping ?blank_comp should be a blank node.		
+		FILTER(isBlank(?blank_comp))		
+	} 
 }

--- a/minerva-converter/src/test/java/org/geneontology/minerva/legacy/sparql/GPADSPARQLTest.java
+++ b/minerva-converter/src/test/java/org/geneontology/minerva/legacy/sparql/GPADSPARQLTest.java
@@ -1,10 +1,13 @@
 package org.geneontology.minerva.legacy.sparql;
 
+import java.io.File;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import org.apache.commons.io.FileUtils;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.reasoner.rulesys.Rule;
@@ -28,7 +31,6 @@ import org.semanticweb.owlapi.model.parameters.Imports;
 import scala.collection.JavaConverters;
 
 public class GPADSPARQLTest {
-
 	private static RuleEngine arachne;
 	private static GPADSPARQLExport exporter;
 
@@ -60,4 +62,42 @@ public class GPADSPARQLTest {
 		Assert.assertTrue("Should produce annotations", lines > 2);
 	}
 
+	/**
+	 * Test whether the GPAD output contains all required entries and rows without any spurious results.
+	 * Example Input file: the owl dump from http://noctua-dev.berkeleybop.org/editor/graph/gomodel:59d1072300000074
+	 * 
+	 * Note on the GPAD file format and its contents:
+	 * 1. the number of entries in the GPAD output from this owl dump should be 6, not 7 (although there are 7 individuals/boxes) 
+	 *     because the edge/relationship "molecular_function" is a trivial one, which is supposed to be removed from the output.
+	 * 2. the 4th columns, which consists of the list of GO IDs attributed to the DB object ID (These should be GO:0005634, GO:0007267, GO:0007507, GO:0016301) 
+	 * 3. the 2nd columns: the rest of entities in the noctua screen, i.e.  S000028630 (YFR032C-B Scer) or S000004724(SHH3 Scer)
+	*
+	 * @throws Exception
+	 */
+	@Test
+	public void testGPADOutputWithNegation() throws Exception {
+		Model model = ModelFactory.createDefaultModel();
+		model.read(this.getClass().getResourceAsStream("/59d1072300000074.ttl"), "", "ttl");
+		Set<Triple> triples = model.listStatements().toList().stream().map(s -> Bridge.tripleFromJena(s.asTriple())).collect(Collectors.toSet());
+		WorkingMemory mem = arachne.processTriples(JavaConverters.asScalaSetConverter(triples).asScala());
+		String gpad = exporter.exportGPAD(mem);
+		
+		/* Check the number of rows in GPAD output */
+		String gpadOutputArr[] = gpad.split("\n", -1);
+		/* 1 for header and 6 for the rest of the rows. the length should be  7 or 8.*/
+		Assert.assertTrue("Should produce annotations", gpadOutputArr.length >= 1 + 6);
+		
+		/* Compare the output with the GPAD file that contains sample answers */
+		List<String> lines = FileUtils.readLines(new File("src/test/resources/59d1072300000074.gpad"), "UTF-8");
+		/* The order of the rows in the GPAD file can be different, so we compare rows by rows */
+		for (String gpadOutputRow : gpadOutputArr) {
+			 /* Additionally check all rows's qualifier contains |NOT substring inside */
+			 String gpadRowArr[] =  gpadOutputRow.split("\t");
+			 /* Skip checking the header; all rows need to contain NOT in its qualifier */
+			 if (gpadRowArr.length > 2) {
+				 Assert.assertTrue(lines.contains(gpadOutputRow.trim()));
+				 Assert.assertTrue(gpadRowArr[2].contains("|NOT"));
+			 }
+		 }
+	}
 }

--- a/minerva-converter/src/test/resources/59d1072300000074.gpad
+++ b/minerva-converter/src/test/resources/59d1072300000074.gpad
@@ -1,0 +1,7 @@
+!gpa-version: 1.2
+SGD	S000004724	BFO:0000050|NOT	GO:0005634	PMID:456	ECO:0000314			20171101	GO_Noctua		noctua-model-id=http://model.geneontology.org/59d1072300000074|contributor=GOC:kltm
+SGD	S000004724	RO:0002264|NOT	GO:0007267	PMID:123	ECO:0000314			20171101	GO_Noctua		noctua-model-id=http://model.geneontology.org/59d1072300000074|contributor=GOC:kltm
+SGD	S000028630	RO:0002264|NOT	GO:0007507	PMID:123	ECO:0005669			20171101	GO_Noctua	RO:0002131(GO:0003674)	noctua-model-id=http://model.geneontology.org/59d1072300000074|contributor=GOC:kltm
+SGD	S000004724	RO:0002331|NOT	GO:0007267	PMID:123	ECO:0000314			20171101	GO_Noctua		noctua-model-id=http://model.geneontology.org/59d1072300000074|contributor=GOC:kltm
+SGD	S000004724	RO:0002327|NOT	GO:0016301	2	ECO:0005662	1		20171101	GO_Noctua		noctua-model-id=http://model.geneontology.org/59d1072300000074|contributor=GOC:kltm
+SGD	S000028630	RO:0002331|NOT	GO:0007507	PMID:123	ECO:0005669			20171101	GO_Noctua	RO:0002131(GO:0003674)	noctua-model-id=http://model.geneontology.org/59d1072300000074|contributor=GOC:kltm

--- a/minerva-converter/src/test/resources/59d1072300000074.ttl
+++ b/minerva-converter/src/test/resources/59d1072300000074.ttl
@@ -1,0 +1,238 @@
+@prefix : <http://model.geneontology.org/59d1072300000074#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@base <http://model.geneontology.org/59d1072300000074> .
+
+<http://model.geneontology.org/59d1072300000074> rdf:type owl:Ontology ;
+                                                  owl:versionIRI <http://model.geneontology.org/59d1072300000074> ;
+                                                  owl:imports <http://purl.obolibrary.org/obo/go/extensions/go-lego.owl> ;
+                                                  <http://geneontology.org/lego/modelstate> "development"^^xsd:string ;
+                                                  <http://purl.org/dc/elements/1.1/title> "Test for negation"^^xsd:string ;
+                                                  <http://www.geneontology.org/formats/oboInOwl#id> "gomodel:59d1072300000074"^^xsd:string ;
+                                                  <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-6601-2165"^^xsd:string ,
+                                                                                                "GOC:kltm"^^xsd:string ;
+                                                  <http://purl.org/pav/providedBy> "http://geneontology.org"^^xsd:string ;
+                                                  <http://purl.org/dc/elements/1.1/date> "2017-11-01"^^xsd:string .
+
+#################################################################
+#    Annotation properties
+#################################################################
+
+###  http://geneontology.org/lego/evidence
+<http://geneontology.org/lego/evidence> rdf:type owl:AnnotationProperty .
+
+
+###  http://geneontology.org/lego/evidence-with
+<http://geneontology.org/lego/evidence-with> rdf:type owl:AnnotationProperty .
+
+
+###  http://geneontology.org/lego/hint/layout/x
+<http://geneontology.org/lego/hint/layout/x> rdf:type owl:AnnotationProperty .
+
+
+###  http://geneontology.org/lego/hint/layout/y
+<http://geneontology.org/lego/hint/layout/y> rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/pav/providedBy
+<http://purl.org/pav/providedBy> rdf:type owl:AnnotationProperty .
+
+
+#################################################################
+#    Classes
+#################################################################
+
+###  http://identifiers.org/sgd/S000004724
+<http://identifiers.org/sgd/S000004724> rdf:type owl:Class .
+
+
+###  http://identifiers.org/sgd/S000028630
+<http://identifiers.org/sgd/S000028630> rdf:type owl:Class .
+
+
+#################################################################
+#    Individuals
+#################################################################
+
+###  http://model.geneontology.org/59d1072300000074/59d1072300000075
+<http://model.geneontology.org/59d1072300000074/59d1072300000075> rdf:type owl:NamedIndividual ,
+                                                                           <http://identifiers.org/sgd/S000004724> ;
+                                                                  <http://purl.obolibrary.org/obo/BFO_0000050> <http://model.geneontology.org/59d1072300000074/59f8d86400000006> ;
+                                                                  <http://geneontology.org/lego/hint/layout/x> "55"^^xsd:string ;
+                                                                  <http://geneontology.org/lego/hint/layout/y> "350"^^xsd:string ;
+                                                                  <http://purl.org/dc/elements/1.1/contributor> "GOC:kltm"^^xsd:string ,
+                                                                                                                "http://orcid.org/0000-0002-6601-2165"^^xsd:string ;
+                                                                  <http://purl.org/dc/elements/1.1/date> "2017-11-01"^^xsd:string ;
+                                                                  <http://purl.org/pav/providedBy> "http://geneontology.org"^^xsd:string .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource <http://model.geneontology.org/59d1072300000074/59d1072300000075> ;
+   owl:annotatedProperty <http://purl.obolibrary.org/obo/BFO_0000050> ;
+   owl:annotatedTarget <http://model.geneontology.org/59d1072300000074/59f8d86400000006> ;
+   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/59d1072300000074/59f8d86400000007> ;
+   <http://purl.org/dc/elements/1.1/contributor> "GOC:kltm"^^xsd:string ;
+   <http://purl.org/dc/elements/1.1/date> "2017-11-01"^^xsd:string
+ ] .
+
+
+###  http://model.geneontology.org/59d1072300000074/59d1072300000076
+<http://model.geneontology.org/59d1072300000074/59d1072300000076> rdf:type owl:NamedIndividual ,
+                                                                           [ rdf:type owl:Class ;
+                                                                             owl:complementOf <http://purl.obolibrary.org/obo/GO_0016301>
+                                                                           ] ;
+                                                                  <http://purl.obolibrary.org/obo/BFO_0000050> <http://model.geneontology.org/59d1072300000074/59f8d86400000004> ;
+                                                                  <http://purl.obolibrary.org/obo/RO_0002333> <http://model.geneontology.org/59d1072300000074/59d1072300000075> ;
+                                                                  <http://geneontology.org/lego/hint/layout/x> "94"^^xsd:string ;
+                                                                  <http://geneontology.org/lego/hint/layout/y> "192"^^xsd:string ;
+                                                                  <http://purl.org/dc/elements/1.1/contributor> "GOC:kltm"^^xsd:string ,
+                                                                                                                "http://orcid.org/0000-0002-6601-2165"^^xsd:string ;
+                                                                  <http://purl.org/dc/elements/1.1/date> "2017-11-01"^^xsd:string ;
+                                                                  <http://purl.org/pav/providedBy> "http://geneontology.org"^^xsd:string .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource <http://model.geneontology.org/59d1072300000074/59d1072300000076> ;
+   owl:annotatedProperty <http://purl.obolibrary.org/obo/BFO_0000050> ;
+   owl:annotatedTarget <http://model.geneontology.org/59d1072300000074/59f8d86400000004> ;
+   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/59d1072300000074/59f8d86400000005> ;
+   <http://purl.org/dc/elements/1.1/contributor> "GOC:kltm"^^xsd:string ;
+   <http://purl.org/dc/elements/1.1/date> "2017-11-01"^^xsd:string
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource <http://model.geneontology.org/59d1072300000074/59d1072300000076> ;
+   owl:annotatedProperty <http://purl.obolibrary.org/obo/RO_0002333> ;
+   owl:annotatedTarget <http://model.geneontology.org/59d1072300000074/59d1072300000075> ;
+   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/59d1072300000074/59f8d86400000002> ;
+   <http://purl.org/dc/elements/1.1/contributor> "GOC:kltm"^^xsd:string ,
+                                                 "http://orcid.org/0000-0002-6601-2165"^^xsd:string ;
+   <http://purl.org/dc/elements/1.1/date> "2017-11-01"^^xsd:string ;
+   <http://purl.org/pav/providedBy> "http://geneontology.org"^^xsd:string
+ ] .
+
+
+###  http://model.geneontology.org/59d1072300000074/59d1072300000077
+<http://model.geneontology.org/59d1072300000074/59d1072300000077> rdf:type owl:NamedIndividual ,
+                                                                           [ rdf:type owl:Class ;
+                                                                             owl:complementOf <http://purl.obolibrary.org/obo/GO_0007507>
+                                                                           ] ;
+                                                                  <http://geneontology.org/lego/hint/layout/x> "380"^^xsd:string ;
+                                                                  <http://geneontology.org/lego/hint/layout/y> "99"^^xsd:string ;
+                                                                  <http://purl.org/dc/elements/1.1/contributor> "GOC:kltm"^^xsd:string ,
+                                                                                                                "http://orcid.org/0000-0002-6601-2165"^^xsd:string ;
+                                                                  <http://purl.org/dc/elements/1.1/date> "2017-11-01"^^xsd:string ;
+                                                                  <http://purl.org/pav/providedBy> "http://geneontology.org"^^xsd:string .
+
+
+###  http://model.geneontology.org/59d1072300000074/59d1072300000078
+<http://model.geneontology.org/59d1072300000074/59d1072300000078> rdf:type owl:NamedIndividual ,
+                                                                           <http://identifiers.org/sgd/S000028630> ;
+                                                                  <http://geneontology.org/lego/hint/layout/x> "319"^^xsd:string ;
+                                                                  <http://geneontology.org/lego/hint/layout/y> "404"^^xsd:string ;
+                                                                  <http://purl.org/dc/elements/1.1/contributor> "GOC:kltm"^^xsd:string ,
+                                                                                                                "http://orcid.org/0000-0002-6601-2165"^^xsd:string ;
+                                                                  <http://purl.org/dc/elements/1.1/date> "2017-11-01"^^xsd:string ;
+                                                                  <http://purl.org/pav/providedBy> "http://geneontology.org"^^xsd:string .
+
+
+###  http://model.geneontology.org/59d1072300000074/59d1072300000079
+<http://model.geneontology.org/59d1072300000074/59d1072300000079> rdf:type owl:NamedIndividual ,
+                                                                           <http://purl.obolibrary.org/obo/GO_0003674> ;
+                                                                  <http://purl.obolibrary.org/obo/BFO_0000050> <http://model.geneontology.org/59d1072300000074/59d1072300000077> ;
+                                                                  <http://purl.obolibrary.org/obo/RO_0002333> <http://model.geneontology.org/59d1072300000074/59d1072300000078> ;
+                                                                  <http://geneontology.org/lego/hint/layout/x> "329"^^xsd:string ;
+                                                                  <http://geneontology.org/lego/hint/layout/y> "260"^^xsd:string ;
+                                                                  <http://purl.org/dc/elements/1.1/contributor> "GOC:kltm"^^xsd:string ,
+                                                                                                                "http://orcid.org/0000-0002-6601-2165"^^xsd:string ;
+                                                                  <http://purl.org/dc/elements/1.1/date> "2017-11-01"^^xsd:string ;
+                                                                  <http://purl.org/pav/providedBy> "http://geneontology.org"^^xsd:string .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource <http://model.geneontology.org/59d1072300000074/59d1072300000079> ;
+   owl:annotatedProperty <http://purl.obolibrary.org/obo/BFO_0000050> ;
+   owl:annotatedTarget <http://model.geneontology.org/59d1072300000074/59d1072300000077> ;
+   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/59d1072300000074/59f8d86400000000> ;
+   <http://purl.org/dc/elements/1.1/contributor> "GOC:kltm"^^xsd:string ,
+                                                 "http://orcid.org/0000-0002-6601-2165"^^xsd:string ;
+   <http://purl.org/dc/elements/1.1/date> "2017-11-01"^^xsd:string ;
+   <http://purl.org/pav/providedBy> "http://geneontology.org"^^xsd:string
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource <http://model.geneontology.org/59d1072300000074/59d1072300000079> ;
+   owl:annotatedProperty <http://purl.obolibrary.org/obo/RO_0002333> ;
+   owl:annotatedTarget <http://model.geneontology.org/59d1072300000074/59d1072300000078> ;
+   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/59d1072300000074/59f8d86400000003> ;
+   <http://purl.org/dc/elements/1.1/contributor> "GOC:kltm"^^xsd:string ,
+                                                 "http://orcid.org/0000-0002-6601-2165"^^xsd:string ;
+   <http://purl.org/dc/elements/1.1/date> "2017-11-01"^^xsd:string ;
+   <http://purl.org/pav/providedBy> "http://geneontology.org"^^xsd:string
+ ] .
+
+
+###  http://model.geneontology.org/59d1072300000074/59f8d86400000000
+<http://model.geneontology.org/59d1072300000074/59f8d86400000000> rdf:type owl:NamedIndividual ,
+                                                                           <http://purl.obolibrary.org/obo/ECO_0005669> ;
+                                                                  <http://purl.org/dc/elements/1.1/contributor> "GOC:kltm"^^xsd:string ;
+                                                                  <http://purl.org/dc/elements/1.1/date> "2017-11-01"^^xsd:string ;
+                                                                  <http://purl.org/dc/elements/1.1/source> "PMID:123"^^xsd:string .
+
+
+###  http://model.geneontology.org/59d1072300000074/59f8d86400000002
+<http://model.geneontology.org/59d1072300000074/59f8d86400000002> rdf:type owl:NamedIndividual ,
+                                                                           <http://purl.obolibrary.org/obo/ECO_0005662> ;
+                                                                  <http://geneontology.org/lego/evidence-with> "1"^^xsd:string ;
+                                                                  <http://purl.org/dc/elements/1.1/contributor> "GOC:kltm"^^xsd:string ;
+                                                                  <http://purl.org/dc/elements/1.1/date> "2017-11-01"^^xsd:string ;
+                                                                  <http://purl.org/dc/elements/1.1/source> "2"^^xsd:string .
+
+
+###  http://model.geneontology.org/59d1072300000074/59f8d86400000003
+<http://model.geneontology.org/59d1072300000074/59f8d86400000003> rdf:type owl:NamedIndividual ,
+                                                                           <http://purl.obolibrary.org/obo/ECO_0005665> ;
+                                                                  <http://geneontology.org/lego/evidence-with> "3"^^xsd:string ;
+                                                                  <http://purl.org/dc/elements/1.1/contributor> "GOC:kltm"^^xsd:string ;
+                                                                  <http://purl.org/dc/elements/1.1/date> "2017-11-01"^^xsd:string ;
+                                                                  <http://purl.org/dc/elements/1.1/source> "4"^^xsd:string .
+
+
+###  http://model.geneontology.org/59d1072300000074/59f8d86400000004
+<http://model.geneontology.org/59d1072300000074/59f8d86400000004> rdf:type owl:NamedIndividual ,
+                                                                           [ rdf:type owl:Class ;
+                                                                             owl:complementOf <http://purl.obolibrary.org/obo/GO_0007267>
+                                                                           ] ;
+                                                                  <http://geneontology.org/lego/hint/layout/x> "85"^^xsd:string ;
+                                                                  <http://geneontology.org/lego/hint/layout/y> "9"^^xsd:string ;
+                                                                  <http://purl.org/dc/elements/1.1/contributor> "GOC:kltm"^^xsd:string ;
+                                                                  <http://purl.org/dc/elements/1.1/date> "2017-11-01"^^xsd:string .
+
+
+###  http://model.geneontology.org/59d1072300000074/59f8d86400000005
+<http://model.geneontology.org/59d1072300000074/59f8d86400000005> rdf:type owl:NamedIndividual ,
+                                                                           <http://purl.obolibrary.org/obo/ECO_0000314> ;
+                                                                  <http://purl.org/dc/elements/1.1/contributor> "GOC:kltm"^^xsd:string ;
+                                                                  <http://purl.org/dc/elements/1.1/date> "2017-11-01"^^xsd:string ;
+                                                                  <http://purl.org/dc/elements/1.1/source> "PMID:123"^^xsd:string .
+
+
+###  http://model.geneontology.org/59d1072300000074/59f8d86400000006
+<http://model.geneontology.org/59d1072300000074/59f8d86400000006> rdf:type owl:NamedIndividual ,
+                                                                           [ rdf:type owl:Class ;
+                                                                             owl:complementOf <http://purl.obolibrary.org/obo/GO_0005634>
+                                                                           ] ;
+                                                                  <http://geneontology.org/lego/hint/layout/y> "109"^^xsd:string ;
+                                                                  <http://purl.org/dc/elements/1.1/contributor> "GOC:kltm"^^xsd:string ;
+                                                                  <http://purl.org/dc/elements/1.1/date> "2017-11-01"^^xsd:string .
+
+
+###  http://model.geneontology.org/59d1072300000074/59f8d86400000007
+<http://model.geneontology.org/59d1072300000074/59f8d86400000007> rdf:type owl:NamedIndividual ,
+                                                                           <http://purl.obolibrary.org/obo/ECO_0000314> ;
+                                                                  <http://purl.org/dc/elements/1.1/contributor> "GOC:kltm"^^xsd:string ;
+                                                                  <http://purl.org/dc/elements/1.1/date> "2017-11-01"^^xsd:string ;
+                                                                  <http://purl.org/dc/elements/1.1/source> "PMID:456"^^xsd:string .
+
+
+###  Generated by the OWL API (version 4.2.8) https://github.com/owlcs/owlapi


### PR DESCRIPTION
It is a bit overdue but this branch extends the codes that generate GPAD in Minerva to include negations in the qualifier field of GPAD (See also: [issue #149](https://github.com/geneontology/minerva/issues/149)). Unittest codes and sample ttle files are also added to check whether negations are properly produced and recorded in GPAD files.