### PR TITLE
Performance go shapes199

### DIFF
--- a/minerva-cli/src/main/java/org/geneontology/minerva/cli/CommandLineInterface.java
+++ b/minerva-cli/src/main/java/org/geneontology/minerva/cli/CommandLineInterface.java
@@ -81,6 +81,8 @@ import com.google.common.collect.Sets;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 
+import fr.inria.lille.shexjava.schema.ShexSchema;
+import fr.inria.lille.shexjava.schema.parsing.GenParser;
 import owltools.cli.Opts;
 import owltools.io.ParserWrapper;
 
@@ -89,6 +91,9 @@ public class CommandLineInterface {
 	private static final Logger LOGGER = Logger.getLogger(CommandLineInterface.class);
 
 	public static void main(String[] args) throws Exception {
+		ShexSchema schema = GenParser.parseSchema(new File("/Users/benjamingood/GitHub/GO_Shapes/shapes/go-cam-shapes.shex").toPath());
+		
+		
 		reportSystemParams();
 		Options main_options = new Options();
 		OptionGroup methods = new OptionGroup();
@@ -594,20 +599,17 @@ public class CommandLineInterface {
 				BlazegraphMolecularModelManager<Void> m3 = new BlazegraphMolecularModelManager<>(dummy, curieHandler, modelIdPrefix, inputDB, null);
 				if(i.isDirectory()) {
 					FileUtils.listFiles(i, null, true).parallelStream().parallel().forEach(file-> {
-						if(!(file.getName().equals("reactome-homosapiens-Synthesis_of_PIPs_at_the_plasma_membrane.ttl"))
-							&&!(file.getName().equals("reactome-homosapiens-Circadian_Clock.ttl"))) {
-							if(file.getName().endsWith(".ttl")||file.getName().endsWith("owl")) {
-								LOGGER.info("Loading " + file);
-								try {
-									String modeluri = m3.importModelToDatabase(file, true);
-									modelid_filename.put(modeluri, file.getName());
-								} catch (OWLOntologyCreationException | RepositoryException | RDFParseException
-										| RDFHandlerException | IOException e) {
-									// TODO Auto-generated catch block
-									e.printStackTrace();
-								}
-							} 
-						}
+						if(file.getName().endsWith(".ttl")||file.getName().endsWith("owl")) {
+							LOGGER.info("Loading " + file);
+							try {
+								String modeluri = m3.importModelToDatabase(file, true);
+								modelid_filename.put(modeluri, file.getName());
+							} catch (OWLOntologyCreationException | RepositoryException | RDFParseException
+									| RDFHandlerException | IOException e) {
+								// TODO Auto-generated catch block
+								e.printStackTrace();
+							}
+						} 
 					});
 				}else {
 					LOGGER.info("Loading " + i);
@@ -687,8 +689,10 @@ public class CommandLineInterface {
 					boolean isConsistent = true;
 					boolean isConformant = true;
 					LOGGER.info("processing "+filename+"\t"+modelIRI);
-					ModelContainer mc = m3.getModel(modelIRI);		
+					ModelContainer mc = m3.getModel(modelIRI);	
+					LOGGER.info("building inference provider "+filename+"\t"+modelIRI);
 					InferenceProvider ip = ipc.create(mc);
+					LOGGER.info("writing results, isConsistent = "+ip.isConsistent());
 					isConsistent = ip.isConsistent();
 					if(!isConsistent&&explanationOutputFile!=null) {
 						FileWriter explanations = new FileWriter(explanationOutputFile, true);
@@ -737,7 +741,7 @@ public class CommandLineInterface {
 		}finally{
 			basic_output.close();
 		}
-		
+
 	}
 
 
@@ -756,36 +760,36 @@ public class CommandLineInterface {
 		System.out.println(key+"\t"+value);
 		return value;
 	}
-	
+
 	public static void reportSystemParams() {
-		 /* Total number of processors or cores available to the JVM */
+		/* Total number of processors or cores available to the JVM */
 		LOGGER.info("Available processors (cores): " + 
-		  Runtime.getRuntime().availableProcessors());
+				Runtime.getRuntime().availableProcessors());
 
-		  /* Total amount of free memory available to the JVM */
+		/* Total amount of free memory available to the JVM */
 		LOGGER.info("Free memory (m bytes): " + 
-		  Runtime.getRuntime().freeMemory()/1048576);
+				Runtime.getRuntime().freeMemory()/1048576);
 
-		  /* This will return Long.MAX_VALUE if there is no preset limit */
-		  long maxMemory = Runtime.getRuntime().maxMemory()/1048576;
-		  /* Maximum amount of memory the JVM will attempt to use */
-		  LOGGER.info("Maximum memory (m bytes): " + 
-		  (maxMemory == Long.MAX_VALUE ? "no limit" : maxMemory));
+		/* This will return Long.MAX_VALUE if there is no preset limit */
+		long maxMemory = Runtime.getRuntime().maxMemory()/1048576;
+		/* Maximum amount of memory the JVM will attempt to use */
+		LOGGER.info("Maximum memory (m bytes): " + 
+				(maxMemory == Long.MAX_VALUE ? "no limit" : maxMemory));
 
-		  /* Total memory currently in use by the JVM */
-		  LOGGER.info("Total memory (m bytes): " + 
-		  Runtime.getRuntime().totalMemory()/1048576);
+		/* Total memory currently in use by the JVM */
+		LOGGER.info("Total memory (m bytes): " + 
+				Runtime.getRuntime().totalMemory()/1048576);
 
-		  /* Get a list of all filesystem roots on this system */
-		  File[] roots = File.listRoots();
+		/* Get a list of all filesystem roots on this system */
+		File[] roots = File.listRoots();
 
-		  /* For each filesystem root, print some info */
-		  for (File root : roots) {
-			  LOGGER.info("File system root: " + root.getAbsolutePath());
-			  LOGGER.info("Total space (bytes): " + root.getTotalSpace());
-			  LOGGER.info("Free space (bytes): " + root.getFreeSpace());
-			  LOGGER.info("Usable space (bytes): " + root.getUsableSpace());
-		  }
+		/* For each filesystem root, print some info */
+		for (File root : roots) {
+			LOGGER.info("File system root: " + root.getAbsolutePath());
+			LOGGER.info("Total space (bytes): " + root.getTotalSpace());
+			LOGGER.info("Free space (bytes): " + root.getFreeSpace());
+			LOGGER.info("Usable space (bytes): " + root.getUsableSpace());
+		}
 	}
 
 }

--- a/minerva-core/src/main/java/org/geneontology/minerva/validation/ShexValidationReport.java
+++ b/minerva-core/src/main/java/org/geneontology/minerva/validation/ShexValidationReport.java
@@ -77,4 +77,5 @@ public class ShexValidationReport extends ModelValidationReport{
 		}
 		return report;
 	}
+
 }

