### PR TITLE
Update version of owl-to-rules to avoid 'indirect rules' for reflexive subclasses.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -334,7 +334,7 @@
 			<dependency>
 				<groupId>org.geneontology</groupId>
 				<artifactId>owl-to-rules_2.12</artifactId>
-				<version>0.3.5</version>
+				<version>0.3.6</version>
 				<exclusions>
 					<exclusion>
 						<groupId>ch.qos.logback</groupId>


### PR DESCRIPTION
This should fix a problem in returning explanations for owl:Nothing inferences in Noctua. go-plus currently contains the axiom `owl:Nothing SubClassOf owl:Nothing`. That also needs to be figured out.