### PR TITLE
take out all super types from response.  rendering took forever

### DIFF
--- a/minerva-core/src/main/java/org/geneontology/minerva/json/MolecularModelJsonRenderer.java
+++ b/minerva-core/src/main/java/org/geneontology/minerva/json/MolecularModelJsonRenderer.java
@@ -124,7 +124,7 @@ public class MolecularModelJsonRenderer {
 		JsonModel json = new JsonModel();
 		json.modelId = modelId;
 		// per-Individual
-		//TODO this loop is the slowest part of the service response time.  
+		//TODO this loop is the slowest part of the service response time. 
 		List<JsonOwlIndividual> iObjs = new ArrayList<JsonOwlIndividual>();
 		for (OWLNamedIndividual i : ont.getIndividualsInSignature()) {
 			iObjs.add(renderObject(i));
@@ -228,20 +228,22 @@ public class MolecularModelJsonRenderer {
 				json.inferredType = inferredTypeObjs.toArray(new JsonOwlObject[inferredTypeObjs.size()]);
 			}
 			//testing approach to adding additional type information to response
-			List<JsonOwlObject> inferredTypeObjsWithAll = new ArrayList<JsonOwlObject>();
-			//TODO this is particularly slow as there can be a lot of inferred types
-			Set<OWLClass> inferredTypesWithAll = inferenceProvider.getAllTypes(i);
-			// optimization, do not render inferences, if they are equal to the asserted ones
-			if (assertedTypes.equals(inferredTypesWithAll) == false) {
-				for(OWLClass c : inferredTypesWithAll) {
-					if (c.isBuiltIn() == false) {
-						inferredTypeObjsWithAll.add(renderObject(c));
-					}
-				}
-			}
-			if (inferredTypeObjsWithAll.isEmpty() == false) {
-				json.inferredTypeWithAll = inferredTypeObjsWithAll.toArray(new JsonOwlObject[inferredTypeObjsWithAll.size()]);
-			}
+			//this works but ends up going extremely slowly when a lot of inferences are happening
+			//since its not being consumed anywhere now, leaving it out speeds things up considerably
+//			List<JsonOwlObject> inferredTypeObjsWithAll = new ArrayList<JsonOwlObject>();
+//			//TODO this is particularly slow as there can be a lot of inferred types
+//			Set<OWLClass> inferredTypesWithAll = inferenceProvider.getAllTypes(i);
+//			// optimization, do not render inferences, if they are equal to the asserted ones
+//			if (assertedTypes.equals(inferredTypesWithAll) == false) {
+//				for(OWLClass c : inferredTypesWithAll) {
+//					if (c.isBuiltIn() == false) {
+//						inferredTypeObjsWithAll.add(renderObject(c));
+//					}
+//				}
+//			}
+//			if (inferredTypeObjsWithAll.isEmpty() == false) {
+//				json.inferredTypeWithAll = inferredTypeObjsWithAll.toArray(new JsonOwlObject[inferredTypeObjsWithAll.size()]);
+//			}
 			
 			
 		}


### PR DESCRIPTION
Since last fall, Minerva has been sending the full closure of types (all superclasses of each type associated with an instance) in the json response whenever the reasoner is on.  I thought this might be useful, but I don't think it is being used by anyone and it is really slowing down the response time when the reasoner is on.  

This commit takes that out of the response resulting in significant speed improvement.  If we want to add it back in, we should be more clever about limiting the types served up to only those needed by applications.  

If you are okay with this, lets merge and include with bug fix from earlier tonight.  