--- a/minerva-core/src/main/java/org/geneontology/minerva/validation/ShexValidator.java
+++ b/minerva-core/src/main/java/org/geneontology/minerva/validation/ShexValidator.java
@@ -32,6 +32,7 @@ import org.apache.jena.rdf.model.RDFNode;
 import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.rdf.model.StmtIterator;
 import org.apache.jena.vocabulary.RDFS;
+import org.apache.log4j.Logger;
 import org.semanticweb.owlapi.model.IRI;
 import org.semanticweb.owlapi.model.OWLClass;
 import org.semanticweb.owlapi.reasoner.OWLReasoner;
@@ -60,6 +61,7 @@ import fr.inria.lille.shexjava.validation.Typing;
  *
  */
 public class ShexValidator {
+	private static final Logger LOGGER = Logger.getLogger(ShexValidator.class);
 	public ShexSchema schema;
 	public Map<String, String> GoQueryMap;
 	public OWLReasoner tbox_reasoner;

--- a/minerva-lookup/src/main/java/org/bbop/golr/java/AbstractRetrieveGolr.java
+++ b/minerva-lookup/src/main/java/org/bbop/golr/java/AbstractRetrieveGolr.java
@@ -2,39 +2,49 @@ package org.bbop.golr.java;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.UnsupportedEncodingException;
 import java.net.HttpURLConnection;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 
+import org.apache.commons.httpclient.NameValuePair;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.http.client.entity.UrlEncodedFormEntity;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.utils.URIBuilder;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.message.BasicNameValuePair;
+import org.apache.http.util.EntityUtils;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonSyntaxException;
 
 public abstract class AbstractRetrieveGolr {
-	
+
 	protected static final Gson GSON = new GsonBuilder().create();
-	
+
 	private final String server;
 	private int retryCount;
-	
+
 	public AbstractRetrieveGolr(String server) {
 		this(server, 3);
 	}
-	
+
 	public AbstractRetrieveGolr(String server, int retryCount) {
 		this.server = server;
 		this.retryCount = retryCount;
 	}
-	
+
 	protected abstract boolean isIndentJson();
-	
+
 	protected abstract List<String> getRelevantFields();
 
 	/*
@@ -46,8 +56,8 @@ public abstract class AbstractRetrieveGolr {
 	&fq=document_category:%22ontology_class%22
 	&fq=is_obsolete:%22false%22
 	&fq=id:%22UniProtKB:P32241-1%22
-	
-	*/
+
+	 */
 	URI createGolrRequest(List<String []> tagvalues, String category, int start, int pagination) throws IOException {
 		try {
 			URIBuilder builder = new URIBuilder(server);
@@ -89,12 +99,64 @@ public abstract class AbstractRetrieveGolr {
 			throw new IOException("Could not build URI for Golr request", e);
 		}
 	}
+
+
+	HttpPost createGolrPostRequest(List<String []> tagvalues, String category, int start, int pagination) throws UnsupportedEncodingException {
+		HttpPost post = new HttpPost(server+"/select");
+		List<BasicNameValuePair> urlParameters = new ArrayList<>();
+		urlParameters.add(new BasicNameValuePair("username", "abc"));
+
+		urlParameters.add(new BasicNameValuePair("defType", "edismax"));
+		urlParameters.add(new BasicNameValuePair("qt", "standard"));
+		urlParameters.add(new BasicNameValuePair("wt", "json"));
+		if (isIndentJson()) {
+			urlParameters.add(new BasicNameValuePair("indent","on"));
+		}
+		urlParameters.add(new BasicNameValuePair("fl",StringUtils.join(getRelevantFields(), ',')));
+		urlParameters.add(new BasicNameValuePair("facet","false"));
+		urlParameters.add(new BasicNameValuePair("json.nl","arrarr"));
+		urlParameters.add(new BasicNameValuePair("q","*:*"));
+		urlParameters.add(new BasicNameValuePair("rows", Integer.toString(pagination)));
+		urlParameters.add(new BasicNameValuePair("start", Integer.toString(start)));
+		urlParameters.add(new BasicNameValuePair("fq", "document_category:\""+category+"\""));
+		for (String [] tagvalue : tagvalues) {
+			if (tagvalue.length == 2) {
+				urlParameters.add(new BasicNameValuePair("fq", tagvalue[0]+":\""+tagvalue[1]+"\""));
+			}
+			else if (tagvalue.length > 2) {
+				// if there is more than one value, assume that this is an OR query
+				StringBuilder value = new StringBuilder();
+				value.append(tagvalue[0]).append(":(");
+				for (int i = 1; i < tagvalue.length; i++) {
+					if (i > 1) {
+						value.append(" OR ");
+					}
+					value.append('"').append(tagvalue[i]).append('"');
+				}
+				value.append(')');
+				urlParameters.add(new BasicNameValuePair("fq", value.toString()));
+			}
+		}
+		post.setEntity(new UrlEncodedFormEntity(urlParameters));
+		return post;
+	}
+
+
+
+	protected String getJsonStringFromPost(HttpPost post) throws IOException {
+		
+		CloseableHttpClient httpClient = HttpClients.createDefault();
+		CloseableHttpResponse response = httpClient.execute(post);
+		String json = EntityUtils.toString(response.getEntity());
+	
+		return json;
+	}
 	
 	protected String getJsonStringFromUri(URI uri) throws IOException {
 		logRequest(uri);
 		return getJsonStringFromUri(uri, retryCount);
 	}
-	
+
 	protected String getJsonStringFromUri(URI uri, int retryCount) throws IOException {
 		final URL url = uri.toURL();
 		final HttpURLConnection connection;
@@ -102,6 +164,7 @@ public abstract class AbstractRetrieveGolr {
 		// setup and open (actual connection)
 		try {
 			connection = (HttpURLConnection) url.openConnection();
+			//	connection.setRequestMethod("POST");
 			connection.setInstanceFollowRedirects(true); // warning does not follow redirects from http to https
 			response = connection.getInputStream(); // opens the connection to the server
 		}
@@ -121,10 +184,10 @@ public abstract class AbstractRetrieveGolr {
 		if (status != 200) {
 			// try to check error stream
 			String errorMsg = getErrorMsg(connection);
-			
+
 			// construct message for exception
 			StringBuilder sb = new StringBuilder("Unexpected HTTP status code: "+status);
-			
+
 			if (errorMsg != null) {
 				sb.append(" Details: ");
 				sb.append(errorMsg);
@@ -132,7 +195,7 @@ public abstract class AbstractRetrieveGolr {
 			IOException e = new IOException(sb.toString());
 			return retryRequest(uri, e, retryCount);
 		}
-		
+
 		// try to detect charset
 		String contentType = connection.getHeaderField("Content-Type");
 		String charset = null;
@@ -174,7 +237,7 @@ public abstract class AbstractRetrieveGolr {
 		logRequestError(uri, e);
 		throw e;
 	}
-	
+
 	private static String getErrorMsg(HttpURLConnection connection) {
 		String errorMsg = null;
 		InputStream errorStream = null;
@@ -193,7 +256,7 @@ public abstract class AbstractRetrieveGolr {
 		}
 		return errorMsg;
 	}
-	
+
 	protected void defaultRandomWait() {
 		// wait a random interval between 400 and 1500 ms
 		randomWait(400, 1500);
@@ -209,23 +272,23 @@ public abstract class AbstractRetrieveGolr {
 		}
 	}
 
-	
+
 	protected void logRequest(URI uri) {
 		// do nothing
 		// hook to implement logging of requests
 	}
-	
+
 	protected void logRequestError(URI uri, IOException exception) {
 		// do nothing
 		// hook to implement logging of request errors
 	}
-	
+
 	protected void logRetry(URI uri, IOException exception, int remaining) {
 		// do nothing
 		// hook to implement logging of a retry
 	}
-	
-	
+
+
 	protected <T extends GolrEnvelope<?>> T parseGolrResponse(String response, Class<T> clazz) throws IOException {
 		try {
 			T envelope = GSON.fromJson(response, clazz);
@@ -240,22 +303,22 @@ public abstract class AbstractRetrieveGolr {
 			throw new IOException("Could not parse JSON response.", e);
 		}
 	}
-	
+
 	static class GolrEnvelope<T> {
 		GolrResponseHeader responseHeader;
 		GolrResponse<T> response;
 	}
-	
+
 	static class GolrResponseHeader {
 		String status;
 		String QTime;
 		Object params;
 	}
-	
+
 	static class GolrResponse<T> {
 		int numFound;
 		int start;
 		T[] docs;
 	}
-	
+
 }

--- a/minerva-lookup/src/main/java/org/bbop/golr/java/RetrieveGolrOntologyClass.java
+++ b/minerva-lookup/src/main/java/org/bbop/golr/java/RetrieveGolrOntologyClass.java
@@ -9,6 +9,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.apache.http.client.methods.HttpPost;
+
 public class RetrieveGolrOntologyClass extends AbstractRetrieveGolr {
 
 	static int PAGINATION_CHUNK_SIZE = 1000;
@@ -33,15 +35,14 @@ public class RetrieveGolrOntologyClass extends AbstractRetrieveGolr {
 
 	public Map<String, List<GolrOntologyClassDocument>> getGolrOntologyCls(Set<String> curies) throws IOException {
 		List<String[]> tagvalues = new ArrayList<String[]>();
-		String [] tagvalue = new String[2*curies.size()];
+		String [] tagvalue = new String[1+curies.size()];
 		int i = 0;
-		for(String curie : curies) {
-			int p1 = i; int p2 = i+1;
-			tagvalue[p1] = "annotation_class";
-			tagvalue[p2] = curie;
-			tagvalues.add(tagvalue);
-			i = i+2;
+		tagvalue[i] = "annotation_class";
+		for(String curie : curies) {	
+			i++;
+			tagvalue[i] = curie;
 		}
+		tagvalues.add(tagvalue);
 		final List<GolrOntologyClassDocument> documents = getGolrOntologyCls(tagvalues);
 		//remap 
 		Map<String, List<GolrOntologyClassDocument>> curie_response = new HashMap<String, List<GolrOntologyClassDocument>>();
@@ -69,8 +70,12 @@ public class RetrieveGolrOntologyClass extends AbstractRetrieveGolr {
 	}
 
 	public List<GolrOntologyClassDocument> getGolrOntologyCls(List<String []> tagvalues) throws IOException {
-		final URI uri = createGolrRequest(tagvalues, "ontology_class", 0, PAGINATION_CHUNK_SIZE);
-		final String jsonString = getJsonStringFromUri(uri);
+//		final URI uri = createGolrRequest(tagvalues, "ontology_class", 0, PAGINATION_CHUNK_SIZE);
+//		final String jsonString = getJsonStringFromUri(uri);
+		
+		final HttpPost post = createGolrPostRequest(tagvalues, "ontology_class", 0, PAGINATION_CHUNK_SIZE);
+		final String jsonString = getJsonStringFromPost(post);
+		
 		final GolrResponse<GolrOntologyClassDocument> response = parseGolrResponse(jsonString);
 		final List<GolrOntologyClassDocument> documents = new ArrayList<GolrOntologyClassDocument>(response.numFound);
 		documents.addAll(Arrays.<GolrOntologyClassDocument>asList(response.docs));

--- a/minerva-lookup/src/main/java/org/geneontology/minerva/lookup/CachingExternalLookupService.java
+++ b/minerva-lookup/src/main/java/org/geneontology/minerva/lookup/CachingExternalLookupService.java
@@ -2,6 +2,8 @@ package org.geneontology.minerva.lookup;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
@@ -73,6 +75,12 @@ public class CachingExternalLookupService implements ExternalLookupService {
 	@Override
 	public String toString() {
 		return "Caching("+service.toString()+")";
+	}
+
+	@Override
+	public Map<IRI, List<LookupEntry>> lookupBatch(Set<IRI> to_look_up) {
+		// TODO Auto-generated method stub
+		return null;
 	}
 	
 	

--- a/minerva-lookup/src/main/java/org/geneontology/minerva/lookup/CachingExternalLookupService.java
+++ b/minerva-lookup/src/main/java/org/geneontology/minerva/lookup/CachingExternalLookupService.java
@@ -1,6 +1,8 @@
 package org.geneontology.minerva.lookup;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -79,8 +81,24 @@ public class CachingExternalLookupService implements ExternalLookupService {
 
 	@Override
 	public Map<IRI, List<LookupEntry>> lookupBatch(Set<IRI> to_look_up) {
-		// TODO Auto-generated method stub
-		return null;
+		try {
+			Map<IRI, List<LookupEntry>> id_lookups = new HashMap<IRI, List<LookupEntry>>();
+			for(IRI id : to_look_up) {
+				 List<ExternalLookupService.LookupEntry> lookups = cache.get(id);
+				 if(lookups!=null) {
+					 id_lookups.put(id, lookups);
+				 }else {
+					 return null; //no partial results for now.  
+				 }
+			}
+			return id_lookups;
+		} catch (ExecutionException e) {
+			return null;
+		} catch (UncheckedExecutionException e) {
+			return null;
+		} catch (ExecutionError e) {
+			return null;
+		}
 	}
 	
 	

--- a/minerva-lookup/src/main/java/org/geneontology/minerva/lookup/CombinedExternalLookupService.java
+++ b/minerva-lookup/src/main/java/org/geneontology/minerva/lookup/CombinedExternalLookupService.java
@@ -3,6 +3,8 @@ package org.geneontology.minerva.lookup;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import org.apache.commons.lang3.StringUtils;
 import org.semanticweb.owlapi.model.IRI;
@@ -52,6 +54,12 @@ public class CombinedExternalLookupService implements ExternalLookupService {
 	@Override
 	public String toString() {
 		return "["+StringUtils.join(services, "|")+"]";
+	}
+
+	@Override
+	public Map<IRI, List<LookupEntry>> lookupBatch(Set<IRI> to_look_up) {
+		// TODO Auto-generated method stub
+		return null;
 	}
 
 	

--- a/minerva-lookup/src/main/java/org/geneontology/minerva/lookup/ExternalLookupService.java
+++ b/minerva-lookup/src/main/java/org/geneontology/minerva/lookup/ExternalLookupService.java
@@ -1,6 +1,8 @@
 package org.geneontology.minerva.lookup;
 
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import org.semanticweb.owlapi.model.IRI;
 
@@ -67,5 +69,9 @@ public interface ExternalLookupService {
 	 * @return entry
 	 */
 	public LookupEntry lookup(IRI id, String taxon);
+
+	public Map<IRI, List<LookupEntry>> lookupBatch(Set<IRI> to_look_up);
+
+	
 	
 }

--- a/minerva-lookup/src/main/java/org/geneontology/minerva/lookup/GolrExternalLookupService.java
+++ b/minerva-lookup/src/main/java/org/geneontology/minerva/lookup/GolrExternalLookupService.java
@@ -82,6 +82,9 @@ public class GolrExternalLookupService implements ExternalLookupService {
 			String curie = curieHandler.getCuri(iri);
 			curies.add(curie);
 			curie_iri.put(curie,  iri);
+			if(iri.toString().contains("WBGene00006923")) {
+				System.out.println("wormy ");
+			}
 		}
 		
 		try {
@@ -93,9 +96,15 @@ public class GolrExternalLookupService implements ExternalLookupService {
 				}
 				iri_lookups.put(curie_iri.get(id), result);
 			}
-		} catch (IOException e) {
-			// TODO Auto-generated catch block
-			e.printStackTrace();
+		} catch(IOException exception) {
+			if (LOG.isDebugEnabled()) {
+				LOG.debug("Error during retrieval for id: "+curies+" GOLR-URL: "+golrUrl, exception);
+			}
+			return null;
+		}
+		catch (Throwable exception) {
+			LOG.warn("Unexpected problem during Golr lookup for id: "+curies, exception);
+			throw exception;
 		}
 		 
 		return iri_lookups;

--- a/minerva-lookup/src/main/java/org/geneontology/minerva/lookup/GolrExternalLookupService.java
+++ b/minerva-lookup/src/main/java/org/geneontology/minerva/lookup/GolrExternalLookupService.java
@@ -4,8 +4,10 @@ import java.io.IOException;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.apache.log4j.Logger;
 import org.bbop.golr.java.RetrieveGolrBioentities;
@@ -13,6 +15,7 @@ import org.bbop.golr.java.RetrieveGolrOntologyClass;
 import org.bbop.golr.java.RetrieveGolrBioentities.GolrBioentityDocument;
 import org.bbop.golr.java.RetrieveGolrOntologyClass.GolrOntologyClassDocument;
 import org.geneontology.minerva.curie.CurieHandler;
+import org.geneontology.minerva.lookup.ExternalLookupService.LookupEntry;
 import org.semanticweb.owlapi.model.IRI;
 
 public class GolrExternalLookupService implements ExternalLookupService {
@@ -62,6 +65,40 @@ public class GolrExternalLookupService implements ExternalLookupService {
 		this.ontologyClient = ontologyClient;
 		this.golrUrl = golrUrl;
 		this.curieHandler = curieHandler;
+	}
+	
+	@Override
+	public Map<IRI, List<LookupEntry>> lookupBatch(Set<IRI> to_look_up){
+		Map<IRI, List<LookupEntry>> iri_lookups = new HashMap<IRI, List<LookupEntry>>();
+		//slow - replace with batch
+//		for(IRI iri : to_look_up) {
+//			List<LookupEntry> lookup = lookup(iri);
+//			iri_lookups.put(iri, lookup);
+//		}
+		
+		Set<String> curies = new HashSet<String>();
+		Map<String, IRI> curie_iri = new HashMap<String, IRI>();
+		for(IRI iri : to_look_up) {
+			String curie = curieHandler.getCuri(iri);
+			curies.add(curie);
+			curie_iri.put(curie,  iri);
+		}
+		
+		try {
+			Map<String, List<GolrOntologyClassDocument>> ontologyEntities = ontologyClient.getGolrOntologyCls(curies);
+			for(String id : ontologyEntities.keySet()) {
+				List<LookupEntry> result = new ArrayList<LookupEntry>();
+				for(GolrOntologyClassDocument doc : ontologyEntities.get(id)) {
+					result.add(new LookupEntry(curie_iri.get(id), doc.annotation_class_label, "ontology_class", doc.only_in_taxon, doc.isa_closure));
+				}
+				iri_lookups.put(curie_iri.get(id), result);
+			}
+		} catch (IOException e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		}
+		 
+		return iri_lookups;
 	}
 	
 	@Override

--- a/minerva-lookup/src/main/java/org/geneontology/minerva/lookup/GolrExternalLookupService.java
+++ b/minerva-lookup/src/main/java/org/geneontology/minerva/lookup/GolrExternalLookupService.java
@@ -70,21 +70,13 @@ public class GolrExternalLookupService implements ExternalLookupService {
 	@Override
 	public Map<IRI, List<LookupEntry>> lookupBatch(Set<IRI> to_look_up){
 		Map<IRI, List<LookupEntry>> iri_lookups = new HashMap<IRI, List<LookupEntry>>();
-		//slow - replace with batch
-//		for(IRI iri : to_look_up) {
-//			List<LookupEntry> lookup = lookup(iri);
-//			iri_lookups.put(iri, lookup);
-//		}
-		
+	
 		Set<String> curies = new HashSet<String>();
 		Map<String, IRI> curie_iri = new HashMap<String, IRI>();
 		for(IRI iri : to_look_up) {
 			String curie = curieHandler.getCuri(iri);
 			curies.add(curie);
 			curie_iri.put(curie,  iri);
-			if(iri.toString().contains("WBGene00006923")) {
-				System.out.println("wormy ");
-			}
 		}
 		
 		try {

--- a/minerva-lookup/src/main/java/org/geneontology/minerva/lookup/MonarchExternalLookupService.java
+++ b/minerva-lookup/src/main/java/org/geneontology/minerva/lookup/MonarchExternalLookupService.java
@@ -4,6 +4,8 @@ import java.io.IOException;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import org.apache.log4j.Logger;
 import org.bbop.golr.java.RetrieveGolrOntologyClass;
@@ -84,6 +86,12 @@ public class MonarchExternalLookupService implements ExternalLookupService {
 	@Override
 	public String toString() {
 		return "Monarch: "+monarchUrl;
+	}
+
+	@Override
+	public Map<IRI, List<LookupEntry>> lookupBatch(Set<IRI> to_look_up) {
+		// TODO Auto-generated method stub
+		return null;
 	}
 
 	

--- a/minerva-lookup/src/main/java/org/geneontology/minerva/lookup/TableLookupService.java
+++ b/minerva-lookup/src/main/java/org/geneontology/minerva/lookup/TableLookupService.java
@@ -5,6 +5,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.semanticweb.owlapi.model.IRI;
 
@@ -51,6 +52,12 @@ public class TableLookupService implements ExternalLookupService {
 	@Override
 	public String toString() {
 		return "table: "+entries.size();
+	}
+
+	@Override
+	public Map<IRI, List<LookupEntry>> lookupBatch(Set<IRI> to_look_up) {
+		// TODO Auto-generated method stub
+		return null;
 	}
 
 }

--- a/minerva-server/src/main/java/org/geneontology/minerva/server/StartUpTool.java
+++ b/minerva-server/src/main/java/org/geneontology/minerva/server/StartUpTool.java
@@ -263,10 +263,10 @@ public class StartUpTool {
 		// wrap the Golr service with a cache
 		if (conf.golrUrl != null) {
 			conf.lookupService = new GolrExternalLookupService(conf.golrUrl, conf.curieHandler, conf.useGolrUrlLogging);
-//			LOGGER.info("Setting up Golr cache with size: "+conf.golrCacheSize+" duration: "+
-//					conf.golrCacheDuration+" "+conf.golrCacheDurationUnit+
-//					" use url logging: "+conf.useGolrUrlLogging);
-//			conf.lookupService = new CachingExternalLookupService(conf.lookupService, conf.golrCacheSize, conf.golrCacheDuration, conf.golrCacheDurationUnit);
+			LOGGER.info("Setting up Golr cache with size: "+conf.golrCacheSize+" duration: "+
+					conf.golrCacheDuration+" "+conf.golrCacheDurationUnit+
+					" use url logging: "+conf.useGolrUrlLogging);
+			conf.lookupService = new CachingExternalLookupService(conf.lookupService, conf.golrCacheSize, conf.golrCacheDuration, conf.golrCacheDurationUnit);
 		}
 		if (conf.monarchUrl != null) {
 			conf.lookupService = new MonarchExternalLookupService(conf.monarchUrl, conf.curieHandler, conf.useGolrUrlLogging);

--- a/minerva-server/src/main/java/org/geneontology/minerva/server/StartUpTool.java
+++ b/minerva-server/src/main/java/org/geneontology/minerva/server/StartUpTool.java
@@ -263,10 +263,10 @@ public class StartUpTool {
 		// wrap the Golr service with a cache
 		if (conf.golrUrl != null) {
 			conf.lookupService = new GolrExternalLookupService(conf.golrUrl, conf.curieHandler, conf.useGolrUrlLogging);
-			LOGGER.info("Setting up Golr cache with size: "+conf.golrCacheSize+" duration: "+
-					conf.golrCacheDuration+" "+conf.golrCacheDurationUnit+
-					" use url logging: "+conf.useGolrUrlLogging);
-			conf.lookupService = new CachingExternalLookupService(conf.lookupService, conf.golrCacheSize, conf.golrCacheDuration, conf.golrCacheDurationUnit);
+//			LOGGER.info("Setting up Golr cache with size: "+conf.golrCacheSize+" duration: "+
+//					conf.golrCacheDuration+" "+conf.golrCacheDurationUnit+
+//					" use url logging: "+conf.useGolrUrlLogging);
+//			conf.lookupService = new CachingExternalLookupService(conf.lookupService, conf.golrCacheSize, conf.golrCacheDuration, conf.golrCacheDurationUnit);
 		}
 		if (conf.monarchUrl != null) {
 			conf.lookupService = new MonarchExternalLookupService(conf.monarchUrl, conf.curieHandler, conf.useGolrUrlLogging);

--- a/minerva-server/src/main/java/org/geneontology/minerva/server/handler/JsonOrJsonpBatchHandler.java
+++ b/minerva-server/src/main/java/org/geneontology/minerva/server/handler/JsonOrJsonpBatchHandler.java
@@ -99,7 +99,6 @@ public class JsonOrJsonpBatchHandler extends OperationsImpl implements M3BatchHa
 			return error(response, "The batch contains no requests: null value for request array", null);
 		}
 		try {
-			logger.info("returning m3batch server 102");
 			return m3Batch(response, requests, uid, providerGroups, useReasoner, isPrivileged);
 		} catch (InsufficientPermissionsException e) {
 			return error(response, e.getMessage(), null);
@@ -123,9 +122,7 @@ public class JsonOrJsonpBatchHandler extends OperationsImpl implements M3BatchHa
 			return error(response, "The batch contains no requests: null value for request", null);
 		}
 		try {
-			logger.info("server getting requests");
 			M3Request[] requests = MolecularModelJsonRenderer.parseFromJson(requestString, requestType);
-			logger.info("server preparing response 128 ");
 			return m3Batch(response, requests, uid, providerGroups, useReasoner, isPrivileged);
 		} catch (Exception e) {
 			return error(response, "Could not successfully handle batch request.", e);
@@ -205,35 +202,26 @@ public class JsonOrJsonpBatchHandler extends OperationsImpl implements M3BatchHa
 		boolean isConsistent = true;
 		boolean isConformant = true;
 		if (inferenceProviderCreator != null && useReasoner) {
-			logger.info("server building inference provider");
 			inferenceProvider = inferenceProviderCreator.create(values.model);
-			logger.info("server done building inference provider");
 			isConsistent = inferenceProvider.isConsistent();
 			response.setReasoned(true);
 			values.renderBulk = true; // to ensure that all individuals are in the response
-			logger.info("assembling validation results");
 			org.geneontology.minerva.validation.ValidationResultSet validations = inferenceProvider.getValidation_results();
-			logger.info("done assembling validation results");
 			isConformant = validations.allConformant();	
 		}
 
 		// create response.data
 		response.data = new ResponseData();
-		logger.info("server setting up json renderer");
 		final MolecularModelJsonRenderer renderer = createModelRenderer(values.model, externalLookupService, inferenceProvider, curieHandler);
-		logger.info("server done setting up json renderer");
 		if (values.renderBulk) {
 			// render complete model
-			logger.info("server render bulk");
 			JsonModel jsonModel = renderer.renderModel();
-			logger.info("server render bulk ini response data");
 			initResponseData(jsonModel, response.data);
 			response.signal = M3BatchResponse.SIGNAL_REBUILD;
 		}
 		else {
 			response.signal = M3BatchResponse.SIGNAL_MERGE;
 			// render individuals
-			logger.info("server render individuals");
 			if (values.relevantIndividuals.isEmpty() == false) {
 				Pair<JsonOwlIndividual[],JsonOwlFact[]> pair = renderer.renderIndividuals(values.relevantIndividuals);
 				response.data.individuals = pair.getLeft();
@@ -243,7 +231,6 @@ public class JsonOrJsonpBatchHandler extends OperationsImpl implements M3BatchHa
 			response.data.annotations = MolecularModelJsonRenderer.renderModelAnnotations(values.model.getAboxOntology(), curieHandler);
 			response.data.modelId = curieHandler.getCuri(values.model.getModelId());
 		}
-		logger.info("server adding other information");
 		// add other infos to data
 		if (!isConsistent) {
 			response.data.inconsistentFlag =  Boolean.TRUE;
@@ -257,7 +244,6 @@ public class JsonOrJsonpBatchHandler extends OperationsImpl implements M3BatchHa
 		if( response.message == null ){
 			response.message = "success";
 		}
-		logger.info("server sending response 260 \n"+response);
 		return response;
 	}
 

--- a/minerva-server/src/main/java/org/geneontology/minerva/server/inferences/InferenceProviderCreatorImpl.java
+++ b/minerva-server/src/main/java/org/geneontology/minerva/server/inferences/InferenceProviderCreatorImpl.java
@@ -111,19 +111,13 @@ public class InferenceProviderCreatorImpl implements InferenceProviderCreator {
 					//add root types for gene products.  
 					//TODO investigate performance impact
 					//tradefoff these queries versus loading all possible genes into tbox 
-					LOG.info("Adding root types");
 					temp_ont = addRootTypesToCopy(ont, shex.externalLookupService);
 					//do reasoning and validation on the enhanced model
-					LOG.info("Building reasoned model");
 					reasoner = rf.createReasoner(temp_ont);
-					LOG.info("Making inference and validation provider");
 					provider = MapInferenceProvider.create(reasoner, temp_ont, shex);
-					LOG.info("Done making inference provider");
 				}
 				finally {
-					LOG.info("releasing lock");
 					concurrentLock.release();
-					LOG.info("released");
 				}
 			}
 			return provider;
@@ -131,15 +125,12 @@ public class InferenceProviderCreatorImpl implements InferenceProviderCreator {
 		finally {
 			if (reasoner != null) {
 				reasoner.dispose();
-				LOG.info("reasoner disposed");
 			}
 			if (module != null) {
 				m.removeOntology(module);
-				LOG.info("removed ontology module");
 			}
 			if (temp_ont != null) {
 				m.removeOntology(temp_ont);
-				LOG.info("removed temp model");
 			}
 		}
 

--- a/minerva-server/src/main/java/org/geneontology/minerva/server/inferences/InferenceProviderCreatorImpl.java
+++ b/minerva-server/src/main/java/org/geneontology/minerva/server/inferences/InferenceProviderCreatorImpl.java
@@ -32,9 +32,9 @@ import uk.ac.manchester.cs.owlapi.modularity.ModuleType;
 import uk.ac.manchester.cs.owlapi.modularity.SyntacticLocalityModuleExtractor;
 
 public class InferenceProviderCreatorImpl implements InferenceProviderCreator {
-	
+
 	private final static Logger LOG = Logger.getLogger(InferenceProviderCreatorImpl.class);
-	
+
 	private final OWLReasonerFactory rf;
 	private final Semaphore concurrentLock;
 	private final boolean useSLME;
@@ -57,8 +57,8 @@ public class InferenceProviderCreatorImpl implements InferenceProviderCreator {
 		root_types.add("http://purl.obolibrary.org/obo/UBERON_0001062"); //anatomical entity
 	}
 	 */
-	
-	
+
+
 	InferenceProviderCreatorImpl(OWLReasonerFactory rf, int maxConcurrent, boolean useSLME, String name, MinervaShexValidator shex) {
 		super();
 		this.rf = rf;
@@ -78,15 +78,15 @@ public class InferenceProviderCreatorImpl implements InferenceProviderCreator {
 		}
 		return new InferenceProviderCreatorImpl(new ElkReasonerFactory(), 1, useSLME, name, shex);
 	}
-	
-//	public static InferenceProviderCreator createHermiT(MinervaShexValidator shex) {
-//		int maxConcurrent = Runtime.getRuntime().availableProcessors();
-//		return createHermiT(maxConcurrent, shex);
-//	}
-	
-//	public static InferenceProviderCreator createHermiT(int maxConcurrent, MinervaShexValidator shex) {
-//		return new InferenceProviderCreatorImpl(new org.semanticweb.HermiT.ReasonerFactory(), maxConcurrent, true, "Hermit-SLME", shex);
-//	}
+
+	//	public static InferenceProviderCreator createHermiT(MinervaShexValidator shex) {
+	//		int maxConcurrent = Runtime.getRuntime().availableProcessors();
+	//		return createHermiT(maxConcurrent, shex);
+	//	}
+
+	//	public static InferenceProviderCreator createHermiT(int maxConcurrent, MinervaShexValidator shex) {
+	//		return new InferenceProviderCreatorImpl(new org.semanticweb.HermiT.ReasonerFactory(), maxConcurrent, true, "Hermit-SLME", shex);
+	//	}
 
 	@Override
 	public InferenceProvider create(ModelContainer model) throws OWLOntologyCreationException, InterruptedException {
@@ -133,7 +133,7 @@ public class InferenceProviderCreatorImpl implements InferenceProviderCreator {
 				m.removeOntology(temp_ont);
 			}
 		}
-		
+
 	}
 
 	public static OWLOntology addRootTypesToCopy(OWLOntology asserted_ont, ExternalLookupService externalLookupService) throws OWLOntologyCreationException {
@@ -163,25 +163,29 @@ public class InferenceProviderCreatorImpl implements InferenceProviderCreator {
 		}		 
 		//look up all at once
 		Map<IRI, List<LookupEntry>> iri_lookup = externalLookupService.lookupBatch(to_look_up);
-		//add the identified root types on to the individuals in the model
-		for(OWLNamedIndividual i : individual_types.keySet()) {
-			for(IRI asserted_type : individual_types.get(i)) {
-				List<LookupEntry> lookup = iri_lookup.get(asserted_type);
-				if(lookup!=null&&!lookup.isEmpty()&&lookup.get(0).direct_parent_iri!=null) {
-					OWLClass parent_class = temp_ont.getOWLOntologyManager().getOWLDataFactory().getOWLClass(IRI.create(lookup.get(0).direct_parent_iri));	
-					OWLClassAssertionAxiom add_root = temp_ont.getOWLOntologyManager().getOWLDataFactory().getOWLClassAssertionAxiom(parent_class, i);
-					temp_ont.getOWLOntologyManager().addAxiom(temp_ont, add_root);
+		if(iri_lookup!=null) {
+			//add the identified root types on to the individuals in the model
+			for(OWLNamedIndividual i : individual_types.keySet()) {
+				for(IRI asserted_type : individual_types.get(i)) {
+					if(asserted_type==null) {
+						continue;
+					}
+					List<LookupEntry> lookup = iri_lookup.get(asserted_type);
+					if(lookup!=null&&!lookup.isEmpty()&&lookup.get(0).direct_parent_iri!=null) {
+						OWLClass parent_class = temp_ont.getOWLOntologyManager().getOWLDataFactory().getOWLClass(IRI.create(lookup.get(0).direct_parent_iri));	
+						OWLClassAssertionAxiom add_root = temp_ont.getOWLOntologyManager().getOWLDataFactory().getOWLClassAssertionAxiom(parent_class, i);
+						temp_ont.getOWLOntologyManager().addAxiom(temp_ont, add_root);
+					}
 				}
 			}
 		}
-		
 		return temp_ont;
 	}
-	
+
 	@Override
 	public String toString() {
 		return "InferenceProviderCreator: " + name;
 	}
 
-	
+
 }

--- a/minerva-server/src/main/java/org/geneontology/minerva/server/inferences/InferenceProviderCreatorImpl.java
+++ b/minerva-server/src/main/java/org/geneontology/minerva/server/inferences/InferenceProviderCreatorImpl.java
@@ -111,13 +111,19 @@ public class InferenceProviderCreatorImpl implements InferenceProviderCreator {
 					//add root types for gene products.  
 					//TODO investigate performance impact
 					//tradefoff these queries versus loading all possible genes into tbox 
+					LOG.info("Adding root types");
 					temp_ont = addRootTypesToCopy(ont, shex.externalLookupService);
 					//do reasoning and validation on the enhanced model
+					LOG.info("Building reasoned model");
 					reasoner = rf.createReasoner(temp_ont);
+					LOG.info("Making inference and validation provider");
 					provider = MapInferenceProvider.create(reasoner, temp_ont, shex);
+					LOG.info("Done making inference provider");
 				}
 				finally {
+					LOG.info("releasing lock");
 					concurrentLock.release();
+					LOG.info("released");
 				}
 			}
 			return provider;
@@ -125,12 +131,15 @@ public class InferenceProviderCreatorImpl implements InferenceProviderCreator {
 		finally {
 			if (reasoner != null) {
 				reasoner.dispose();
+				LOG.info("reasoner disposed");
 			}
 			if (module != null) {
 				m.removeOntology(module);
+				LOG.info("removed ontology module");
 			}
 			if (temp_ont != null) {
 				m.removeOntology(temp_ont);
+				LOG.info("removed temp model");
 			}
 		}
 

--- a/minerva-server/src/main/java/org/geneontology/minerva/server/inferences/InferenceProviderCreatorImpl.java
+++ b/minerva-server/src/main/java/org/geneontology/minerva/server/inferences/InferenceProviderCreatorImpl.java
@@ -108,7 +108,7 @@ public class InferenceProviderCreatorImpl implements InferenceProviderCreator {
 					}
 					//add root types for gene products.  
 					//TODO investigate performance impact
-					//tradefoff these queries versus loading all possible genes into tbox
+					//tradefoff these queries versus loading all possible genes into tbox 
 					temp_ont = addRootTypesToCopy(ont, shex.externalLookupService);
 					//do reasoning and validation on the enhanced model
 					reasoner = rf.createReasoner(temp_ont);
@@ -147,7 +147,11 @@ public class InferenceProviderCreatorImpl implements InferenceProviderCreator {
 				if(cls.isAnonymous()) {
 					continue;
 				}
-				List<LookupEntry> lookup = externalLookupService.lookup(cls.asOWLClass().getIRI());
+				IRI class_iri = cls.asOWLClass().getIRI();
+				if(class_iri.toString().contains("ECO")) {
+					continue; //this only deals with genes, chemicals, proteins, and complexes.  
+				}
+				List<LookupEntry> lookup = externalLookupService.lookup(class_iri);
 				if(lookup!=null&&!lookup.isEmpty()&&lookup.get(0).direct_parent_iri!=null) {
 					OWLClass parent_class = temp_ont.getOWLOntologyManager().getOWLDataFactory().getOWLClass(IRI.create(lookup.get(0).direct_parent_iri));	
 					OWLClassAssertionAxiom add_root = temp_ont.getOWLOntologyManager().getOWLDataFactory().getOWLClassAssertionAxiom(parent_class, individual);

--- a/minerva-server/src/main/java/org/geneontology/minerva/server/inferences/MapInferenceProvider.java
+++ b/minerva-server/src/main/java/org/geneontology/minerva/server/inferences/MapInferenceProvider.java
@@ -74,7 +74,6 @@ public class MapInferenceProvider implements InferenceProvider {
 		//shex
 		ShexValidationReport shex_validation = null;
 		if(shex.isActive()) {
-			LOGGER.info("Setting up shex validation");
 			//generate an RDF model
 			Model model = JenaOwlTool.getJenaModel(ont);
 			//add superclasses to types used in model 
@@ -89,9 +88,7 @@ public class MapInferenceProvider implements InferenceProvider {
 				e.printStackTrace();
 			}	
 		}
-		LOGGER.info("Building validation result set ");
 		ValidationResultSet all_validations = new ValidationResultSet(reasoner_validation, shex_validation);
-		LOGGER.info("Done building validation result set");
 		return new MapInferenceProvider(isConsistent, inferredTypes, inferredTypesWithIndirects, all_validations);
 	}
 

--- a/minerva-server/src/main/java/org/geneontology/minerva/server/inferences/MapInferenceProvider.java
+++ b/minerva-server/src/main/java/org/geneontology/minerva/server/inferences/MapInferenceProvider.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.apache.jena.rdf.model.Model;
+import org.apache.log4j.Logger;
 import org.geneontology.minerva.json.InferenceProvider;
 import org.geneontology.minerva.server.validation.MinervaShexValidator;
 import org.geneontology.minerva.util.JenaOwlTool;
@@ -21,7 +22,7 @@ import org.semanticweb.owlapi.model.OWLOntologyCreationException;
 import org.semanticweb.owlapi.reasoner.OWLReasoner;
 
 public class MapInferenceProvider implements InferenceProvider {
-
+	private static final Logger LOGGER = Logger.getLogger(InferenceProvider.class);
 	private final boolean isConsistent;
 	private final Map<OWLNamedIndividual, Set<OWLClass>> inferredTypes;
 	private final Map<OWLNamedIndividual, Set<OWLClass>> inferredTypesWithIndirects;
@@ -52,7 +53,7 @@ public class MapInferenceProvider implements InferenceProvider {
 				}
 				inferredTypes.put(individual, inferred);
 				//adding the rest of the types
-				//TODO consider filtering down to root types - depending on uses cases
+				//TODO consider filtering down to root types - depending on use cases
 				Set<OWLClass> all_inferred = new HashSet<>();
 				Set<OWLClass> all_flattened = r.getTypes(individual, false).getFlattened();
 				for (OWLClass cls : all_flattened) {
@@ -70,7 +71,6 @@ public class MapInferenceProvider implements InferenceProvider {
 			Violation i_v = new Violation("id of inconsistent node");
 			reasoner_validation.addViolation(i_v);
 		}
-
 		//shex
 		ShexValidationReport shex_validation = null;	
 		if(shex.isActive()) {

--- a/minerva-server/src/main/java/org/geneontology/minerva/server/inferences/MapInferenceProvider.java
+++ b/minerva-server/src/main/java/org/geneontology/minerva/server/inferences/MapInferenceProvider.java
@@ -72,21 +72,26 @@ public class MapInferenceProvider implements InferenceProvider {
 			reasoner_validation.addViolation(i_v);
 		}
 		//shex
-		ShexValidationReport shex_validation = null;	
+		ShexValidationReport shex_validation = null;
 		if(shex.isActive()) {
+			LOGGER.info("Setting up shex validation");
 			//generate an RDF model
 			Model model = JenaOwlTool.getJenaModel(ont);
 			//add superclasses to types used in model 
 			model = shex.enrichSuperClasses(model);	
 			try {
 				boolean stream_output_for_debug = false;
+				LOGGER.info("Running shex validation");
 				shex_validation = shex.runShapeMapValidation(model, stream_output_for_debug);
+				LOGGER.info("Done with shex validation");
 			} catch (Exception e) {
 				// TODO Auto-generated catch block
 				e.printStackTrace();
 			}	
 		}
+		LOGGER.info("Building validation result set ");
 		ValidationResultSet all_validations = new ValidationResultSet(reasoner_validation, shex_validation);
+		LOGGER.info("Done building validation result set");
 		return new MapInferenceProvider(isConsistent, inferredTypes, inferredTypesWithIndirects, all_validations);
 	}
 

--- a/minerva-server/src/main/java/org/geneontology/minerva/server/validation/MinervaShexValidator.java
+++ b/minerva-server/src/main/java/org/geneontology/minerva/server/validation/MinervaShexValidator.java
@@ -50,20 +50,5 @@ public class MinervaShexValidator extends ShexValidator {
 		this.externalLookupService = externalLookupService;
 	}
 	
-	@Override
-	public String getPreferredId(String node, Resource focus_node_resource) {
-		if(curieHandler!=null) {
-			node = curieHandler.getCuri(IRI.create(focus_node_resource.getURI()));
-		}
-		return node;
-	}
-	
-	@Override
-	public String getPreferredId(String node, IRI iri) {
-		if(curieHandler!=null) {
-			node = curieHandler.getCuri(iri);
-		}
-		return node;
-	}
 
 }

--- a/minerva-server/src/main/java/org/geneontology/minerva/server/validation/MinervaShexValidator.java
+++ b/minerva-server/src/main/java/org/geneontology/minerva/server/validation/MinervaShexValidator.java
@@ -36,7 +36,7 @@ public class MinervaShexValidator extends ShexValidator {
 	 * @throws Exception
 	 */
 	public MinervaShexValidator(String shexpath, String goshapemappath, CurieHandler curieHandler, OWLReasoner tbox_reasoner, ExternalLookupService externalLookupService) throws Exception {
-		super(shexpath, goshapemappath, tbox_reasoner);
+		super(shexpath, goshapemappath, tbox_reasoner, curieHandler);
 		this.externalLookupService = externalLookupService;
 	}
 
@@ -46,7 +46,7 @@ public class MinervaShexValidator extends ShexValidator {
 	 * @throws Exception
 	 */
 	public MinervaShexValidator(File shex_schema_file, File shex_map_file, CurieHandler curieHandler, OWLReasoner tbox_reasoner, ExternalLookupService externalLookupService) throws Exception {
-		super(shex_schema_file, shex_map_file, tbox_reasoner);
+		super(shex_schema_file, shex_map_file, tbox_reasoner, curieHandler);
 		this.externalLookupService = externalLookupService;
 	}
 	


### PR DESCRIPTION
This PR combines changes to the GOLR requests (POSTing single batch requests per model rather than multiple GETs) and an extension to the shex validation service that effectively CLOSEs the shapes listed in our shape map.  Also amended shex validation service such that all elements that were URIs are now Curies.  