### PR TITLE
Shex validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ target/
 .classpath
 minerva-server/blazegraph.jnl
 /bin/
+*.icloud
+minerva-server/.DS_Store

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: java
 
 jdk:
-  - oraclejdk8
+  - openjdk8
 
 # run tests
 # Warning: travis fails, when log output >4M

--- a/minerva-core/src/main/java/org/geneontology/minerva/json/InferenceProvider.java
+++ b/minerva-core/src/main/java/org/geneontology/minerva/json/InferenceProvider.java
@@ -10,4 +10,8 @@ public interface InferenceProvider {
 	public boolean isConsistent();
 	
 	public Set<OWLClass> getTypes(OWLNamedIndividual i);
+	
+	public boolean isConformant();
+	
+	public Set<String> getNonconformant_uris();
 }

--- a/minerva-server/pom.xml
+++ b/minerva-server/pom.xml
@@ -54,6 +54,12 @@
 	</build>
 
 	<dependencies>
+	<!-- https://mvnrepository.com/artifact/org.apache.httpcomponents/httpclient -->
+<dependency>
+    <groupId>org.apache.httpcomponents</groupId>
+    <artifactId>httpclient</artifactId>
+    <version>4.5.9</version>
+</dependency>
 		<dependency>
 			<groupId>org.geneontology</groupId>
 			<artifactId>minerva-core</artifactId>
@@ -123,5 +129,17 @@
     		<artifactId>jersey-media-json-processing</artifactId>
     		<version>2.28</version>
 		</dependency>
+		<dependency>
+  			<groupId>fr.inria.lille.shexjava</groupId>
+  			<artifactId>shexjava-core</artifactId>
+  			<version>1.2.3c</version> 
+    <!-- 	avoiding an incompatibility with the shexjava jena version 3.0.0 and the arachne version 3.11.0    --> 
+  			<exclusions>
+        		<exclusion>  <!-- declare the exclusion here -->
+          			<groupId>org.apache.jena</groupId>
+          			<artifactId>*</artifactId>
+       			</exclusion>
+      		</exclusions> 
+ 		</dependency>
 	</dependencies>
 </project>

--- a/minerva-server/src/main/java/org/geneontology/minerva/server/StartUpTool.java
+++ b/minerva-server/src/main/java/org/geneontology/minerva/server/StartUpTool.java
@@ -37,6 +37,7 @@ import owltools.io.CatalogXmlIRIMapper;
 import owltools.io.ParserWrapper;
 
 import java.io.File;
+import java.net.URL;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
@@ -94,8 +95,8 @@ public class StartUpTool {
 
 		public int sparqlEndpointTimeout = 100;
 		
-		public String shexpath = "./target/classes/go-cam-shapes.shex";
-		public String goshapemappath = "./target/classes/go-cam-shapes.shapeMap";
+		public String shexFileUrl = "https://raw.githubusercontent.com/geneontology/go-shapes/master/shapes/go-cam-shapes.shex";
+		public String goshapemapFileUrl = "https://raw.githubusercontent.com/geneontology/go-shapes/master/shapes/go-cam-shapes.shapeMap";
 		public ShexController shex;
 	
 	}
