### PR TITLE
Remove “MGI:” from MGI prefix expansion. 

### DIFF
--- a/minerva-core/src/main/resources/go_context.jsonld
+++ b/minerva-core/src/main/resources/go_context.jsonld
@@ -95,7 +95,7 @@
         "TGD_LOCUS": "http://db.ciliate.org/cgi-bin/locus.pl?locus=", 
         "MA": "http://purl.obolibrary.org/obo/MA_", 
         "UniProtKB": "http://identifiers.org/uniprot/", 
-        "MGI": "http://identifiers.org/mgi/MGI:", 
+        "MGI": "http://identifiers.org/mgi/",
         "GRINDesc": "https://npgsweb.ars-grin.gov/gringlobal/descriptordetail.aspx?id=", 
         "DDANAT": "http://purl.obolibrary.org/obo/DDANAT_", 
         "RAP-DB": "http://rapdb.dna.affrc.go.jp/tools/search/run?id=on&attr=desc&attr=cgs&attr=cgn&attr=cgss&attr=cgns&attr=rgss&attr=rgns&keyword=", 


### PR DESCRIPTION
Fixes #199. This was requested by MGI, although https://github.com/geneontology/go-site/issues/91 suggests that removing the `MGI`: doubling is desired eventually. I will open a separate PR to change https://github.com/prefixcommons/biocontext/blob/master/registry/go_context.jsonld.