### PR TITLE
I think this corrects #335

### DIFF
--- a/minerva-converter/src/main/java/org/geneontology/minerva/legacy/sparql/GPADSPARQLExport.java
+++ b/minerva-converter/src/main/java/org/geneontology/minerva/legacy/sparql/GPADSPARQLExport.java
@@ -194,6 +194,7 @@ public class GPADSPARQLExport {
 		Map<String, String> modelAnnotations = new HashMap<>();
 		while (result.hasNext()) {
 			QuerySolution qs = result.next();
+			//"http://therules.org" 
 			if (qs.get("model_state") != null) {
 				String modelState = qs.getLiteral("model_state").getLexicalForm();
 				modelAnnotations.put("model-state", modelState);
@@ -202,7 +203,7 @@ public class GPADSPARQLExport {
 				String providedBy = qs.getLiteral("provided_by").getLexicalForm();
 				modelAnnotations.put("assigned-by", providedBy);
 			}
-			break;
+			//break;
 		}
 		return modelAnnotations;
 	}

--- a/minerva-core/src/main/java/org/geneontology/minerva/CoreMolecularModelManager.java
+++ b/minerva-core/src/main/java/org/geneontology/minerva/CoreMolecularModelManager.java
@@ -316,6 +316,7 @@ public abstract class CoreMolecularModelManager<METADATA> {
 			// Using model's ontology IRI so that a spurious different ontology declaration triple isn't added
 		//	OWLOntology schemaOntology = OWLManager.createOWLOntologyManager().createOntology(getOntology().getRBoxAxioms(Imports.INCLUDED), modelId);
 		// I think the re-use of the model IRI as the IRI of the rule ontology has some weird effects on the model in question, rendering its contents inaccesible.  
+		//this influences GPAD export
 			OWLOntologyManager tmp_man = OWLManager.createOWLOntologyManager();
 			OWLOntology schemaOntology = tmp_man.createOntology(IRI.create("http://therules.org"));
 			Set<OWLAxiom> owl_rules = getOntology().getRBoxAxioms(Imports.INCLUDED);


### PR DESCRIPTION
There is a method in the GPAD sparql export that gathers model annotations such as state.  This was getting confused because, at that point in the code, the RDF for the model also contains the RDF for all the Arachne rules.  See comment in CoreMMM .