### PR TITLE
implements pattern for retrieving canonical identifiers in gpad output

### DIFF
--- a/minerva-cli/src/main/java/org/geneontology/minerva/cli/MinervaCommandRunner.java
+++ b/minerva-cli/src/main/java/org/geneontology/minerva/cli/MinervaCommandRunner.java
@@ -419,7 +419,7 @@ public class MinervaCommandRunner extends JsCommandRunner {
 		BlazegraphMolecularModelManager<Void> m3 = new BlazegraphMolecularModelManager<>(ontology, curieHandler, modelIdPrefix, inputDB, null);
 		for (IRI modelIRI : m3.getAvailableModelIds()) {
 			try {
-				String gpad = new GPADSPARQLExport(curieHandler, m3.getLegacyRelationShorthandIndex(), m3.getTboxShorthandIndex(), m3.getDoNotAnnotateSubset()).exportGPAD(m3.createInferredModel(modelIRI));
+				String gpad = new GPADSPARQLExport(curieHandler, m3.getLegacyRelationShorthandIndex(), m3.getTboxShorthandIndex(), m3.getDoNotAnnotateSubset()).exportGPAD(m3.createCanonicalInferredModel(modelIRI));
 				String fileName = StringUtils.replaceOnce(modelIRI.toString(), modelIdPrefix, "") + ".gpad";
 				Writer writer = new OutputStreamWriter(new FileOutputStream(Paths.get(gpadOutputFolder, fileName).toFile()), StandardCharsets.UTF_8);
 				writer.write(gpad);

--- a/minerva-core/src/main/java/org/geneontology/minerva/UndoAwareMolecularModelManager.java
+++ b/minerva-core/src/main/java/org/geneontology/minerva/UndoAwareMolecularModelManager.java
@@ -13,6 +13,7 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.geneontology.minerva.UndoAwareMolecularModelManager.UndoMetadata;
 import org.geneontology.minerva.curie.CurieHandler;
 import org.geneontology.minerva.util.ReverseChangeGenerator;
+import org.geneontology.rules.engine.WorkingMemory;
 import org.semanticweb.owlapi.model.IRI;
 import org.semanticweb.owlapi.model.OWLOntology;
 import org.semanticweb.owlapi.model.OWLOntologyChange;
@@ -314,5 +315,6 @@ public class UndoAwareMolecularModelManager extends MolecularModelManager<UndoMe
 	protected void applyChanges(ModelContainer model, List<OWLOntologyChange> changes) {
 		model.applyChanges(changes);
 	}
+
 	
 }

--- a/minerva-server/src/main/java/org/geneontology/minerva/server/handler/OperationsImpl.java
+++ b/minerva-server/src/main/java/org/geneontology/minerva/server/handler/OperationsImpl.java
@@ -676,7 +676,7 @@ abstract class OperationsImpl extends ModelCreator {
 		if ("gpad".equals(format)) {
 			initMetaResponse(response);
 			try {
-				response.data.exportModel = new GPADSPARQLExport(curieHandler, m3.getLegacyRelationShorthandIndex(), m3.getTboxShorthandIndex(), m3.getDoNotAnnotateSubset()).exportGPAD(m3.createInferredModel(model.getModelId()));
+				response.data.exportModel = new GPADSPARQLExport(curieHandler, m3.getLegacyRelationShorthandIndex(), m3.getTboxShorthandIndex(), m3.getDoNotAnnotateSubset()).exportGPAD(m3.createCanonicalInferredModel(model.getModelId()));
 			} catch (InconsistentOntologyException e) {
 				response.messageType = MinervaResponse.MESSAGE_TYPE_ERROR;
 				response.message = "The model is inconsistent; a GPAD cannot be created.";


### PR DESCRIPTION
This work is in reference to https://github.com/geneontology/pathways2GO/issues/71

This allows entity ontologies aside from neo to be used to construct go-cams while maintaining GPAD outputs that adhere strictly to canonical terminologies such as UniProt for human genes.  It works by adding the annotation property  http://geneontology.org/lego/canonical_record to link new terms (e.g. reactome entities) to canonical terms (e.g. corresponding uniprots).  When these annotations are present, the GPAD SPARQL export process begins by converting the model to one with all of the external types replaced by canonical types.  The rest of the gpad export process is then unchanged.