@@ -104,7 +105,13 @@ public class StartUpTool {
 		Opts opts = new Opts(args);
 		MinervaStartUpConfig conf = new MinervaStartUpConfig();
 		//TODO maybe make these command line parameters
-		conf.shex = new ShexController(conf.shexpath, conf.goshapemappath);
+		URL shex_schema_url = new URL(conf.shexFileUrl);
+		File shex_schema_file = new File("./target/shex-schema.shex");
+		org.apache.commons.io.FileUtils.copyURLToFile(shex_schema_url, shex_schema_file);
+		URL shex_map_url = new URL(conf.goshapemapFileUrl);
+		File shex_map_file = new File("./target/go-cam-shapes.shapeMap");
+		org.apache.commons.io.FileUtils.copyURLToFile(shex_map_url, shex_map_file);
+		conf.shex = new ShexController(shex_schema_file, shex_map_file);
 		
 		while (opts.hasArgs()) {
 			if (opts.nextEq("-g|--graph")) {

--- a/minerva-server/src/main/java/org/geneontology/minerva/server/handler/M3BatchHandler.java
+++ b/minerva-server/src/main/java/org/geneontology/minerva/server/handler/M3BatchHandler.java
@@ -120,6 +120,12 @@ public interface M3BatchHandler {
 
 			@SerializedName("sparql-result")
 			public JsonObject sparqlResult;
+			
+			@SerializedName("uncomformant-p")
+			public Boolean unconformantFlag;
+
+			@SerializedName("noncomformant-uris")
+			public Set<String> nonconformant_uris;
 		}
 		
 		public static class MetaResponse {

--- a/minerva-server/src/main/java/org/geneontology/minerva/server/inferences/CachingInferenceProviderCreatorImpl.java
+++ b/minerva-server/src/main/java/org/geneontology/minerva/server/inferences/CachingInferenceProviderCreatorImpl.java
@@ -18,11 +18,11 @@ public class CachingInferenceProviderCreatorImpl extends InferenceProviderCreato
 	
 	private final Map<ModelContainer, InferenceProvider> inferenceCache = new ConcurrentHashMap<>();
 	
-	protected CachingInferenceProviderCreatorImpl(OWLReasonerFactory rf, int maxConcurrent, boolean useSLME, String name) {
-		super(rf, maxConcurrent, useSLME, name);
+	protected CachingInferenceProviderCreatorImpl(OWLReasonerFactory rf, int maxConcurrent, boolean useSLME, String name, ShexController shex) {
+		super(rf, maxConcurrent, useSLME, name, shex);	
 	}
 
-	public static InferenceProviderCreator createElk(boolean useSLME) {
+	public static InferenceProviderCreator createElk(boolean useSLME, ShexController shex) {
 		String name;
 		if (useSLME) {
 			name = "Caching ELK-SLME";
@@ -30,21 +30,21 @@ public class CachingInferenceProviderCreatorImpl extends InferenceProviderCreato
 		else {
 			name = "Caching ELK";
 		}
-		return new CachingInferenceProviderCreatorImpl(new ElkReasonerFactory(), 1, useSLME, name);
+		return new CachingInferenceProviderCreatorImpl(new ElkReasonerFactory(), 1, useSLME, name, shex);
 	}
 
-	public static InferenceProviderCreator createHermiT() {
+	public static InferenceProviderCreator createHermiT(ShexController shex) {
 		int maxConcurrent = Runtime.getRuntime().availableProcessors();
-		return createHermiT(maxConcurrent);
+		return createHermiT(maxConcurrent, shex);
 	}
 	
-	public static InferenceProviderCreator createHermiT(int maxConcurrent) {
+	public static InferenceProviderCreator createHermiT(int maxConcurrent, ShexController shex) {
 		return new CachingInferenceProviderCreatorImpl(new org.semanticweb.HermiT.ReasonerFactory(),
-				maxConcurrent, true, "Caching Hermit-SLME");
+				maxConcurrent, true, "Caching Hermit-SLME", shex);
 	}
 	
-	public static InferenceProviderCreator createArachne(RuleEngine arachne) {
-		return new CachingInferenceProviderCreatorImpl(new ArachneOWLReasonerFactory(arachne), 1, false, "Caching Arachne");
+	public static InferenceProviderCreator createArachne(RuleEngine arachne, ShexController shex) {
+		return new CachingInferenceProviderCreatorImpl(new ArachneOWLReasonerFactory(arachne), 1, false, "Caching Arachne", shex);
 	}
 
 	@Override

--- a/minerva-server/src/main/java/org/geneontology/minerva/server/inferences/InferenceProviderCreatorImpl.java
+++ b/minerva-server/src/main/java/org/geneontology/minerva/server/inferences/InferenceProviderCreatorImpl.java
@@ -27,16 +27,18 @@ public class InferenceProviderCreatorImpl implements InferenceProviderCreator {
 	private final Semaphore concurrentLock;
 	private final boolean useSLME;
 	private final String name;
+	private final ShexController shex;
 
-	InferenceProviderCreatorImpl(OWLReasonerFactory rf, int maxConcurrent, boolean useSLME, String name) {
+	InferenceProviderCreatorImpl(OWLReasonerFactory rf, int maxConcurrent, boolean useSLME, String name, ShexController shex) {
 		super();
 		this.rf = rf;
 		this.useSLME = useSLME;
 		this.name = name;
 		this.concurrentLock = new Semaphore(maxConcurrent);
+		this.shex = shex;
 	}
 
-	public static InferenceProviderCreator createElk(boolean useSLME) {
+	public static InferenceProviderCreator createElk(boolean useSLME, ShexController shex) {
 		String name;
 		if (useSLME) {
 			name = "ELK-SLME";
@@ -44,16 +46,16 @@ public class InferenceProviderCreatorImpl implements InferenceProviderCreator {
 		else {
 			name = "ELK";
 		}
-		return new InferenceProviderCreatorImpl(new ElkReasonerFactory(), 1, useSLME, name);
+		return new InferenceProviderCreatorImpl(new ElkReasonerFactory(), 1, useSLME, name, shex);
 	}
 	
-	public static InferenceProviderCreator createHermiT() {
+	public static InferenceProviderCreator createHermiT(ShexController shex) {
 		int maxConcurrent = Runtime.getRuntime().availableProcessors();
-		return createHermiT(maxConcurrent);
+		return createHermiT(maxConcurrent, shex);
 	}
 	
-	public static InferenceProviderCreator createHermiT(int maxConcurrent) {
-		return new InferenceProviderCreatorImpl(new org.semanticweb.HermiT.ReasonerFactory(), maxConcurrent, true, "Hermit-SLME");
+	public static InferenceProviderCreator createHermiT(int maxConcurrent, ShexController shex) {
+		return new InferenceProviderCreatorImpl(new org.semanticweb.HermiT.ReasonerFactory(), maxConcurrent, true, "Hermit-SLME", shex);
 	}
 
 	@Override
@@ -76,7 +78,7 @@ public class InferenceProviderCreatorImpl implements InferenceProviderCreator {
 						LOG.info("Done creating module: "+model.getModelId());
 					}
 					reasoner = rf.createReasoner(ont);
-					provider = MapInferenceProvider.create(reasoner, ont);
+					provider = MapInferenceProvider.create(reasoner, ont, shex);
 				}
 				finally {
 					concurrentLock.release();

--- a/minerva-server/src/main/java/org/geneontology/minerva/server/inferences/MapInferenceProvider.java
+++ b/minerva-server/src/main/java/org/geneontology/minerva/server/inferences/MapInferenceProvider.java
@@ -1,22 +1,62 @@
 package org.geneontology.minerva.server.inferences;
 
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.PipedInputStream;
+import java.io.PipedOutputStream;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.rdf.simple.SimpleRDF;
+import org.apache.jena.query.Query;
+import org.apache.jena.query.QueryExecution;
+import org.apache.jena.query.QueryExecutionFactory;
+import org.apache.jena.query.QueryFactory;
+import org.apache.jena.query.QueryParseException;
+import org.apache.jena.query.QuerySolution;
+import org.apache.jena.query.ResultSet;
+import org.apache.jena.rdf.model.Literal;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.rdf.model.Resource;
 import org.geneontology.minerva.json.InferenceProvider;
+import org.semanticweb.owlapi.formats.TurtleDocumentFormat;
 import org.semanticweb.owlapi.model.OWLClass;
 import org.semanticweb.owlapi.model.OWLNamedIndividual;
 import org.semanticweb.owlapi.model.OWLOntology;
+import org.semanticweb.owlapi.model.OWLOntologyStorageException;
 import org.semanticweb.owlapi.reasoner.OWLReasoner;
+
+import fr.inria.lille.shexjava.schema.Label;
+import fr.inria.lille.shexjava.schema.ShexSchema;
+import fr.inria.lille.shexjava.schema.parsing.GenParser;
+import fr.inria.lille.shexjava.util.Pair;
+import fr.inria.lille.shexjava.validation.RecursiveValidation;
+import fr.inria.lille.shexjava.validation.Status;
+import fr.inria.lille.shexjava.validation.Typing;
+import org.apache.commons.rdf.api.RDF;
+import org.apache.commons.rdf.api.RDFTerm;
+import org.apache.commons.rdf.jena.JenaGraph;
+import org.apache.commons.rdf.jena.JenaRDF;
 
 public class MapInferenceProvider implements InferenceProvider {
 
 	private final boolean isConsistent;
 	private final Map<OWLNamedIndividual, Set<OWLClass>> inferredTypes;
-
+	//for shex-based validation
+	private final boolean isConformant;
+	private Set<String> nonconformant_uris; 
+	public static final String endpoint = "http://rdf.geneontology.org/blazegraph/sparql";
+	
 	public static InferenceProvider create(OWLReasoner r, OWLOntology ont) {
 		Map<OWLNamedIndividual, Set<OWLClass>> inferredTypes = new HashMap<>();
 		boolean isConsistent = r.isConsistent();
@@ -33,12 +73,266 @@ public class MapInferenceProvider implements InferenceProvider {
 				inferredTypes.put(individual, inferred);
 			}
 		}
-		return new MapInferenceProvider(isConsistent, inferredTypes);
+		//shex
+		boolean isConformant = true;
+		Set<String> nonconformant_uris = new HashSet<String>();
+		//generate an RDF model
+		Model model = getModel(ont);
+		//add superclasses to types used in model
+		//TODO examine how to get this done with reasoner here, avoiding external call 
+		model = enrichSuperClasses(model);
+		
+		//TODO get this from a cache
+		//refactor all these methods into new class
+		//store on startup and re-use
+		String shexpath = "./target/classes/go-cam-shapes.shex";
+		String goshapemappath = "./target/classes/go-cam-shapes.shapeMap";
+		
+		ShexSchema schema;
+		try {
+			schema = GenParser.parseSchema(new File(shexpath).toPath());
+			Map<String, String> GoQueryMap = makeGoQueryMap(goshapemappath);
+			ModelValidationResult result = runShapeMapValidation(schema, model, true, GoQueryMap);
+			isConformant = result.model_is_valid;
+			for(String bad_node : result.node_is_valid.keySet()) {
+				if(!(result.node_is_valid.get(bad_node))) {
+					nonconformant_uris.add(bad_node);
+				}
+			}
+		} catch (Exception e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		}
+
+		return new MapInferenceProvider(isConsistent, inferredTypes, isConformant, nonconformant_uris);
 	}
 
-	MapInferenceProvider(boolean isConsistent, Map<OWLNamedIndividual, Set<OWLClass>> inferredTypes) {
+	public static Model enrichSuperClasses(Model model) {
+		String getOntTerms = 
+				"PREFIX owl: <http://www.w3.org/2002/07/owl#> "
+						+ "SELECT DISTINCT ?term " + 
+						"        WHERE { " + 
+						"        ?ind a owl:NamedIndividual . " + 
+						"        ?ind a ?term . " + 
+						"        FILTER(?term != owl:NamedIndividual)" + 
+						"        FILTER(isIRI(?term)) ." + 
+						"        }";
+		String terms = "";
+		try{
+			QueryExecution qe = QueryExecutionFactory.create(getOntTerms, model);
+			ResultSet results = qe.execSelect();
+
+			while (results.hasNext()) {
+				QuerySolution qs = results.next();
+				Resource term = qs.getResource("term");
+				terms+=("<"+term.getURI()+"> ");
+			}
+			qe.close();
+		} catch(QueryParseException e){
+			e.printStackTrace();
+		}
+		String superQuery = ""
+				+ "PREFIX owl: <http://www.w3.org/2002/07/owl#> "
+				+ "PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#> "
+				+ "CONSTRUCT { " + 
+				"        ?term rdfs:subClassOf ?superclass ." + 
+				"        ?term a owl:Class ." + 
+				"        }" + 
+				"        WHERE {" + 
+				"        VALUES ?term { "+terms+" } " + 
+				"        ?term rdfs:subClassOf* ?superclass ." + 
+				"        FILTER(isIRI(?superclass)) ." + 
+				"        }";
+
+		Query query = QueryFactory.create(superQuery); 
+		try ( 
+				QueryExecution qexec = QueryExecutionFactory.sparqlService(endpoint, query) ) {
+			qexec.execConstruct(model);
+			qexec.close();
+		} catch(QueryParseException e){
+			e.printStackTrace();
+		}
+		return model;
+	}
+	
+	public static Map<String, String> makeGoQueryMap(String shapemap_file) throws IOException{ //"../shapes/go-cam-shapes.shapeMap
+		Map<String, String> shapelabel_sparql = new HashMap<String, String>();
+		BufferedReader reader = new BufferedReader(new FileReader(shapemap_file));
+		String line = reader.readLine();
+		String all = line;
+		while(line!=null) {
+			all+=line;
+			line = reader.readLine();			
+		}
+		reader.close();
+		String[] maps = all.split(",");
+		for(String map : maps) {
+			String sparql = StringUtils.substringBetween(map, "'", "'");
+			sparql = sparql.replace("a/", "<http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?c . ?c ");
+			String[] shapemaprow = map.split("@");
+			String shapelabel = shapemaprow[1];
+			shapelabel = shapelabel.replace(">", "");
+			shapelabel = shapelabel.replace("<", "");
+			shapelabel = shapelabel.trim();
+			shapelabel_sparql.put(shapelabel, sparql);
+		}
+		return shapelabel_sparql;
+	}
+
+	public static class ModelValidationResult {
+		boolean model_is_valid; 
+		boolean model_is_consistent;
+		Map<String, Set<String>> node_shapes;
+		Map<String, Set<String>> node_types;
+		Map<String, String> node_report;
+		Map<String, Boolean> node_is_valid = new HashMap<String, Boolean>();
+		Map<String, Boolean> node_is_consistent;
+		String model_report;
+		String model_id;
+		String model_title;
+		/**
+		 * 
+		 */
+		public ModelValidationResult(Model model) {
+			String q = "select ?cam ?title where {"
+					+ "?cam <http://purl.org/dc/elements/1.1/title> ?title }";
+			//	+ "?cam <"+DC.description.getURI()+"> ?title }";
+			QueryExecution qe = QueryExecutionFactory.create(q, model);
+			ResultSet results = qe.execSelect();
+			if (results.hasNext()) {
+				QuerySolution qs = results.next();
+				Resource id = qs.getResource("cam");
+				Literal title = qs.getLiteral("title");
+				model_id = id.getURI();
+				model_title = title.getString();
+			}
+			qe.close();
+			model_report = "shape id\tnode uri\tvalidation status\n";
+		}
+
+	}
+
+	public static ModelValidationResult runShapeMapValidation(ShexSchema schema, Model test_model, boolean stream_output, Map<String, String> GoQueryMap) throws Exception {
+		Map<String, Typing> shape_node_typing = validateGoShapeMap(schema, test_model, GoQueryMap);
+		ModelValidationResult r = new ModelValidationResult(test_model);
+		RDF rdfFactory = new SimpleRDF();
+		for(String shape_node : shape_node_typing.keySet()) {
+			Typing typing = shape_node_typing.get(shape_node);
+			String shape_id = shape_node.split(",")[0];
+			String focus_node_iri = shape_node.split(",")[1];
+			String result = getValidationReport(typing, rdfFactory, focus_node_iri, shape_id, true);
+			//TODO refactor
+			Label shape_label = new Label(rdfFactory.createIRI(shape_id));
+			RDFTerm focus_node = rdfFactory.createIRI(focus_node_iri);
+			Pair<RDFTerm, Label> p = new Pair<RDFTerm, Label>(focus_node, shape_label);
+			Status node_r = typing.getStatusMap().get(p);
+			if(node_r.equals(Status.NONCONFORMANT)) {
+				r.node_is_valid.put(focus_node_iri, false);
+			}else {
+				r.node_is_valid.put(focus_node_iri, true);
+			}
+			r.model_report+=result;
+		}
+		if(r.model_report.contains("NONCONFORMANT")) {
+			r.model_is_valid=false;
+			if(stream_output) {
+				System.out.println("Invalid model: GO shape map report for model:"+r.model_title+"\n"+r.model_report);
+			}
+		}else {
+			r.model_is_valid=true;
+			if(stream_output) {
+				System.out.println("Valid model:"+r.model_title);
+			}
+		}
+		return r;
+	}
+
+	public static String getValidationReport(Typing typing_result, RDF rdfFactory, String focus_node_iri, String shape_id, boolean only_negative) throws Exception {
+		Label shape_label = new Label(rdfFactory.createIRI(shape_id));
+		RDFTerm focus_node = rdfFactory.createIRI(focus_node_iri);
+		Pair<RDFTerm, Label> p = new Pair<RDFTerm, Label>(focus_node, shape_label);
+		Status r = typing_result.getStatusMap().get(p);
+		String s = "";
+		if(r!=null) {
+			if(only_negative) {
+				if(r.equals(Status.NONCONFORMANT)) {
+					s+=p.two+"\t"+p.one+"\t"+r.toString()+"\n";
+				}
+			}else { //report all
+				s+=p.two+"\t"+p.one+"\t"+r.toString()+"\n";
+			}
+		}
+		return s;
+	}
+	
+	public static Map<String, Typing> validateGoShapeMap(ShexSchema schema, Model jena_model, Map<String, String> GoQueryMap) throws Exception {
+		Map<String, Typing> shape_node_typing = new HashMap<String, Typing>();
+		Typing result = null;
+		RDF rdfFactory = new SimpleRDF();
+		JenaRDF jr = new JenaRDF();
+		//this shex implementation likes to use the commons JenaRDF interface, nothing exciting here
+		JenaGraph shexy_graph = jr.asGraph(jena_model);
+		//recursive only checks the focus node against the chosen shape.  
+		RecursiveValidation shex_recursive_validator = new RecursiveValidation(schema, shexy_graph);
+		for(String shapelabel : GoQueryMap.keySet()) {
+			Label shape_label = new Label(rdfFactory.createIRI(shapelabel));
+			Set<String> focus_nodes = getFocusNodesBySparql(jena_model, GoQueryMap.get(shapelabel));
+			for(String focus_node_iri : focus_nodes) {
+				RDFTerm focus_node = rdfFactory.createIRI(focus_node_iri);
+				shex_recursive_validator.validate(focus_node, shape_label);
+				result = shex_recursive_validator.getTyping();
+				shape_node_typing.put(shapelabel+","+focus_node_iri, result);
+			}
+		}
+		return shape_node_typing;
+	}
+
+	public static Set<String> getFocusNodesBySparql(Model model, String sparql){
+		Set<String> nodes = new HashSet<String>();
+		QueryExecution qe = QueryExecutionFactory.create(sparql, model);
+		ResultSet results = qe.execSelect();
+		while (results.hasNext()) {
+			QuerySolution qs = results.next();
+			Resource node = qs.getResource("x");
+			nodes.add(node.getURI());
+		}
+		qe.close();
+		return nodes;
+	}
+	
+	/**
+	 * From https://stackoverflow.com/questions/46866783/conversion-from-owlontology-to-jena-model-in-java
+	 * Converts an OWL API ontology into a JENA API model.
+	 * @param ontology the OWL API ontology
+	 * @return the JENA API model
+	 */
+	public static Model getModel(final OWLOntology ontology) {
+		Model model = ModelFactory.createDefaultModel();
+
+		try (PipedInputStream is = new PipedInputStream(); PipedOutputStream os = new PipedOutputStream(is)) {
+			new Thread(new Runnable() {
+				@Override
+				public void run() {
+					try {
+						ontology.getOWLOntologyManager().saveOntology(ontology, new TurtleDocumentFormat(), os);
+						os.close();
+					} catch (OWLOntologyStorageException | IOException e) {
+						e.printStackTrace();
+					}
+				}
+			}).start();
+			model.read(is, null, "TURTLE");
+			return model;
+		} catch (Exception e) {
+			throw new RuntimeException("Could not convert OWL API ontology to JENA API model.", e);
+		}
+	}
+
+	MapInferenceProvider(boolean isConsistent, Map<OWLNamedIndividual, Set<OWLClass>> inferredTypes, boolean isConformant, Set<String> nonconformant_uris) {
 		this.isConsistent = isConsistent;
 		this.inferredTypes = inferredTypes;
+		this.isConformant = isConformant;
+		this.nonconformant_uris = nonconformant_uris;
 	}
 
 	@Override
@@ -56,5 +350,15 @@ public class MapInferenceProvider implements InferenceProvider {
 			}
 		}
 		return result;
+	}
+
+	@Override
+	public boolean isConformant() {
+		return isConformant;
+	}
+
+	@Override
+	public Set<String> getNonconformant_uris() {
+		return nonconformant_uris;
 	}
 }

--- a/minerva-server/src/main/java/org/geneontology/minerva/server/inferences/ShexController.java
+++ b/minerva-server/src/main/java/org/geneontology/minerva/server/inferences/ShexController.java
@@ -50,6 +50,11 @@ public class ShexController {
 		GoQueryMap = makeGoQueryMap(goshapemappath);
 	}
 
+	public ShexController(File shex_schema_file, File shex_map_file) throws Exception {
+		schema = GenParser.parseSchema(shex_schema_file.toPath());
+		GoQueryMap = makeGoQueryMap(shex_map_file.getAbsolutePath());
+	}
+
 	public static Map<String, String> makeGoQueryMap(String shapemap_file) throws IOException{ 
 		Map<String, String> shapelabel_sparql = new HashMap<String, String>();
 		BufferedReader reader = new BufferedReader(new FileReader(shapemap_file));

--- a/minerva-server/src/main/java/org/geneontology/minerva/server/inferences/ShexController.java
+++ b/minerva-server/src/main/java/org/geneontology/minerva/server/inferences/ShexController.java
@@ -1,0 +1,164 @@
+/**
+ * 
+ */
+package org.geneontology.minerva.server.inferences;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.rdf.api.RDF;
+import org.apache.commons.rdf.api.RDFTerm;
+import org.apache.commons.rdf.jena.JenaGraph;
+import org.apache.commons.rdf.jena.JenaRDF;
+import org.apache.commons.rdf.simple.SimpleRDF;
+import org.apache.jena.query.QueryExecution;
+import org.apache.jena.query.QueryExecutionFactory;
+import org.apache.jena.query.QuerySolution;
+import org.apache.jena.query.ResultSet;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.Resource;
+import org.geneontology.minerva.server.inferences.MapInferenceProvider.ModelValidationResult;
+
+import fr.inria.lille.shexjava.schema.Label;
+import fr.inria.lille.shexjava.schema.ShexSchema;
+import fr.inria.lille.shexjava.schema.parsing.GenParser;
+import fr.inria.lille.shexjava.util.Pair;
+import fr.inria.lille.shexjava.validation.RecursiveValidation;
+import fr.inria.lille.shexjava.validation.Status;
+import fr.inria.lille.shexjava.validation.Typing;
+
+/**
+ * @author bgood
+ *
+ */
+public class ShexController {
+	public ShexSchema schema;
+	public Map<String, String> GoQueryMap;
+	/**
+	 * @throws Exception 
+	 * 
+	 */
+	public ShexController(String shexpath, String goshapemappath) throws Exception {
+		schema = GenParser.parseSchema(new File(shexpath).toPath());
+		GoQueryMap = makeGoQueryMap(goshapemappath);
+	}
+
+	public static Map<String, String> makeGoQueryMap(String shapemap_file) throws IOException{ 
+		Map<String, String> shapelabel_sparql = new HashMap<String, String>();
+		BufferedReader reader = new BufferedReader(new FileReader(shapemap_file));
+		String line = reader.readLine();
+		String all = line;
+		while(line!=null) {
+			all+=line;
+			line = reader.readLine();			
+		}
+		reader.close();
+		String[] maps = all.split(",");
+		for(String map : maps) {
+			String sparql = StringUtils.substringBetween(map, "'", "'");
+			sparql = sparql.replace("a/", "<http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?c . ?c ");
+			String[] shapemaprow = map.split("@");
+			String shapelabel = shapemaprow[1];
+			shapelabel = shapelabel.replace(">", "");
+			shapelabel = shapelabel.replace("<", "");
+			shapelabel = shapelabel.trim();
+			shapelabel_sparql.put(shapelabel, sparql);
+		}
+		return shapelabel_sparql;
+	}
+	
+	public ModelValidationResult runShapeMapValidation(Model test_model, boolean stream_output) throws Exception {
+		Map<String, Typing> shape_node_typing = validateGoShapeMap(schema, test_model, GoQueryMap);
+		ModelValidationResult r = new ModelValidationResult(test_model);
+		RDF rdfFactory = new SimpleRDF();
+		for(String shape_node : shape_node_typing.keySet()) {
+			Typing typing = shape_node_typing.get(shape_node);
+			String shape_id = shape_node.split(",")[0];
+			String focus_node_iri = shape_node.split(",")[1];
+			String result = getValidationReport(typing, rdfFactory, focus_node_iri, shape_id, true);
+			//TODO refactor
+			Label shape_label = new Label(rdfFactory.createIRI(shape_id));
+			RDFTerm focus_node = rdfFactory.createIRI(focus_node_iri);
+			Pair<RDFTerm, Label> p = new Pair<RDFTerm, Label>(focus_node, shape_label);
+			Status node_r = typing.getStatusMap().get(p);
+			if(node_r.equals(Status.NONCONFORMANT)) {
+				r.node_is_valid.put(focus_node_iri, false);
+			}else {
+				r.node_is_valid.put(focus_node_iri, true);
+			}
+			r.model_report+=result;
+		}
+		if(r.model_report.contains("NONCONFORMANT")) {
+			r.model_is_valid=false;
+			if(stream_output) {
+				System.out.println("Invalid model: GO shape map report for model:"+r.model_title+"\n"+r.model_report);
+			}
+		}else {
+			r.model_is_valid=true;
+			if(stream_output) {
+				System.out.println("Valid model:"+r.model_title);
+			}
+		}
+		return r;
+	}
+
+	public static String getValidationReport(Typing typing_result, RDF rdfFactory, String focus_node_iri, String shape_id, boolean only_negative) throws Exception {
+		Label shape_label = new Label(rdfFactory.createIRI(shape_id));
+		RDFTerm focus_node = rdfFactory.createIRI(focus_node_iri);
+		Pair<RDFTerm, Label> p = new Pair<RDFTerm, Label>(focus_node, shape_label);
+		Status r = typing_result.getStatusMap().get(p);
+		String s = "";
+		if(r!=null) {
+			if(only_negative) {
+				if(r.equals(Status.NONCONFORMANT)) {
+					s+=p.two+"\t"+p.one+"\t"+r.toString()+"\n";
+				}
+			}else { //report all
+				s+=p.two+"\t"+p.one+"\t"+r.toString()+"\n";
+			}
+		}
+		return s;
+	}
+	
+	public static Map<String, Typing> validateGoShapeMap(ShexSchema schema, Model jena_model, Map<String, String> GoQueryMap) throws Exception {
+		Map<String, Typing> shape_node_typing = new HashMap<String, Typing>();
+		Typing result = null;
+		RDF rdfFactory = new SimpleRDF();
+		JenaRDF jr = new JenaRDF();
+		//this shex implementation likes to use the commons JenaRDF interface, nothing exciting here
+		JenaGraph shexy_graph = jr.asGraph(jena_model);
+		//recursive only checks the focus node against the chosen shape.  
+		RecursiveValidation shex_recursive_validator = new RecursiveValidation(schema, shexy_graph);
+		for(String shapelabel : GoQueryMap.keySet()) {
+			Label shape_label = new Label(rdfFactory.createIRI(shapelabel));
+			Set<String> focus_nodes = getFocusNodesBySparql(jena_model, GoQueryMap.get(shapelabel));
+			for(String focus_node_iri : focus_nodes) {
+				RDFTerm focus_node = rdfFactory.createIRI(focus_node_iri);
+				shex_recursive_validator.validate(focus_node, shape_label);
+				result = shex_recursive_validator.getTyping();
+				shape_node_typing.put(shapelabel+","+focus_node_iri, result);
+			}
+		}
+		return shape_node_typing;
+	}
+
+	public static Set<String> getFocusNodesBySparql(Model model, String sparql){
+		Set<String> nodes = new HashSet<String>();
+		QueryExecution qe = QueryExecutionFactory.create(sparql, model);
+		ResultSet results = qe.execSelect();
+		while (results.hasNext()) {
+			QuerySolution qs = results.next();
+			Resource node = qs.getResource("x");
+			nodes.add(node.getURI());
+		}
+		qe.close();
+		return nodes;
+	}
+}

--- a/minerva-server/src/main/resources/go-cam-shapes.shapeMap
+++ b/minerva-server/src/main/resources/go-cam-shapes.shapeMap
@@ -1,0 +1,5 @@
+SPARQL 'SELECT ?x WHERE { ?x a/<http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://purl.obolibrary.org/obo/GO_0003674> }' @ <http://purl.obolibrary.org/obo/go/shapes/MolecularFunction>,
+SPARQL 'SELECT ?x WHERE { ?x a/<http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://purl.obolibrary.org/obo/GO_0008150> }' @ <http://purl.obolibrary.org/obo/go/shapes/BiologicalProcess>,
+SPARQL 'SELECT ?x WHERE { ?x a/<http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://purl.obolibrary.org/obo/GO_0005575> }' @ <http://purl.obolibrary.org/obo/go/shapes/CellularComponent>,
+SPARQL 'SELECT ?x WHERE { ?x a/<http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://purl.obolibrary.org/obo/CHEBI_36080> }' @ <http://purl.obolibrary.org/obo/go/shapes/Protein>,
+SPARQL 'SELECT ?x WHERE { ?x a/<http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://purl.obolibrary.org/obo/ECO_0000000> }' @ <http://purl.obolibrary.org/obo/go/shapes/Evidence>

--- a/minerva-server/src/main/resources/go-cam-shapes.shex
+++ b/minerva-server/src/main/resources/go-cam-shapes.shex
@@ -1,0 +1,232 @@
+BASE   <http://purl.obolibrary.org/obo/go/shapes/>
+PREFIX obo: <http://purl.obolibrary.org/obo/>
+PREFIX rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+#metadata
+PREFIX bl: <https://w3id.org/biolink/vocab/>
+PREFIX contributor: <http://purl.org/dc/elements/1.1/contributor>
+PREFIX provided_by: <http://purl.org/pav/providedBy>
+PREFIX date: <http://purl.org/dc/elements/1.1/date>
+PREFIX xref: <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
+PREFIX exact_match: <http://www.w3.org/2004/02/skos/core#exactMatch>
+PREFIX source: <http://purl.org/dc/elements/1.1/source>
+PREFIX evidence: <http://geneontology.org/lego/evidence>
+PREFIX with: <http://geneontology.org/lego/evidence-with>
+#semantic: classes
+PREFIX GoInformationBiomacromolecule: <http://purl.obolibrary.org/obo/CHEBI_33695>
+PREFIX GoProtein: <http://purl.obolibrary.org/obo/CHEBI_36080>
+PREFIX GoProteinContainingComplex: <http://purl.obolibrary.org/obo/GO_0032991>
+PREFIX GoCellularComponent: <http://purl.obolibrary.org/obo/GO_0005575>
+PREFIX GoBiologicalProcess: <http://purl.obolibrary.org/obo/GO_0008150>
+PREFIX GoMolecularFunction: <http://purl.obolibrary.org/obo/GO_0003674>
+PREFIX GoMolecularEntity: <http://purl.obolibrary.org/obo/CHEBI_23367>
+PREFIX GoChemicalEntity: <http://purl.obolibrary.org/obo/CHEBI_24431>
+PREFIX GoEvidence: <http://purl.obolibrary.org/obo/ECO_0000000>
+PREFIX GoAnatomicalEntity: <http://purl.obolibrary.org/obo/CARO_0000000>
+PREFIX GoOrganism: <http://purl.obolibrary.org/obo/NCBITaxon_1>
+PREFIX GoBiologicalPhase: <http://purl.obolibrary.org/obo/GO_0044848>
+#semantic: relations
+PREFIX part_of: <http://purl.obolibrary.org/obo/BFO_0000050>
+PREFIX occurs_in: <http://purl.obolibrary.org/obo/BFO_0000066>
+PREFIX enabled_by: <http://purl.obolibrary.org/obo/RO_0002333>
+PREFIX has_input: <http://purl.obolibrary.org/obo/RO_0002233>
+PREFIX has_output: <http://purl.obolibrary.org/obo/RO_0002234>
+PREFIX directly_provides_input_for: <http://purl.obolibrary.org/obo/RO_0002413>
+PREFIX directly_positively_regulates: <http://purl.obolibrary.org/obo/RO_0002629>
+PREFIX located_in: <http://purl.obolibrary.org/obo/RO_0001025>
+PREFIX happens_during: <http://purl.obolibrary.org/obo/RO_0002092>
+PREFIX regulates: <http://purl.obolibrary.org/obo/RO_0002211>
+PREFIX negatively_regulates: <http://purl.obolibrary.org/obo/RO_0002212>
+PREFIX positively_regulates: <http://purl.obolibrary.org/obo/RO_0002213>
+PREFIX directly_regulates: <http://purl.obolibrary.org/obo/RO_0002578>
+PREFIX directly_negatively_regulates: <http://purl.obolibrary.org/obo/RO_0002630>
+PREFIX directly_positively_regulates: <http://purl.obolibrary.org/obo/RO_0002406>
+PREFIX causally_upstream_of_or_within: <http://purl.obolibrary.org/obo/RO_0002418>
+PREFIX causally_upstream_of_or_within_negative_effect: <http://purl.obolibrary.org/obo/RO_0004046>
+PREFIX causally_upstream_of_or_within_positive_effect: <http://purl.obolibrary.org/obo/RO_0004047>
+PREFIX causally_upstream_of: <http://purl.obolibrary.org/obo/RO_0002411>
+PREFIX causally_upstream_of_negative_effect: <http://purl.obolibrary.org/obo/RO_0002305>
+PREFIX causally_upstream_of_positive_effect: <http://purl.obolibrary.org/obo/RO_0002304>
+
+<ProvenanceAnnotated> {
+  contributor: xsd:string *; #TODO would be better as an IRI
+  date: xsd:string *; #TODO can we make this an xsd:date?
+  provided_by: xsd:string *; #TODO would be better as an IRI
+  rdfs:comment xsd:string *
+}
+
+<GoCamEntity> IRI @<ProvenanceAnnotated> AND EXTRA a {
+  a [owl:NamedIndividual] * // rdfs:comment  "Every entity we care about is a named individual";
+  xref: . *;
+  rdfs:label . {0,1};
+  exact_match: . *;
+} // rdfs:comment  "Default allowable metadata for GO-CAM entities"
+
+<OwlClass> {
+  rdf:type [ owl:Class ] {1};
+}
+
+<BiologicalProcessClass> IRI @<OwlClass> AND EXTRA rdfs:subClassOf {
+  rdfs:subClassOf [ GoBiologicalProcess: ] ;
+}
+
+<NegatedBiologicalProcessClass> BNode @<OwlClass> AND {
+  owl:complementOf @<BiologicalProcessClass>
+}
+
+##something wrong with this one
+# note it effects other shapes that use it
+<BiologicalProcess> @<GoCamEntity> AND EXTRA a {
+  a ( @<BiologicalProcessClass> OR @<NegatedBiologicalProcessClass> ) {1};
+  part_of: @<BiologicalProcess> {0,1};
+  has_input: ( @<MolecularEntity> OR @<AnatomicalEntity> ) *;
+  has_output: ( @<MolecularEntity> OR @<AnatomicalEntity> ) *;
+} // rdfs:comment  "A biological process"
+
+
+<MolecularFunctionClass> IRI @<OwlClass> AND EXTRA rdfs:subClassOf {
+  rdfs:subClassOf [ GoMolecularFunction: ] ;
+}
+
+<NegatedMolecularFunctionClass> BNode @<OwlClass> AND {
+  owl:complementOf @<MolecularFunctionClass>
+}
+
+<MolecularFunction> @<GoCamEntity> AND EXTRA a {
+  a ( @<MolecularFunctionClass> OR @<NegatedMolecularFunctionClass> ) {1};
+  enabled_by:  ( @<Protein> OR @<Complex> OR @<InformationBiomacromolecule> ) {0,1}; # get rid of protein
+  part_of: @<BiologicalProcess> {0,1};
+  occurs_in: (@<CellularComponent> OR @<AnatomicalEntity>) {0,1};
+  has_output: @<MolecularEntity> *;
+  has_input: @<MolecularEntity> *;
+  directly_provides_input_for: @<MolecularFunction> *;
+  regulates: @<MolecularFunction> *;
+  negatively_regulates: @<MolecularFunction> *;
+  positively_regulates: @<MolecularFunction> *;
+  directly_regulates: @<MolecularFunction> *;
+  directly_negatively_regulates: @<MolecularFunction> *;
+  directly_positively_regulates: @<MolecularFunction> *;
+  causally_upstream_of_or_within: ( @<BiologicalProcess> OR @<MolecularFunction> ) *;
+  causally_upstream_of_or_within_negative_effect: @<BiologicalProcess> *;
+  causally_upstream_of_or_within_positive_effect: @<BiologicalProcess> *;
+  causally_upstream_of: @<BiologicalProcess> *;
+  causally_upstream_of_negative_effect: @<BiologicalProcess> *;
+  causally_upstream_of_positive_effect: @<BiologicalProcess> *;
+  happens_during: @<BiologicalPhase> *;
+} // rdfs:comment  "A molecular function"
+
+<BiologicalPhase> @<GoCamEntity> AND {
+  bl:category [GoBiologicalPhase:];
+}// rdfs:comment  "an biological phase"
+
+<AnatomicalEntityClass> IRI @<OwlClass> AND EXTRA rdfs:subClassOf {
+  rdfs:subClassOf [ GoAnatomicalEntity: ];
+}
+
+<AnatomicalEntity> @<GoCamEntity> AND EXTRA a {
+  a @<AnatomicalEntityClass>;
+}// rdfs:comment  "an anatomical entity"
+
+<CellularComponentClass> IRI @<OwlClass> AND EXTRA rdfs:subClassOf {
+  rdfs:subClassOf [ GoCellularComponent: ];
+}
+
+<NegatedCellularComponentClass> BNode @<OwlClass> AND {
+  owl:complementOf @<CellularComponentClass>
+}
+
+#<CellularComponent> @<AnatomicalEntity> AND EXTRA a { # If we want to intersect with anatomical entity, then GO cellular_component needs to subclass anatomical entity in go-lego
+<CellularComponent> @<GoCamEntity> AND EXTRA a {
+  a ( @<CellularComponentClass> OR @<NegatedCellularComponentClass> ) {1};
+  part_of: @<CellularComponent> {0,1};
+  part_of: @<Cell> {0,1};
+# allow direct pass-through for single-cell organisms"
+  part_of: @<Organism> {0,1};
+} // rdfs:comment  "a cellular component"
+
+<Cell> @<AnatomicalEntity> AND {
+  part_of: @<GrossAnatomicalEntity> {0,1};
+} // rdfs:comment  "a cell type"
+
+<GrossAnatomicalEntity>  @<AnatomicalEntity> AND {
+  part_of: @<Organism> {0,1};
+} // rdfs:comment  "an anatomical entity"
+
+<Organism> {
+} // rdfs:comment  "an organism"
+
+#<Complex> @<MolecularEntity> AND EXTRA a {
+<Complex> EXTRA a {
+  a @<ProteinContainingComplexClass>;
+  located_in: @<CellularComponent> {0,1};
+}// rdfs:comment  "a protein complex"
+
+<ProteinContainingComplexClass> IRI @<OwlClass> AND EXTRA rdfs:subClassOf {
+  rdfs:subClassOf [ GoProteinContainingComplex: ];
+}
+
+<MolecularEntity> @<GoCamEntity> AND EXTRA a {
+  a @<MolecularEntityClass>;
+}// rdfs:comment  "a molecular entity (a gene product, chemical, or complex typically)"
+
+<MolecularEntityClass> IRI @<OwlClass> AND EXTRA rdfs:subClassOf  {
+  #rdfs:subClassOf [ GoMolecularEntity: ];
+  rdfs:subClassOf [ GoChemicalEntity: ]; # Weakened this from molecular entity to chemical entity until we clarify the requirements. A test model used 'methylated polymer', which is not under molecular entity.
+}
+
+<Gene> @<MolecularEntity> AND {
+  located_in: @<CellularComponent> {0,1};
+}// rdfs:comment  "a gene (a piece of DNA with a purpose)"
+
+<ProteinClass> IRI @<OwlClass> AND EXTRA rdfs:subClassOf {
+  rdfs:subClassOf [ GoProtein: ];
+}
+<Protein> @<MolecularEntity> AND EXTRA a {
+  a @<ProteinClass> ;
+  located_in: @<CellularComponent> {0,1};
+}// rdfs:comment  "a protein"
+
+
+<InformationBiomacromoleculeClass> IRI @<OwlClass> AND EXTRA rdfs:subClassOf {
+  rdfs:subClassOf [ GoInformationBiomacromolecule: ];
+}
+<InformationBiomacromolecule> @<MolecularEntity> AND EXTRA a {
+   a @<InformationBiomacromoleculeClass> ;
+   located_in: @<CellularComponent> {0,1};
+}// rdfs:comment  "an information biomacromolecule - e.g. a protein or RNA product"
+
+<ChemicalEntity> EXTRA bl:category{
+}// rdfs:comment  "a chemical entity"
+
+<EvidenceClass> IRI @<OwlClass> AND EXTRA rdfs:subClassOf {
+  rdfs:subClassOf [ GoEvidence: ] ;
+}
+
+<Evidence> @<GoCamEntity> AND EXTRA a  {
+  a @<EvidenceClass> {1};
+  source: xsd:string {1,};
+  with: xsd:string {0,1}
+}// rdfs:comment  "A kind of evidence"
+
+<AnnotatedEdge> BNode @<ProvenanceAnnotated> AND {
+  a owl:Axiom ;
+  owl:annotatedSource @<GoCamEntity> ;
+  owl:annotatedProperty IRI ;
+  owl:annotatedTarget @<GoCamEntity> ;
+  evidence: @<Evidence> {0,1}
+}
+
+#<BL_UNTYPED> {
+#   bl:category . {0}
+#   // rdfs:comment  "has no type tag inside" ;
+#} // rdfs:comment  "has no type tag full rule"
+
+#<BL_TYPED> {
+#   bl:category . {1}
+#} // rdfs:comment  "has exactly one type tag"
+
+#<BL_MULTI_TYPED> {
+#   bl:category . {2,}
+#} // rdfs:comment  "has multiple type tags"

--- a/minerva-server/src/test/java/org/geneontology/minerva/server/handler/BatchModelHandlerTest.java
+++ b/minerva-server/src/test/java/org/geneontology/minerva/server/handler/BatchModelHandlerTest.java
@@ -69,7 +69,7 @@ public class BatchModelHandlerTest {
 		final String modelIdPrefix = "http://model.geneontology.org/";
 		final CurieMappings localMappings = new CurieMappings.SimpleCurieMappings(Collections.singletonMap(modelIdcurie, modelIdPrefix));
 		curieHandler = new MappedCurieHandler(DefaultCurieHandler.loadDefaultMappings(), localMappings);
-		InferenceProviderCreator ipc = CachingInferenceProviderCreatorImpl.createElk(false);
+		InferenceProviderCreator ipc = CachingInferenceProviderCreatorImpl.createElk(false, null);
 		models = new UndoAwareMolecularModelManager(graph.getSourceOntology(), curieHandler, modelIdPrefix, folder.newFile().getAbsolutePath(), null);
 		lookupService = createTestProteins(curieHandler);
 		handler = new JsonOrJsonpBatchHandler(models, "development", ipc, importantRelations, lookupService) {

--- a/minerva-server/src/test/java/org/geneontology/minerva/server/handler/ModelReasonerTest.java
+++ b/minerva-server/src/test/java/org/geneontology/minerva/server/handler/ModelReasonerTest.java
@@ -51,7 +51,7 @@ public class ModelReasonerTest {
 		curieHandler = new MappedCurieHandler(DefaultCurieHandler.loadDefaultMappings(), localMappings);
 		
 		models = new UndoAwareMolecularModelManager(tbox, curieHandler, modelIdPrefix, folder.newFile().getAbsolutePath(), null);
-		InferenceProviderCreator ipc = CachingInferenceProviderCreatorImpl.createElk(false);
+		InferenceProviderCreator ipc = CachingInferenceProviderCreatorImpl.createElk(false, null);
 		handler = new JsonOrJsonpBatchHandler(models, "development", ipc,
 				Collections.<OWLObjectProperty>emptySet(), (ExternalLookupService) null);
 		//models.setPathToOWLFiles("src/test/resources/reasoner-test");

--- a/minerva-server/src/test/java/org/geneontology/minerva/server/handler/ParallelModelReasonerTest.java
+++ b/minerva-server/src/test/java/org/geneontology/minerva/server/handler/ParallelModelReasonerTest.java
@@ -121,7 +121,7 @@ public class ParallelModelReasonerTest {
 		final AtomicLong miss = new AtomicLong(0L);
 		
 		private CountingCachingInferenceProvider(boolean useSLME) {
-			super(new ElkReasonerFactory(), 1, useSLME, "Counting Caching ELK");
+			super(new ElkReasonerFactory(), 1, useSLME, "Counting Caching ELK", null);
 		}
 
 		@Override


### PR DESCRIPTION
Adds a shex validation step when the reasoner flag is on.  Look for information coming back in the response object:
response.data.unconformantFlag 
response.data.nonconformant_uris 
response.message 

Although the change is stuck in next to the reasoner process, it works independently.  e.g. it will still run when the model is inconsistent.  This works because it gets superclass information from a sparql query to rdf.geneontology.org .  If we changed the schema to look at types on individuals with the expectation that they would be fully expanded, then we could read those in from the reasoner without the external call.  (Noting that Arachne does not provide subclass expansion, just node typing).  It also downloads the schema from the GO_Shapes repository on startup, hence it needs net access to work.