### PR TITLE
removing /tmp/blazegraph.jnl references

### DIFF
--- a/minerva-core/src/test/java/org/geneontology/minerva/BlazegraphMolecularModelManagerTest.java
+++ b/minerva-core/src/test/java/org/geneontology/minerva/BlazegraphMolecularModelManagerTest.java
@@ -29,7 +29,7 @@ import static org.junit.Assert.*;
 
 public class BlazegraphMolecularModelManagerTest  {
 	private final CurieHandler curieHandler = DefaultCurieHandler.getDefaultHandler();
-	static final String go_lego_journal_file = "/tmp/blazegraph.jnl";
+	static final String go_lego_journal_file = "/tmp/test-go-lego-blazegraph.jnl";
 
 	@Rule
 	public TemporaryFolder folder = new TemporaryFolder();

--- a/minerva-core/src/test/java/org/geneontology/minerva/BlazegraphOntologyManagerTest.java
+++ b/minerva-core/src/test/java/org/geneontology/minerva/BlazegraphOntologyManagerTest.java
@@ -20,7 +20,7 @@ public class BlazegraphOntologyManagerTest {
 	//if the file isn't there, it will try to download it from 
 	//BlazegraphOntologyManager.http://skyhook.berkeleybop.org/issue-35-neo-test/products/blazegraph/blazegraph-go-lego.jnl.gz
 	//can override the download by providing the file at the specified location
-	static final String ontology_journal_file = "/tmp/blazegraph.jnl";
+	static final String ontology_journal_file = "/tmp/test-go-lego-blazegraph.jnl";
 	static BlazegraphOntologyManager onto_repo;
 	
 	/**

--- a/minerva-core/src/test/java/org/geneontology/minerva/MolecularModelManagerTest.java
+++ b/minerva-core/src/test/java/org/geneontology/minerva/MolecularModelManagerTest.java
@@ -23,7 +23,7 @@ import org.semanticweb.owlapi.apibinding.OWLManager;
 import org.semanticweb.owlapi.model.*;
 
 public class MolecularModelManagerTest {
-	static final String go_lego_journal_file = "/tmp/blazegraph.jnl";
+	static final String go_lego_journal_file = "/tmp/test-go-lego-blazegraph.jnl";
 	
 	// JUnit way of creating a temporary test folder
 	// will be deleted after the test has run, by JUnit.

--- a/minerva-core/src/test/java/org/geneontology/minerva/UndoAwareMolecularModelManagerTest.java
+++ b/minerva-core/src/test/java/org/geneontology/minerva/UndoAwareMolecularModelManagerTest.java
@@ -32,7 +32,7 @@ public class UndoAwareMolecularModelManagerTest  {
 	static MinervaOWLGraphWrapper g = null;
 	static CurieHandler curieHandler = DefaultCurieHandler.getDefaultHandler();
 	static UndoAwareMolecularModelManager m3 = null;
-	static final String go_lego_journal_file = "/tmp/blazegraph.jnl";
+	static final String go_lego_journal_file = "/tmp/test-go-lego-blazegraph.jnl";
 	
 	@Rule
     public TemporaryFolder folder = new TemporaryFolder();

--- a/minerva-server/src/test/java/org/geneontology/minerva/server/handler/BatchModelHandlerTest.java
+++ b/minerva-server/src/test/java/org/geneontology/minerva/server/handler/BatchModelHandlerTest.java
@@ -46,7 +46,7 @@ public class BatchModelHandlerTest {
 	private static UndoAwareMolecularModelManager models = null;
 	private static Set<OWLObjectProperty> importantRelations = null;
 	private final static DateGenerator dateGenerator = new DateGenerator();
-	static final String ontology_journal_file = "/tmp/blazegraph.jnl";
+	static final String ontology_journal_file = "/tmp/test-go-lego-blazegraph.jnl";
 	static final String uid = "test-user";
 	static final Set<String> providedBy = Collections.singleton("test-provider"); 
 	static final String intention = "test-intention";

--- a/minerva-server/src/test/java/org/geneontology/minerva/server/handler/DataPropertyTest.java
+++ b/minerva-server/src/test/java/org/geneontology/minerva/server/handler/DataPropertyTest.java
@@ -31,7 +31,7 @@ public class DataPropertyTest {
 	public TemporaryFolder folder = new TemporaryFolder();
 	
 	private final CurieHandler curieHandler = DefaultCurieHandler.getDefaultHandler();
-	static final String go_lego_journal_file = "/tmp/blazegraph.jnl";
+	static final String go_lego_journal_file = "/tmp/test-go-lego-blazegraph.jnl";
 	
 	private UndoAwareMolecularModelManager createM3(OWLOntology tbox) throws OWLOntologyCreationException, IOException {
 		UndoAwareMolecularModelManager mmm = new UndoAwareMolecularModelManager(tbox, curieHandler,

--- a/minerva-server/src/test/java/org/geneontology/minerva/server/handler/LocalServerTest.java
+++ b/minerva-server/src/test/java/org/geneontology/minerva/server/handler/LocalServerTest.java
@@ -40,7 +40,7 @@ public class LocalServerTest {
 	private static UndoAwareMolecularModelManager models = null;
 	private static Server server = null;
 	private static String urlPrefix;
-	static final String go_lego_journal_file = "/tmp/blazegraph.jnl";
+	static final String go_lego_journal_file = "/tmp/test-go-lego-blazegraph.jnl";
 
 
 	@BeforeClass

--- a/minerva-server/src/test/java/org/geneontology/minerva/server/handler/ModelEditTest.java
+++ b/minerva-server/src/test/java/org/geneontology/minerva/server/handler/ModelEditTest.java
@@ -33,7 +33,7 @@ public class ModelEditTest {
 	private static CurieHandler curieHandler = null;
 	private static JsonOrJsonpBatchHandler handler = null;
 	private static UndoAwareMolecularModelManager models = null;
-	static final String go_lego_journal_file = "/tmp/blazegraph.jnl";
+	static final String go_lego_journal_file = "/tmp/test-go-lego-blazegraph.jnl";
 
 	@BeforeClass
 	public static void setUpBeforeClass() throws Exception {

--- a/minerva-server/src/test/java/org/geneontology/minerva/server/handler/ModelReasonerTest.java
+++ b/minerva-server/src/test/java/org/geneontology/minerva/server/handler/ModelReasonerTest.java
@@ -35,7 +35,7 @@ public class ModelReasonerTest {
 	private static CurieHandler curieHandler = null;
 	private static JsonOrJsonpBatchHandler handler = null;
 	private static UndoAwareMolecularModelManager models = null;
-	static final String go_lego_journal_file = "/tmp/blazegraph.jnl";
+	static final String go_lego_journal_file = "/tmp/test-go-lego-blazegraph.jnl";
 	
 	@BeforeClass
 	public static void setUpBeforeClass() throws Exception {

--- a/minerva-server/src/test/java/org/geneontology/minerva/server/handler/ModelSearchHandlerTest.java
+++ b/minerva-server/src/test/java/org/geneontology/minerva/server/handler/ModelSearchHandlerTest.java
@@ -83,7 +83,7 @@ public class ModelSearchHandlerTest {
 	static final String ontologyIRI = "http://purl.obolibrary.org/obo/go/extensions/go-lego.owl";
 	static final String modelIdcurie = "http://model.geneontology.org/";
 	static final String modelIdPrefix = "gomodel";
-	static final String go_lego_journal_file = "/tmp/blazegraph.jnl";
+	static final String go_lego_journal_file = "/tmp/test-go-lego-blazegraph.jnl";
 	static OWLOntology tbox_ontology;
 	static CurieHandler curieHandler;	
 	static UndoAwareMolecularModelManager models;

--- a/minerva-server/src/test/java/org/geneontology/minerva/server/handler/ParallelModelReasonerTest.java
+++ b/minerva-server/src/test/java/org/geneontology/minerva/server/handler/ParallelModelReasonerTest.java
@@ -37,7 +37,7 @@ public class ParallelModelReasonerTest {
 	private static JsonOrJsonpBatchHandler handler = null;
 	private static UndoAwareMolecularModelManager models = null;
 	private static CountingCachingInferenceProvider ipc;
-	static final String go_lego_journal_file = "/tmp/blazegraph.jnl";
+	static final String go_lego_journal_file = "/tmp/test-go-lego-blazegraph.jnl";
 	
 	@BeforeClass
 	public static void setUpBeforeClass() throws Exception {

--- a/minerva-server/src/test/java/org/geneontology/minerva/server/handler/TaxonHandlerTest.java
+++ b/minerva-server/src/test/java/org/geneontology/minerva/server/handler/TaxonHandlerTest.java
@@ -87,7 +87,7 @@ public class TaxonHandlerTest {
 	static final String ontologyIRI = "http://purl.obolibrary.org/obo/go/extensions/go-lego.owl";
 	static final String modelIdcurie = "http://model.geneontology.org/";
 	static final String modelIdPrefix = "gomodel";
-	static final String go_lego_journal_file = "/tmp/blazegraph.jnl";
+	static final String go_lego_journal_file = "/tmp/test-go-lego-blazegraph.jnl";
 	static OWLOntology tbox_ontology;
 	static CurieHandler curieHandler;	
 	static TaxonHandler taxonHandler;

--- a/minerva-server/src/test/java/org/geneontology/minerva/server/validation/ValidationTest.java
+++ b/minerva-server/src/test/java/org/geneontology/minerva/server/validation/ValidationTest.java
@@ -53,7 +53,7 @@ import com.google.common.collect.Sets;
 public class ValidationTest {
 	private static final Logger LOGGER = Logger.getLogger(ValidationTest.class);
 	static final String ontologyIRI = "http://purl.obolibrary.org/obo/go/extensions/go-lego.owl";
-	static final String go_lego_journal_file = "/tmp/blazegraph.jnl";
+	static final String go_lego_journal_file = "/tmp/test-go-lego-blazegraph.jnl";
 	static final String catalog = "src/test/resources/ontology/catalog-for-validation.xml";
 	static final String modelIdcurie = "http://model.geneontology.org/";
 	static final String modelIdPrefix = "gomodel";


### PR DESCRIPTION
This ought to go into that config file and not get spread all over..  Someday will do that.  For now just avoiding the likely conflict.  
Regarding:  https://github.com/geneontology/minerva/pull/316#issuecomment-623770972