### PR TITLE
Issue 212 validation service response

### DIFF
--- a/minerva-core/src/main/java/org/geneontology/minerva/BlazegraphMolecularModelManager.java
+++ b/minerva-core/src/main/java/org/geneontology/minerva/BlazegraphMolecularModelManager.java
@@ -209,7 +209,7 @@ public class BlazegraphMolecularModelManager<METADATA> extends CoreMolecularMode
 			createImports(abox, tbox.getOntologyID(), metadata);
 
 			// generate model
-			model = new ModelContainer(modelId, tbox, abox);
+			model = new ModelContainer(modelId, tbox, abox, tbox_reasoner);
 		} catch (OWLOntologyCreationException exception) {
 			if (abox != null) {
 				m.removeOntology(abox);
@@ -360,6 +360,7 @@ public class BlazegraphMolecularModelManager<METADATA> extends CoreMolecularMode
 		if (ontologyFormat == null) {
 			ontologyFormat = this.ontologyFormat;
 		}
+		
 		return exportModel(model, ontologyFormat);
 	}
 

--- a/minerva-core/src/main/java/org/geneontology/minerva/CoreMolecularModelManager.java
+++ b/minerva-core/src/main/java/org/geneontology/minerva/CoreMolecularModelManager.java
@@ -71,6 +71,9 @@ import org.semanticweb.owlapi.model.RemoveOntologyAnnotation;
 import org.semanticweb.owlapi.model.SetOntologyID;
 import org.semanticweb.owlapi.model.parameters.Imports;
 import org.semanticweb.owlapi.oboformat.OBOFormatOWLAPIParserFactory;
+import org.semanticweb.owlapi.reasoner.OWLReasoner;
+import org.semanticweb.owlapi.reasoner.OWLReasonerFactory;
+import org.semanticweb.owlapi.reasoner.structural.StructuralReasonerFactory;
 import org.semanticweb.owlapi.rio.RioMemoryTripleSource;
 import org.semanticweb.owlapi.rio.RioParserImpl;
 import org.semanticweb.owlapi.util.PriorityCollection;
@@ -110,6 +113,7 @@ public abstract class CoreMolecularModelManager<METADATA> {
 
 	final OWLOntology tbox;
 //	final OWLReasonerFactory rf;
+	final OWLReasoner tbox_reasoner;
 	private final IRI tboxIRI;
 	final Map<IRI, ModelContainer> modelMap = new HashMap<IRI, ModelContainer>();
 	Set<IRI> additionalImports;
@@ -201,7 +205,14 @@ public abstract class CoreMolecularModelManager<METADATA> {
 		initializeTboxLabelIndex();
 		initializeTboxShorthandIndex();
 		initializeDoNotAnnotateSubset();
+		this.tbox_reasoner = initializeTboxReasoner(tbox);
 		init();
+	}
+
+	private OWLReasoner initializeTboxReasoner(OWLOntology tbox) {
+		OWLReasonerFactory reasonerFactory = new StructuralReasonerFactory();
+		OWLReasoner r = reasonerFactory.createReasoner(tbox);
+		return r;
 	}
 
 	private static synchronized Set<OWLParserFactory> removeOBOParserFactories(OWLOntologyManager m) {
@@ -890,7 +901,7 @@ public abstract class CoreMolecularModelManager<METADATA> {
 	protected abstract void loadModel(IRI modelId, boolean isOverride) throws OWLOntologyCreationException;
 
 	ModelContainer addModel(IRI modelId, OWLOntology abox) throws OWLOntologyCreationException {
-		ModelContainer m = new ModelContainer(modelId, tbox, abox);
+		ModelContainer m = new ModelContainer(modelId, tbox, abox, tbox_reasoner);
 		modelMap.put(modelId, m);
 		return m;
 	}
@@ -1341,6 +1352,14 @@ public abstract class CoreMolecularModelManager<METADATA> {
 		if (!changes.isEmpty()) {
 			m.applyChanges(changes);
 		}
+	}
+
+	public OWLOntology getTbox() {
+		return tbox;
+	}
+
+	public OWLReasoner getTbox_reasoner() {
+		return tbox_reasoner;
 	}
 	
 }

--- a/minerva-core/src/main/java/org/geneontology/minerva/ModelContainer.java
+++ b/minerva-core/src/main/java/org/geneontology/minerva/ModelContainer.java
@@ -13,6 +13,7 @@ import org.semanticweb.owlapi.model.OWLOntologyChange;
 import org.semanticweb.owlapi.model.OWLOntologyCreationException;
 import org.semanticweb.owlapi.model.OWLOntologyManager;
 import org.semanticweb.owlapi.model.parameters.ChangeApplied;
+import org.semanticweb.owlapi.reasoner.OWLReasoner;
 
 import com.google.common.base.Optional;
 
@@ -24,6 +25,7 @@ public class ModelContainer {
 	private OWLOntology aboxOntology = null;
 	private boolean aboxModified = false;
 	private OWLOntology tboxOntology = null;
+	private OWLReasoner tboxReasoner = null;
 	
 	private final List<ModelChangeListener> listeners = new CopyOnWriteArrayList<>();
 
@@ -53,10 +55,11 @@ public class ModelContainer {
 	 * @param abox
 	 * @throws OWLOntologyCreationException
 	 */
-	public ModelContainer(IRI modelId, OWLOntology tbox, OWLOntology abox) throws OWLOntologyCreationException {
+	public ModelContainer(IRI modelId, OWLOntology tbox, OWLOntology abox, OWLReasoner tbox_reasoner) throws OWLOntologyCreationException {
 		tboxOntology = tbox;
 		aboxOntology = abox;
 		this.modelId = modelId;
+		this.tboxReasoner = tbox_reasoner;
 		init();
 	}
 

--- a/minerva-core/src/main/java/org/geneontology/minerva/json/InferenceProvider.java
+++ b/minerva-core/src/main/java/org/geneontology/minerva/json/InferenceProvider.java
@@ -4,6 +4,7 @@ import java.util.Set;
 
 import org.semanticweb.owlapi.model.OWLClass;
 import org.semanticweb.owlapi.model.OWLNamedIndividual;
+import org.geneontology.minerva.server.validation.ModelValidationReport;
 
 public interface InferenceProvider {
 
@@ -11,7 +12,5 @@ public interface InferenceProvider {
 	
 	public Set<OWLClass> getTypes(OWLNamedIndividual i);
 	
-	public boolean isConformant();
-	
-	public Set<String> getNonconformant_uris();
+	public Set<ModelValidationReport> getValidation_reports();
 }

--- a/minerva-core/src/main/java/org/geneontology/minerva/json/InferenceProvider.java
+++ b/minerva-core/src/main/java/org/geneontology/minerva/json/InferenceProvider.java
@@ -13,4 +13,6 @@ public interface InferenceProvider {
 	public Set<OWLClass> getTypes(OWLNamedIndividual i);
 	
 	public Set<ModelValidationReport> getValidation_reports();
+
+	Set<OWLClass> getAllTypes(OWLNamedIndividual i);
 }

--- a/minerva-core/src/main/java/org/geneontology/minerva/json/MolecularModelJsonRenderer.java
+++ b/minerva-core/src/main/java/org/geneontology/minerva/json/MolecularModelJsonRenderer.java
@@ -218,6 +218,22 @@ public class MolecularModelJsonRenderer {
 			if (inferredTypeObjs.isEmpty() == false) {
 				json.inferredType = inferredTypeObjs.toArray(new JsonOwlObject[inferredTypeObjs.size()]);
 			}
+			//testing approach to adding additional type information to response
+			List<JsonOwlObject> inferredTypeObjsWithAll = new ArrayList<JsonOwlObject>();
+			Set<OWLClass> inferredTypesWithAll = inferenceProvider.getAllTypes(i);
+			// optimization, do not render inferences, if they are equal to the asserted ones
+			if (assertedTypes.equals(inferredTypesWithAll) == false) {
+				for(OWLClass c : inferredTypesWithAll) {
+					if (c.isBuiltIn() == false) {
+						inferredTypeObjsWithAll.add(renderObject(c));
+					}
+				}
+			}
+			if (inferredTypeObjsWithAll.isEmpty() == false) {
+				json.inferredTypeWithAll = inferredTypeObjsWithAll.toArray(new JsonOwlObject[inferredTypeObjsWithAll.size()]);
+			}
+			
+			
 		}
 		
 		final List<JsonAnnotation> anObjs = new ArrayList<JsonAnnotation>();

--- a/minerva-core/src/main/java/org/geneontology/minerva/server/validation/ModelValidationReport.java
+++ b/minerva-core/src/main/java/org/geneontology/minerva/server/validation/ModelValidationReport.java
@@ -1,0 +1,5 @@
+package org.geneontology.minerva.server.validation;
+
+public interface ModelValidationReport {
+
+}

--- a/minerva-core/src/main/java/org/geneontology/minerva/util/JenaOwlTool.java
+++ b/minerva-core/src/main/java/org/geneontology/minerva/util/JenaOwlTool.java
@@ -1,0 +1,51 @@
+/**
+ * 
+ */
+package org.geneontology.minerva.util;
+
+import java.io.IOException;
+import java.io.PipedInputStream;
+import java.io.PipedOutputStream;
+
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.ModelFactory;
+import org.semanticweb.owlapi.formats.TurtleDocumentFormat;
+import org.semanticweb.owlapi.model.OWLOntology;
+import org.semanticweb.owlapi.model.OWLOntologyStorageException;
+
+/**
+ * @author bgood
+ *
+ */
+public class JenaOwlTool {
+
+	/**
+	 * 
+	 */
+	public JenaOwlTool() {
+		// TODO Auto-generated constructor stub
+	}
+
+	public static Model getJenaModel(OWLOntology ontology) {
+		Model model = ModelFactory.createDefaultModel();
+
+		try (PipedInputStream is = new PipedInputStream(); PipedOutputStream os = new PipedOutputStream(is)) {
+			new Thread(new Runnable() {
+				@Override
+				public void run() {
+					try {
+						ontology.getOWLOntologyManager().saveOntology(ontology, new TurtleDocumentFormat(), os);
+						os.close();
+					} catch (OWLOntologyStorageException | IOException e) {
+						e.printStackTrace();
+					}
+				}
+			}).start();
+			model.read(is, null, "TURTLE");
+			return model;
+		} catch (Exception e) {
+			throw new RuntimeException("Could not convert OWL API ontology to JENA API model.", e);
+		}
+	}
+
+}

--- a/minerva-json/src/main/java/org/geneontology/minerva/json/JsonOwlIndividual.java
+++ b/minerva-json/src/main/java/org/geneontology/minerva/json/JsonOwlIndividual.java
@@ -11,6 +11,9 @@ public class JsonOwlIndividual extends JsonAnnotatedObject {
 
 	@SerializedName("inferred-type")
 	public JsonOwlObject[] inferredType;
+	
+	@SerializedName("inferred-type-with-all")
+	public JsonOwlObject[] inferredTypeWithAll;
 
 	@Override
 	public int hashCode() {

--- a/minerva-server/src/main/java/org/geneontology/minerva/server/StartUpTool.java
+++ b/minerva-server/src/main/java/org/geneontology/minerva/server/StartUpTool.java
@@ -347,7 +347,7 @@ public class StartUpTool {
 				conf.curieHandler, conf.modelIdPrefix, conf.journalFile, conf.exportFolder);
 		// set pre and post file handlers
 		models.addPostLoadOntologyFilter(ModelReaderHelper.INSTANCE);
-		
+		conf.shex.tbox_reasoner = models.getTbox_reasoner();
 		// start server
 		Server server = startUp(models, conf);
 		return server;

--- a/minerva-server/src/main/java/org/geneontology/minerva/server/StartUpTool.java
+++ b/minerva-server/src/main/java/org/geneontology/minerva/server/StartUpTool.java
@@ -21,7 +21,7 @@ import org.geneontology.minerva.lookup.MonarchExternalLookupService;
 import org.geneontology.minerva.server.handler.*;
 import org.geneontology.minerva.server.inferences.CachingInferenceProviderCreatorImpl;
 import org.geneontology.minerva.server.inferences.InferenceProviderCreator;
-import org.geneontology.minerva.server.inferences.ShexController;
+import org.geneontology.minerva.server.validation.ShexValidator;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.glassfish.jersey.servlet.ServletContainer;
 import org.semanticweb.owlapi.model.*;
@@ -94,7 +94,7 @@ public class StartUpTool {
 		
 		public String shexFileUrl = "https://raw.githubusercontent.com/geneontology/go-shapes/master/shapes/go-cam-shapes.shex";
 		public String goshapemapFileUrl = "https://raw.githubusercontent.com/geneontology/go-shapes/master/shapes/go-cam-shapes.shapeMap";
-		public ShexController shex;
+		public ShexValidator shex;
 	
 	}
 	
@@ -108,7 +108,7 @@ public class StartUpTool {
 		URL shex_map_url = new URL(conf.goshapemapFileUrl);
 		File shex_map_file = new File("./target/go-cam-shapes.shapeMap");
 		org.apache.commons.io.FileUtils.copyURLToFile(shex_map_url, shex_map_file);
-		conf.shex = new ShexController(shex_schema_file, shex_map_file);
+		conf.shex = new ShexValidator(shex_schema_file, shex_map_file);
 		
 		while (opts.hasArgs()) {
 			if (opts.nextEq("-g|--graph")) {
@@ -353,7 +353,7 @@ public class StartUpTool {
 		return server;
 	}
 	
-	public static InferenceProviderCreator createInferenceProviderCreator(String reasonerOpt, UndoAwareMolecularModelManager models, ShexController shex) { 
+	public static InferenceProviderCreator createInferenceProviderCreator(String reasonerOpt, UndoAwareMolecularModelManager models, ShexValidator shex) { 
 		switch(reasonerOpt) { 
 		case ("slme-hermit"): return CachingInferenceProviderCreatorImpl.createHermiT(shex); 
 		case ("slme-elk"): return CachingInferenceProviderCreatorImpl.createElk(true, shex); 

--- a/minerva-server/src/main/java/org/geneontology/minerva/server/StartUpTool.java
+++ b/minerva-server/src/main/java/org/geneontology/minerva/server/StartUpTool.java
@@ -21,14 +21,11 @@ import org.geneontology.minerva.lookup.MonarchExternalLookupService;
 import org.geneontology.minerva.server.handler.*;
 import org.geneontology.minerva.server.inferences.CachingInferenceProviderCreatorImpl;
 import org.geneontology.minerva.server.inferences.InferenceProviderCreator;
-import org.geneontology.minerva.server.inferences.MapInferenceProvider.ModelValidationResult;
 import org.geneontology.minerva.server.inferences.ShexController;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.glassfish.jersey.servlet.ServletContainer;
 import org.semanticweb.owlapi.model.*;
 
-import fr.inria.lille.shexjava.schema.ShexSchema;
-import fr.inria.lille.shexjava.schema.parsing.GenParser;
 import owltools.cli.Opts;
 import owltools.gaf.eco.EcoMapperFactory;
 import owltools.gaf.eco.SimpleEcoMapper;

--- a/minerva-server/src/main/java/org/geneontology/minerva/server/handler/JsonOrJsonpBatchHandler.java
+++ b/minerva-server/src/main/java/org/geneontology/minerva/server/handler/JsonOrJsonpBatchHandler.java
@@ -207,7 +207,7 @@ public class JsonOrJsonpBatchHandler extends OperationsImpl implements M3BatchHa
 			isConsistent = inferenceProvider.isConsistent();
 			response.setReasoned(true);
 			values.renderBulk = true; // to ensure that all indivuduals are in the response
-			//TODO @goodb extend response with shape validation information
+			//TODO @goodb fill in explanations for shape and owl validation
 			for(ModelValidationReport report : inferenceProvider.getValidation_reports()) {
 				//if any of the validation tests come back noncomformant, set nonconformant ("something is wrong") flag
 				if(!report.isConformant()) {

--- a/minerva-server/src/main/java/org/geneontology/minerva/server/handler/JsonOrJsonpBatchHandler.java
+++ b/minerva-server/src/main/java/org/geneontology/minerva/server/handler/JsonOrJsonpBatchHandler.java
@@ -202,7 +202,6 @@ public class JsonOrJsonpBatchHandler extends OperationsImpl implements M3BatchHa
 		InferenceProvider inferenceProvider = null;
 		boolean isConsistent = true;
 		boolean isConformant = true;
-		
 		if (inferenceProviderCreator != null && useReasoner) {
 			inferenceProvider = inferenceProviderCreator.create(values.model);
 			isConsistent = inferenceProvider.isConsistent();

--- a/minerva-server/src/main/java/org/geneontology/minerva/server/handler/JsonOrJsonpBatchHandler.java
+++ b/minerva-server/src/main/java/org/geneontology/minerva/server/handler/JsonOrJsonpBatchHandler.java
@@ -10,6 +10,7 @@ import org.geneontology.minerva.json.*;
 import org.geneontology.minerva.lookup.ExternalLookupService;
 import org.geneontology.minerva.server.handler.M3BatchHandler.M3BatchResponse.ResponseData;
 import org.geneontology.minerva.server.inferences.InferenceProviderCreator;
+import org.geneontology.minerva.server.validation.ModelValidationReport;
 import org.glassfish.jersey.server.JSONP;
 import org.semanticweb.owlapi.model.OWLObjectProperty;
 
@@ -201,15 +202,20 @@ public class JsonOrJsonpBatchHandler extends OperationsImpl implements M3BatchHa
 		InferenceProvider inferenceProvider = null;
 		boolean isConsistent = true;
 		boolean isConformant = true;
-		Set<String> nonconformant_uris = new HashSet<String>();
+		
 		if (inferenceProviderCreator != null && useReasoner) {
 			inferenceProvider = inferenceProviderCreator.create(values.model);
 			isConsistent = inferenceProvider.isConsistent();
 			response.setReasoned(true);
 			values.renderBulk = true; // to ensure that all indivuduals are in the response
 			//TODO @goodb extend response with shape validation information
-			isConformant = inferenceProvider.isConformant();
-			nonconformant_uris = inferenceProvider.getNonconformant_uris();
+			for(ModelValidationReport report : inferenceProvider.getValidation_reports()) {
+				//if any of the validation tests come back noncomformant, set nonconformant ("something is wrong") flag
+				if(!report.isConformant()) {
+					isConformant = false;
+					break;
+				}
+			}			
 		}
 
 		// create response.data
@@ -239,9 +245,8 @@ public class JsonOrJsonpBatchHandler extends OperationsImpl implements M3BatchHa
 			response.data.inconsistentFlag =  Boolean.TRUE;
 		}
 		if(!isConformant) {
-			response.data.unconformantFlag = Boolean.TRUE;
-			response.data.nonconformant_uris = nonconformant_uris;
-			response.message = "invalid shapes for: "+nonconformant_uris;
+			response.data.nonconformantFlag = Boolean.TRUE;
+			response.data.validation_results = inferenceProvider.getValidation_reports();
 		}
 		response.data.modifiedFlag = Boolean.valueOf(values.model.isModified());
 		// These are required for an "okay" response.

--- a/minerva-server/src/main/java/org/geneontology/minerva/server/handler/M3BatchHandler.java
+++ b/minerva-server/src/main/java/org/geneontology/minerva/server/handler/M3BatchHandler.java
@@ -3,6 +3,7 @@ package org.geneontology.minerva.server.handler;
 import com.google.gson.JsonObject;
 import com.google.gson.annotations.SerializedName;
 import org.geneontology.minerva.json.*;
+import org.geneontology.minerva.server.validation.ModelValidationReport;
 
 import javax.ws.rs.*;
 import java.util.List;
@@ -121,11 +122,12 @@ public interface M3BatchHandler {
 			@SerializedName("sparql-result")
 			public JsonObject sparqlResult;
 			
-			@SerializedName("uncomformant-p")
-			public Boolean unconformantFlag;
+			@SerializedName("noncomformant-p")
+			public Boolean nonconformantFlag;
 
-			@SerializedName("noncomformant-uris")
-			public Set<String> nonconformant_uris;
+			@SerializedName("validation-results")
+			public Set<ModelValidationReport> validation_results;
+
 		}
 		
 		public static class MetaResponse {

--- a/minerva-server/src/main/java/org/geneontology/minerva/server/handler/ModelSearchHandler.java
+++ b/minerva-server/src/main/java/org/geneontology/minerva/server/handler/ModelSearchHandler.java
@@ -100,7 +100,7 @@ public class ModelSearchHandler {
 			result = search(gene_product_class_uris, goterms, pmids, title, state, contributor, group, date, offset, limit);
 			return result;
 	}
-
+	//TODO make junit tests out of these. 
 	//examples 
 	//http://127.0.0.1:6800/search/?
 	//?gene_product_class_uri=http://identifiers.org/mgi/MGI:1328355

--- a/minerva-server/src/main/java/org/geneontology/minerva/server/inferences/CachingInferenceProviderCreatorImpl.java
+++ b/minerva-server/src/main/java/org/geneontology/minerva/server/inferences/CachingInferenceProviderCreatorImpl.java
@@ -7,6 +7,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import org.geneontology.minerva.ModelContainer;
 import org.geneontology.minerva.ModelContainer.ModelChangeListener;
 import org.geneontology.minerva.json.InferenceProvider;
+import org.geneontology.minerva.server.validation.ShexValidator;
 import org.geneontology.rules.engine.RuleEngine;
 import org.geneontology.rules.util.ArachneOWLReasonerFactory;
 import org.semanticweb.elk.owlapi.ElkReasonerFactory;
@@ -18,11 +19,11 @@ public class CachingInferenceProviderCreatorImpl extends InferenceProviderCreato
 	
 	private final Map<ModelContainer, InferenceProvider> inferenceCache = new ConcurrentHashMap<>();
 	
-	protected CachingInferenceProviderCreatorImpl(OWLReasonerFactory rf, int maxConcurrent, boolean useSLME, String name, ShexController shex) {
+	protected CachingInferenceProviderCreatorImpl(OWLReasonerFactory rf, int maxConcurrent, boolean useSLME, String name, ShexValidator shex) {
 		super(rf, maxConcurrent, useSLME, name, shex);	
 	}
 
-	public static InferenceProviderCreator createElk(boolean useSLME, ShexController shex) {
+	public static InferenceProviderCreator createElk(boolean useSLME, ShexValidator shex) {
 		String name;
 		if (useSLME) {
 			name = "Caching ELK-SLME";
@@ -33,17 +34,17 @@ public class CachingInferenceProviderCreatorImpl extends InferenceProviderCreato
 		return new CachingInferenceProviderCreatorImpl(new ElkReasonerFactory(), 1, useSLME, name, shex);
 	}
 
-	public static InferenceProviderCreator createHermiT(ShexController shex) {
+	public static InferenceProviderCreator createHermiT(ShexValidator shex) {
 		int maxConcurrent = Runtime.getRuntime().availableProcessors();
 		return createHermiT(maxConcurrent, shex);
 	}
 	
-	public static InferenceProviderCreator createHermiT(int maxConcurrent, ShexController shex) {
+	public static InferenceProviderCreator createHermiT(int maxConcurrent, ShexValidator shex) {
 		return new CachingInferenceProviderCreatorImpl(new org.semanticweb.HermiT.ReasonerFactory(),
 				maxConcurrent, true, "Caching Hermit-SLME", shex);
 	}
 	
-	public static InferenceProviderCreator createArachne(RuleEngine arachne, ShexController shex) {
+	public static InferenceProviderCreator createArachne(RuleEngine arachne, ShexValidator shex) {
 		return new CachingInferenceProviderCreatorImpl(new ArachneOWLReasonerFactory(arachne), 1, false, "Caching Arachne", shex);
 	}
 

--- a/minerva-server/src/main/java/org/geneontology/minerva/server/inferences/InferenceProviderCreatorImpl.java
+++ b/minerva-server/src/main/java/org/geneontology/minerva/server/inferences/InferenceProviderCreatorImpl.java
@@ -7,6 +7,7 @@ import java.util.concurrent.Semaphore;
 import org.apache.log4j.Logger;
 import org.geneontology.minerva.ModelContainer;
 import org.geneontology.minerva.json.InferenceProvider;
+import org.geneontology.minerva.server.validation.ShexValidator;
 import org.semanticweb.elk.owlapi.ElkReasonerFactory;
 import org.semanticweb.owlapi.model.IRI;
 import org.semanticweb.owlapi.model.OWLEntity;
@@ -27,9 +28,9 @@ public class InferenceProviderCreatorImpl implements InferenceProviderCreator {
 	private final Semaphore concurrentLock;
 	private final boolean useSLME;
 	private final String name;
-	private final ShexController shex;
+	private final ShexValidator shex;
 
-	InferenceProviderCreatorImpl(OWLReasonerFactory rf, int maxConcurrent, boolean useSLME, String name, ShexController shex) {
+	InferenceProviderCreatorImpl(OWLReasonerFactory rf, int maxConcurrent, boolean useSLME, String name, ShexValidator shex) {
 		super();
 		this.rf = rf;
 		this.useSLME = useSLME;
@@ -38,7 +39,7 @@ public class InferenceProviderCreatorImpl implements InferenceProviderCreator {
 		this.shex = shex;
 	}
 
-	public static InferenceProviderCreator createElk(boolean useSLME, ShexController shex) {
+	public static InferenceProviderCreator createElk(boolean useSLME, ShexValidator shex) {
 		String name;
 		if (useSLME) {
 			name = "ELK-SLME";
@@ -49,12 +50,12 @@ public class InferenceProviderCreatorImpl implements InferenceProviderCreator {
 		return new InferenceProviderCreatorImpl(new ElkReasonerFactory(), 1, useSLME, name, shex);
 	}
 	
-	public static InferenceProviderCreator createHermiT(ShexController shex) {
+	public static InferenceProviderCreator createHermiT(ShexValidator shex) {
 		int maxConcurrent = Runtime.getRuntime().availableProcessors();
 		return createHermiT(maxConcurrent, shex);
 	}
 	
-	public static InferenceProviderCreator createHermiT(int maxConcurrent, ShexController shex) {
+	public static InferenceProviderCreator createHermiT(int maxConcurrent, ShexValidator shex) {
 		return new InferenceProviderCreatorImpl(new org.semanticweb.HermiT.ReasonerFactory(), maxConcurrent, true, "Hermit-SLME", shex);
 	}
 

--- a/minerva-server/src/main/java/org/geneontology/minerva/server/inferences/MapInferenceProvider.java
+++ b/minerva-server/src/main/java/org/geneontology/minerva/server/inferences/MapInferenceProvider.java
@@ -55,9 +55,20 @@ public class MapInferenceProvider implements InferenceProvider {
 				inferredTypes.put(individual, inferred);
 			}
 		}
-		//Aim to support multiple validation regimes - e.g. gorules, reasoner, shex
+		//Aim to support multiple validation regimes - e.g. reasoner, shex, gorules
 		Set<ModelValidationReport> all_validation_results = new HashSet<ModelValidationReport>();
-		
+		//reasoner
+		ModelValidationReport reasoner_validation_report = new ModelValidationReport(
+				"GORULE:OWL_REASONER",
+				"https://github.com/geneontology/helpdesk/issues", 
+				"https://github.com/geneontology/go-ontology",
+				isConsistent);
+		if(!isConsistent) {
+			Violation i_v = new Violation("id of inconsistent node");
+			i_v.setCommentary("comment about why");
+			reasoner_validation_report.addViolation(i_v);
+		}
+		all_validation_results.add(reasoner_validation_report);
 		//shex
 		//generate an RDF model
 		Model model = getModel(ont);
@@ -75,6 +86,12 @@ public class MapInferenceProvider implements InferenceProvider {
 			for(String bad_node : result.node_is_valid.keySet()) {
 				if(!(result.node_is_valid.get(bad_node))) {
 					ShexViolation violation = new ShexViolation(bad_node);
+					violation.setCommentary("Some explanatory text would go here");
+					ShexExplanation explanation = new ShexExplanation();
+					explanation.setShape_id("the shape id that this node should fit here");
+					ShexConstraint constraint = new ShexConstraint("unmatched_property_id", "Range of property id");
+					explanation.addConstraint(constraint);
+					violation.addExplanation(explanation);
 					validation_report.addViolation(violation);
 				}
 			}

--- a/minerva-server/src/main/java/org/geneontology/minerva/server/inferences/ShexController.java
+++ b/minerva-server/src/main/java/org/geneontology/minerva/server/inferences/ShexController.java
@@ -24,7 +24,7 @@ import org.apache.jena.query.QuerySolution;
 import org.apache.jena.query.ResultSet;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.Resource;
-import org.geneontology.minerva.server.inferences.MapInferenceProvider.ModelValidationResult;
+import org.geneontology.minerva.server.inferences.MapInferenceProvider.ShexValidationResult;
 
 import fr.inria.lille.shexjava.schema.Label;
 import fr.inria.lille.shexjava.schema.ShexSchema;
@@ -79,9 +79,9 @@ public class ShexController {
 		return shapelabel_sparql;
 	}
 	
-	public ModelValidationResult runShapeMapValidation(Model test_model, boolean stream_output) throws Exception {
+	public ShexValidationResult runShapeMapValidation(Model test_model, boolean stream_output) throws Exception {
 		Map<String, Typing> shape_node_typing = validateGoShapeMap(schema, test_model, GoQueryMap);
-		ModelValidationResult r = new ModelValidationResult(test_model);
+		ShexValidationResult r = new ShexValidationResult(test_model);
 		RDF rdfFactory = new SimpleRDF();
 		for(String shape_node : shape_node_typing.keySet()) {
 			Typing typing = shape_node_typing.get(shape_node);

--- a/minerva-server/src/main/java/org/geneontology/minerva/server/validation/ModelValidationReport.java
+++ b/minerva-server/src/main/java/org/geneontology/minerva/server/validation/ModelValidationReport.java
@@ -11,28 +11,23 @@ import java.util.Set;
  *
  */
 public class ModelValidationReport {
-	String id;
-	boolean isConformant;
-	String tracker;
-	String rulefile;
+	final String id;
+	boolean conformant;
+	final String tracker;
+	final String rulefile;
 	Set<Violation> violations;
 	
 	/**
 	 * 
 	 */
-	public ModelValidationReport(String id, String tracker, String rulefile, boolean isConformant) {
-		setId(id);
-		setTracker(tracker);
-		setConformant(isConformant);
-		setRulefile(rulefile);
+	public ModelValidationReport(String id, String tracker, String rulefile) {
+		this.id = id;
+		this.tracker = tracker;
+		this.rulefile = rulefile;
 	}
 
 	public String getId() {
 		return id;
-	}
-
-	public void setId(String id) {
-		this.id = id;
 	}
 
 	public Set<Violation> getViolations() {
@@ -51,27 +46,19 @@ public class ModelValidationReport {
 	}
 
 	public boolean isConformant() {
-		return isConformant;
+		return conformant;
 	}
 
-	public void setConformant(boolean isConformant) {
-		this.isConformant = isConformant;
+	public void setConformant(boolean conformant) {
+		this.conformant = conformant;
 	}
 
 	public String getTracker() {
 		return tracker;
 	}
 
-	public void setTracker(String tracker) {
-		this.tracker = tracker;
-	}
-
 	public String getRulefile() {
 		return rulefile;
-	}
-
-	public void setRulefile(String rulefile) {
-		this.rulefile = rulefile;
 	}
 	
 }

--- a/minerva-server/src/main/java/org/geneontology/minerva/server/validation/ModelValidationReport.java
+++ b/minerva-server/src/main/java/org/geneontology/minerva/server/validation/ModelValidationReport.java
@@ -1,0 +1,77 @@
+/**
+ * 
+ */
+package org.geneontology.minerva.server.validation;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * @author bgood
+ *
+ */
+public class ModelValidationReport {
+	String id;
+	boolean isConformant;
+	String tracker;
+	String rulefile;
+	Set<Violation> violations;
+	
+	/**
+	 * 
+	 */
+	public ModelValidationReport(String id, String tracker, String rulefile, boolean isConformant) {
+		setId(id);
+		setTracker(tracker);
+		setConformant(isConformant);
+		setRulefile(rulefile);
+	}
+
+	public String getId() {
+		return id;
+	}
+
+	public void setId(String id) {
+		this.id = id;
+	}
+
+	public Set<Violation> getViolations() {
+		return violations;
+	}
+
+	public void setViolations(Set<Violation> violations) {
+		this.violations = violations;
+	}
+	
+	public void addViolation(Violation violation) {
+		if(this.violations==null) {
+			this.violations = new HashSet<Violation>();
+		}
+		this.violations.add(violation);
+	}
+
+	public boolean isConformant() {
+		return isConformant;
+	}
+
+	public void setConformant(boolean isConformant) {
+		this.isConformant = isConformant;
+	}
+
+	public String getTracker() {
+		return tracker;
+	}
+
+	public void setTracker(String tracker) {
+		this.tracker = tracker;
+	}
+
+	public String getRulefile() {
+		return rulefile;
+	}
+
+	public void setRulefile(String rulefile) {
+		this.rulefile = rulefile;
+	}
+	
+}

--- a/minerva-server/src/main/java/org/geneontology/minerva/server/validation/OWLValidationReport.java
+++ b/minerva-server/src/main/java/org/geneontology/minerva/server/validation/OWLValidationReport.java
@@ -1,0 +1,14 @@
+package org.geneontology.minerva.server.validation;
+
+public class OWLValidationReport extends ModelValidationReport {
+	public static final String report_type_id = "OWL_REASONER";
+	public static final String tracker = "https://github.com/geneontology/helpdesk/issues";
+	public static final String rulefile = "https://github.com/geneontology/go-ontology";
+	
+
+	
+	public OWLValidationReport() {
+		super(report_type_id, tracker, rulefile);
+	}
+
+}

--- a/minerva-server/src/main/java/org/geneontology/minerva/server/validation/ShexConstraint.java
+++ b/minerva-server/src/main/java/org/geneontology/minerva/server/validation/ShexConstraint.java
@@ -1,0 +1,20 @@
+/**
+ * 
+ */
+package org.geneontology.minerva.server.validation;
+
+/**
+ * @author bgood
+ *
+ */
+public class ShexConstraint {
+	String property_id;
+	String propery_range;
+	/**
+	 * 
+	 */
+	public ShexConstraint() {
+		// TODO Auto-generated constructor stub
+	}
+
+}

--- a/minerva-server/src/main/java/org/geneontology/minerva/server/validation/ShexConstraint.java
+++ b/minerva-server/src/main/java/org/geneontology/minerva/server/validation/ShexConstraint.java
@@ -13,8 +13,22 @@ public class ShexConstraint {
 	/**
 	 * 
 	 */
-	public ShexConstraint() {
-		// TODO Auto-generated constructor stub
+	public ShexConstraint(String property_id, String propery_range) {
+		this.property_id = property_id;
+		this.propery_range = propery_range;
+	}
+
+	public String getProperty_id() {
+		return property_id;
+	}
+	public void setProperty_id(String property_id) {
+		this.property_id = property_id;
+	}
+	public String getPropery_range() {
+		return propery_range;
+	}
+	public void setPropery_range(String propery_range) {
+		this.propery_range = propery_range;
 	}
 
 }

--- a/minerva-server/src/main/java/org/geneontology/minerva/server/validation/ShexExplanation.java
+++ b/minerva-server/src/main/java/org/geneontology/minerva/server/validation/ShexExplanation.java
@@ -3,6 +3,7 @@
  */
 package org.geneontology.minerva.server.validation;
 
+import java.util.HashSet;
 import java.util.Set;
 
 /**
@@ -16,7 +17,21 @@ public class ShexExplanation {
 	 * 
 	 */
 	public ShexExplanation() {
-		// TODO Auto-generated constructor stub
+		constraints = new HashSet<ShexConstraint>();
 	}
-
+	public String getShape_id() {
+		return shape_id;
+	}
+	public void setShape_id(String shape_id) {
+		this.shape_id = shape_id;
+	}
+	public Set<ShexConstraint> getConstraints() {
+		return constraints;
+	}
+	public void setConstraints(Set<ShexConstraint> constraints) {
+		this.constraints = constraints;
+	}
+	public void addConstraint(ShexConstraint constraint) {
+		this.constraints.add(constraint);
+	}
 }

--- a/minerva-server/src/main/java/org/geneontology/minerva/server/validation/ShexExplanation.java
+++ b/minerva-server/src/main/java/org/geneontology/minerva/server/validation/ShexExplanation.java
@@ -1,0 +1,22 @@
+/**
+ * 
+ */
+package org.geneontology.minerva.server.validation;
+
+import java.util.Set;
+
+/**
+ * @author bgood
+ *
+ */
+public class ShexExplanation {
+	String shape_id;
+	Set<ShexConstraint> constraints;
+	/**
+	 * 
+	 */
+	public ShexExplanation() {
+		// TODO Auto-generated constructor stub
+	}
+
+}

--- a/minerva-server/src/main/java/org/geneontology/minerva/server/validation/ShexValidationReport.java
+++ b/minerva-server/src/main/java/org/geneontology/minerva/server/validation/ShexValidationReport.java
@@ -20,21 +20,23 @@ import org.apache.jena.rdf.model.Resource;
  *
  */
 
-public class ShexValidationResult {
+public class ShexValidationReport extends ModelValidationReport{
+	public static final String report_type_id = "SHEX_CORE_SCHEMA";
+	public static final String tracker = "https://github.com/geneontology/go-shapes/issues";
+	public static final String rulefile = "https://github.com/geneontology/go-shapes/blob/master/shapes/go-cam-shapes.shex";
+	
 	public boolean model_is_valid; 
-	public boolean model_is_consistent;
-	public Map<String, Set<String>> node_shapes;
-	public Map<String, Set<String>> node_types;
-	public Map<String, String> node_report;
+	public Map<String, Set<String>> node_matched_shapes = new HashMap<String, Set<String>>();
+	public Map<String, Set<String>> node_unmatched_shapes = new HashMap<String, Set<String>>();
+	public Map<String, String> node_report = new HashMap<String, String>();
 	public Map<String, Boolean> node_is_valid = new HashMap<String, Boolean>();
-	public Map<String, Boolean> node_is_consistent;
-	public String model_report;
-	public String model_id;
-	public String model_title;
+	public String model_report = "";
+	public String model_title = "";
 	/**
 	 * 
 	 */
-	public ShexValidationResult(Model model) {
+	public ShexValidationReport(String id, Model model) {
+		super(id, tracker, rulefile);
 		String q = "select ?cam ?title where {"
 				+ "?cam <http://purl.org/dc/elements/1.1/title> ?title }";
 		//	+ "?cam <"+DC.description.getURI()+"> ?title }";
@@ -42,9 +44,11 @@ public class ShexValidationResult {
 		ResultSet results = qe.execSelect();
 		if (results.hasNext()) {
 			QuerySolution qs = results.next();
-			Resource id = qs.getResource("cam");
+			Resource model_id_resource = qs.getResource("cam");
 			Literal title = qs.getLiteral("title");
-			model_id = id.getURI();
+			if(id==null) {
+				id = model_id_resource.getURI();
+			}
 			model_title = title.getString();
 		}
 		qe.close();

--- a/minerva-server/src/main/java/org/geneontology/minerva/server/validation/ShexValidationResult.java
+++ b/minerva-server/src/main/java/org/geneontology/minerva/server/validation/ShexValidationResult.java
@@ -1,0 +1,54 @@
+/**
+ * 
+ */
+package org.geneontology.minerva.server.validation;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.jena.query.QueryExecution;
+import org.apache.jena.query.QueryExecutionFactory;
+import org.apache.jena.query.QuerySolution;
+import org.apache.jena.query.ResultSet;
+import org.apache.jena.rdf.model.Literal;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.Resource;
+
+/**
+ * @author bgood
+ *
+ */
+
+public class ShexValidationResult {
+	public boolean model_is_valid; 
+	public boolean model_is_consistent;
+	public Map<String, Set<String>> node_shapes;
+	public Map<String, Set<String>> node_types;
+	public Map<String, String> node_report;
+	public Map<String, Boolean> node_is_valid = new HashMap<String, Boolean>();
+	public Map<String, Boolean> node_is_consistent;
+	public String model_report;
+	public String model_id;
+	public String model_title;
+	/**
+	 * 
+	 */
+	public ShexValidationResult(Model model) {
+		String q = "select ?cam ?title where {"
+				+ "?cam <http://purl.org/dc/elements/1.1/title> ?title }";
+		//	+ "?cam <"+DC.description.getURI()+"> ?title }";
+		QueryExecution qe = QueryExecutionFactory.create(q, model);
+		ResultSet results = qe.execSelect();
+		if (results.hasNext()) {
+			QuerySolution qs = results.next();
+			Resource id = qs.getResource("cam");
+			Literal title = qs.getLiteral("title");
+			model_id = id.getURI();
+			model_title = title.getString();
+		}
+		qe.close();
+		model_report = "shape id\tnode uri\tvalidation status\n";
+	}
+
+}

--- a/minerva-server/src/main/java/org/geneontology/minerva/server/validation/ShexViolation.java
+++ b/minerva-server/src/main/java/org/geneontology/minerva/server/validation/ShexViolation.java
@@ -1,0 +1,22 @@
+/**
+ * 
+ */
+package org.geneontology.minerva.server.validation;
+
+import java.util.Set;
+
+/**
+ * @author bgood
+ *
+ */
+public class ShexViolation extends Violation {
+
+	Set<ShexExplanation> explanations;
+	/**
+	 * 
+	 */
+	public ShexViolation(String node_id) {
+		super(node_id);
+	}
+
+}

--- a/minerva-server/src/main/java/org/geneontology/minerva/server/validation/ShexViolation.java
+++ b/minerva-server/src/main/java/org/geneontology/minerva/server/validation/ShexViolation.java
@@ -3,6 +3,7 @@
  */
 package org.geneontology.minerva.server.validation;
 
+import java.util.HashSet;
 import java.util.Set;
 
 /**
@@ -17,6 +18,17 @@ public class ShexViolation extends Violation {
 	 */
 	public ShexViolation(String node_id) {
 		super(node_id);
+		explanations = new HashSet<ShexExplanation>();
+	}
+	public Set<ShexExplanation> getExplanations() {
+		return explanations;
+	}
+	public void setExplanations(Set<ShexExplanation> explanations) {
+		this.explanations = explanations;
+	}
+	public void addExplanation(ShexExplanation explanation) {
+		this.explanations.add(explanation);
 	}
 
+	
 }

--- a/minerva-server/src/main/java/org/geneontology/minerva/server/validation/Violation.java
+++ b/minerva-server/src/main/java/org/geneontology/minerva/server/validation/Violation.java
@@ -1,0 +1,34 @@
+/**
+ * 
+ */
+package org.geneontology.minerva.server.validation;
+
+/**
+ * @author bgood
+ *
+ */
+public class Violation {
+
+	String node_id;
+	String commentary;
+	/**
+	 * 
+	 */
+	public Violation(String node_id) {
+		setNode_id(node_id);
+	}
+	public String getNode_id() {
+		return node_id;
+	}
+	public void setNode_id(String node_id) {
+		this.node_id = node_id;
+	}
+	public String getCommentary() {
+		return commentary;
+	}
+	public void setCommentary(String commentary) {
+		this.commentary = commentary;
+	}
+
+	
+}


### PR DESCRIPTION
this contains a bunch of re-organization.  Other noteworthy changes:
Now using reasoned ontology loaded at startup to get superclasses for shex - no more dependency on external sparql.  
Filled in everything in the shex validation response with real data (URIs) with the exception of the property constraints that were violated (still figuring out how to get to those).  
Added complete super type information to individuals in the response.  From this the client could e.g. get root types without any other call.  