### PR TITLE
changing all root protein to chebi reference

### DIFF
--- a/minerva-converter/src/test/resources/go-lego-module.omn
+++ b/minerva-converter/src/test/resources/go-lego-module.omn
@@ -2588,11 +2588,11 @@ Class: OBO:GO_0005515
     
     EquivalentTo: 
         OBO:GO_0005488
-         and (OBO:RO_0002233 some OBO:PR_000000001)
+         and (OBO:RO_0002233 some OBO:CHEBI_36080)
     
     SubClassOf: 
         OBO:GO_0005488,
-        OBO:RO_0002233 some OBO:PR_000000001
+        OBO:RO_0002233 some OBO:CHEBI_36080
     
     
 Class: OBO:GO_0005539
@@ -4106,12 +4106,12 @@ Class: OBO:GO_0019538
     
     EquivalentTo: 
         OBO:GO_0008152
-         and (OBO:RO_0000057 some OBO:PR_000000001)
+         and (OBO:RO_0000057 some OBO:CHEBI_36080)
     
     SubClassOf: 
         OBO:GO_0043170,
         OBO:GO_0044238,
-        OBO:RO_0000057 some OBO:PR_000000001
+        OBO:RO_0000057 some OBO:CHEBI_36080
     
     
 Class: OBO:GO_0021501
@@ -9200,7 +9200,7 @@ Class: OBO:PATO_0002487
         OBO:PATO_0001236
     
     
-Class: OBO:PR_000000001
+Class: OBO:CHEBI_36080
 
     Annotations: 
         rdfs:label "protein"^^xsd:string

--- a/minerva-core/src/main/java/org/geneontology/minerva/BlazegraphOntologyManager.java
+++ b/minerva-core/src/main/java/org/geneontology/minerva/BlazegraphOntologyManager.java
@@ -313,10 +313,9 @@ public class BlazegraphOntologyManager {
 		for(String term : all.keySet()) {
 			Set<String> isa_closure = all.get(term);
 			String direct_parent_iri = null;
-			if(isa_closure.contains("http://purl.obolibrary.org/obo/CHEBI_36080")||isa_closure.contains("http://purl.obolibrary.org/obo/PR_000000001")) {
+			if(isa_closure.contains("http://purl.obolibrary.org/obo/CHEBI_36080")) {
 				//protein
-				//direct_parent_iri = "http://purl.obolibrary.org/obo/CHEBI_36080";
-				direct_parent_iri = "http://purl.obolibrary.org/obo/PR_000000001";
+				direct_parent_iri = "http://purl.obolibrary.org/obo/CHEBI_36080";
 			}else if(isa_closure.contains("http://purl.obolibrary.org/obo/CHEBI_33695")) {
 				//information biomacrolecule (gene, complex)
 				direct_parent_iri = "http://purl.obolibrary.org/obo/CHEBI_33695";

--- a/minerva-core/src/test/java/org/geneontology/minerva/BlazegraphOntologyManagerTest.java
+++ b/minerva-core/src/test/java/org/geneontology/minerva/BlazegraphOntologyManagerTest.java
@@ -125,10 +125,10 @@ public class BlazegraphOntologyManagerTest {
 	//Gene products
 //this is a little extreme.. it works but takes a minute.  Should never have to do this in a live search system
 //		//uniprot
-//		uri = "http://purl.obolibrary.org/obo/PR_000000001";
+//		uri = "http://purl.obolibrary.org/obo/CHEBI_36080";
 //		subs = onto_repo.getAllSubClasses(uri);
 //		//protein
-//		assertTrue("uniprot/Q13253 not subclass of PR_000000001 protein", subs.contains("http://identifiers.org/uniprot/Q13253")); 
+//		assertTrue("uniprot/Q13253 not subclass of http://purl.obolibrary.org/obo/CHEBI_36080 protein", subs.contains("http://identifiers.org/uniprot/Q13253")); 
 //		//"gene"..
 //		//zfin
 //		uri = "http://purl.obolibrary.org/obo/CHEBI_33695";
@@ -178,7 +178,6 @@ public class BlazegraphOntologyManagerTest {
 		uri = "http://identifiers.org/uniprot/Q13253";
 		supers = onto_repo.getAllSuperClasses(uri);
 		//protein
-		assertTrue("uniprot/Q13253 not subclass of PR_000000001 protein", supers.contains("http://purl.obolibrary.org/obo/PR_000000001")); 
 		assertTrue("uniprot/Q13253 not subclass of CHEBI_36080 protein", supers.contains("http://purl.obolibrary.org/obo/CHEBI_36080")); 
 		assertTrue("uniprot/Q13253 not subclass of CHEBI_36695 information biomacromolecule", supers.contains("http://purl.obolibrary.org/obo/CHEBI_33695"));
 		assertTrue("uniprot/Q13253 not subclass of CHEBI_24431 chemical entity", supers.contains("http://purl.obolibrary.org/obo/CHEBI_24431"));

--- a/minerva-server/src/test/resources/validate.shex
+++ b/minerva-server/src/test/resources/validate.shex
@@ -408,13 +408,12 @@ PREFIX results_in_remodeling_of: <http://purl.obolibrary.org/obo/RO_0002591>
   part_of: @<AnatomicalEntity> {0,1};
   adjacent_to: @<AnatomicalEntity> *;
   overlaps: @<AnatomicalEntity> *;
-  has_part:(@<InformationBiomacromolecule> OR  @<ProteinContainingComplex>) {0,1};
 } // rdfs:comment  "a cellular component"
 
 <ProteinContainingComplex> EXTRA a {
   a @<ProteinContainingComplexClass>;
   located_in: @<CellularComponent> {0,1};
-  has_part: @<InformationBiomacromolecule> *;
+  has_part: ( @<InformationBiomacromolecule> OR @<ProteinContainingComplex> ) *;
 } // rdfs:comment  "a protein complex"
 
 <ProteinContainingComplexClass> IRI @<OwlClass> AND EXTRA rdfs:subClassOf {


### PR DESCRIPTION
fixes problem detected in https://github.com/geneontology/minerva/pull/313
resulting from lack of inference step applied to go-lego including neo.  That found that PR_000000001 was equivalent to CHEBI_36080 .  All reference in minerva code now use the chebi uri.