### PR TITLE
Shex closed impl bug fix

### DIFF
--- a/minerva-core/src/main/java/org/geneontology/minerva/model/GoCamModel.java
+++ b/minerva-core/src/main/java/org/geneontology/minerva/model/GoCamModel.java
@@ -57,15 +57,25 @@ public class GoCamModel extends ProvenanceAnnotated{
 			if(types!=null) {
 				if(types.contains(mf.getIRI().toString())||types.contains(me.getIRI().toString())) {
 					ActivityUnit unit = new ActivityUnit(ind, ont, this);
-					activities.add(unit);
-					ind_entity.put(ind, unit);
-					for(OWLObjectProperty prop : unit.causal_out.keySet()) {
-						Integer np = causal_count.get(prop);
-						if(np==null) {
-							np = 0;
+					
+					boolean skip = false;
+					for(String comment : unit.getComments()){
+						if(comment.contains("reaction from external pathway")) {
+							skip = true;
+							break;
 						}
-						np++;
-						causal_count.put(prop, np);
+					}
+					if(!skip) {
+						activities.add(unit);
+						ind_entity.put(ind, unit);
+						for(OWLObjectProperty prop : unit.causal_out.keySet()) {
+							Integer np = causal_count.get(prop);
+							if(np==null) {
+								np = 0;
+							}
+							np++;
+							causal_count.put(prop, np);
+						}
 					}
 				}
 			}

--- a/minerva-core/src/main/java/org/geneontology/minerva/validation/ShexValidator.java
+++ b/minerva-core/src/main/java/org/geneontology/minerva/validation/ShexValidator.java
@@ -191,6 +191,7 @@ public class ShexValidator {
 								extra_violations = checkForExtraProperties(node, test_model, shape_label, all_typed);
 								if(extra_violations!=null&&!extra_violations.isEmpty()) {
 									r.addViolations(extra_violations);
+									all_good = false;
 								}
 							} catch (IOException e) {
 								// TODO Auto-generated catch block

--- a/minerva-core/src/test/resources/validation/go-cam-shapes.shex
+++ b/minerva-core/src/test/resources/validation/go-cam-shapes.shex
@@ -448,10 +448,10 @@ PREFIX results_in_remodeling_of: <http://purl.obolibrary.org/obo/RO_0002591>
   overlaps: @<AnatomicalEntity> *;
 } // rdfs:comment  "a cellular component"
 
-<ProteinContainingComplex> EXTRA a {
+<ProteinContainingComplex> @<GoCamEntity> AND EXTRA a {
   a @<ProteinContainingComplexClass>;
   located_in: @<AnatomicalEntity> {0,1};
-  has_part: @<InformationBiomacromolecule> *;
+  has_part: ( @<InformationBiomacromolecule> OR @<ProteinContainingComplex>) *;
 } // rdfs:comment  "a protein complex"
 
 <ProteinContainingComplexClass> IRI @<OwlClass> AND EXTRA rdfs:subClassOf {
@@ -489,7 +489,7 @@ PREFIX results_in_remodeling_of: <http://purl.obolibrary.org/obo/RO_0002591>
   rdfs:subClassOf [ GoEvidence: ] ;
 }
 
-<Evidence> @<ProvenanceAnnotated> AND EXTRA a  {
+<Evidence> @<GoCamEntity> AND EXTRA a  {
   a @<EvidenceClass> {1};
   source: xsd:string {1};
   with: xsd:string {0,1}

--- a/minerva-server/src/test/resources/validate.shex
+++ b/minerva-server/src/test/resources/validate.shex
@@ -52,6 +52,7 @@ PREFIX GoMovementOfCellOrSubcellularComponent: <http://purl.obolibrary.org/obo/G
 PREFIX GoProteinContainingComplexRemodeling: <http://purl.obolibrary.org/obo/GO_0034367>
 PREFIX GoPatternSpecificationProcess: <http://purl.obolibrary.org/obo/GO_0007389>
 PREFIX GoMolecularFunction: <http://purl.obolibrary.org/obo/GO_0003674>
+prefix GoMolecularEvent: <http://purl.obolibrary.org/obo/go/extensions/reacto.owl#molecular_event>
 PREFIX GoTransporterActivity: <http://purl.obolibrary.org/obo/GO_0005215>
 PREFIX GoChemicalEntity: <http://purl.obolibrary.org/obo/CHEBI_24431>
 PREFIX GoEvidence: <http://purl.obolibrary.org/obo/ECO_0000000>
@@ -157,9 +158,9 @@ PREFIX results_in_remodeling_of: <http://purl.obolibrary.org/obo/RO_0002591>
   transports_or_maintains_localization_of: ( @<InformationBiomacromolecule> OR @<ProteinContainingComplex> ) *;
   has_target_end_location: @<AnatomicalEntity> {0,1};
   has_target_start_location: @<AnatomicalEntity> {0,1};
-  causally_upstream_of: ( @<BiologicalProcess> OR @<MolecularFunction> ) *;
-  causally_upstream_of_negative_effect: ( @<BiologicalProcess> OR @<MolecularFunction> ) *;
-  causally_upstream_of_positive_effect: ( @<BiologicalProcess> OR @<MolecularFunction> ) *;
+  causally_upstream_of: ( @<BiologicalProcess> OR @<MolecularFunction> OR @<MolecularEvent> ) *;
+  causally_upstream_of_negative_effect: ( @<BiologicalProcess> OR @<MolecularFunction> OR @<MolecularEvent> ) *;
+  causally_upstream_of_positive_effect: ( @<BiologicalProcess> OR @<MolecularFunction> OR @<MolecularEvent> ) *;
   regulates: @<BiologicalProcess> *;
   negatively_regulates: @<BiologicalProcess> *;
   positively_regulates: @<BiologicalProcess> *;
@@ -338,6 +339,18 @@ PREFIX results_in_remodeling_of: <http://purl.obolibrary.org/obo/RO_0002591>
   owl:complementOf @<MolecularFunctionClass>
 }
 
+<MolecularEventClass> IRI @<OwlClass> AND EXTRA rdfs:subClassOf {
+  rdfs:subClassOf [ GoMolecularEvent: ] ;
+}
+
+<NegatedMolecularEventClass> BNode @<OwlClass> AND {
+  owl:complementOf @<MolecularEventClass>
+}
+
+<MolecularEvent> @<GoCamEntity> AND EXTRA a {
+  a ( @<MolecularEventClass> OR @<NegatedMolecularEventClass> ) {1};
+}
+
 <MolecularFunction> @<GoCamEntity> AND EXTRA a {
   a ( @<MolecularFunctionClass> OR @<NegatedMolecularFunctionClass> ) {1};
   enabled_by:  ( @<InformationBiomacromolecule> OR @<ProteinContainingComplex> ) {0,1};
@@ -345,19 +358,19 @@ PREFIX results_in_remodeling_of: <http://purl.obolibrary.org/obo/RO_0002591>
   occurs_in: @<AnatomicalEntity> {0,1};
   has_output: ( @<ChemicalEntity> OR @<ProteinContainingComplex> ) *;
   has_input: ( @<ChemicalEntity> OR @<ProteinContainingComplex> ) *;
-  directly_provides_input_for: @<MolecularFunction> *;
-  regulates: @<MolecularFunction> *;
-  negatively_regulates: @<MolecularFunction> *;
-  positively_regulates: @<MolecularFunction> *;
-  directly_regulates: @<MolecularFunction> *;
-  directly_negatively_regulates: @<MolecularFunction> *;
-  directly_positively_regulates: @<MolecularFunction> *;
-  causally_upstream_of_or_within: @<BiologicalProcess> *;
+  directly_provides_input_for: ( @<MolecularFunction> OR @<MolecularEvent> ) *;
+  regulates: ( @<MolecularFunction> OR @<MolecularEvent> ) *;
+  negatively_regulates: ( @<MolecularFunction> OR @<MolecularEvent> ) *;
+  positively_regulates: ( @<MolecularFunction> OR @<MolecularEvent> ) *;
+  directly_regulates: ( @<MolecularFunction> OR @<MolecularEvent> ) *;
+  directly_negatively_regulates: ( @<MolecularFunction> OR @<MolecularEvent> ) *;
+  directly_positively_regulates: ( @<MolecularFunction> OR @<MolecularEvent> ) *;
+  causally_upstream_of_or_within: ( @<MolecularFunction> OR @<MolecularEvent> OR @<BiologicalProcess> ) *;
   causally_upstream_of_or_within_negative_effect: @<BiologicalProcess> *;
   causally_upstream_of_or_within_positive_effect: @<BiologicalProcess> *;
-  causally_upstream_of: ( @<BiologicalProcess> OR @<MolecularFunction> ) *;
-  causally_upstream_of_negative_effect: ( @<BiologicalProcess> OR @<MolecularFunction> ) *;
-  causally_upstream_of_positive_effect: ( @<BiologicalProcess> OR @<MolecularFunction> ) *;
+  causally_upstream_of: ( @<BiologicalProcess> OR @<MolecularFunction> OR @<MolecularEvent> ) *;
+  causally_upstream_of_negative_effect: ( @<BiologicalProcess> OR @<MolecularFunction> OR @<MolecularEvent> ) *;
+  causally_upstream_of_positive_effect: ( @<BiologicalProcess> OR @<MolecularFunction> OR @<MolecularEvent> ) *;
   happens_during: ( @<BiologicalPhase> OR @<LifeCycleStage> OR @<PlantStructureDevelopmentStage> ) *;
 } // rdfs:comment  "A molecular function"
 
@@ -435,10 +448,10 @@ PREFIX results_in_remodeling_of: <http://purl.obolibrary.org/obo/RO_0002591>
   overlaps: @<AnatomicalEntity> *;
 } // rdfs:comment  "a cellular component"
 
-<ProteinContainingComplex> EXTRA a {
+<ProteinContainingComplex> @<GoCamEntity> AND EXTRA a {
   a @<ProteinContainingComplexClass>;
   located_in: @<AnatomicalEntity> {0,1};
-  has_part: @<InformationBiomacromolecule> *;
+  has_part: ( @<InformationBiomacromolecule> OR @<ProteinContainingComplex>) *;
 } // rdfs:comment  "a protein complex"
 
 <ProteinContainingComplexClass> IRI @<OwlClass> AND EXTRA rdfs:subClassOf {
@@ -476,7 +489,7 @@ PREFIX results_in_remodeling_of: <http://purl.obolibrary.org/obo/RO_0002591>
   rdfs:subClassOf [ GoEvidence: ] ;
 }
 
-<Evidence> @<ProvenanceAnnotated> AND EXTRA a  {
+<Evidence> @<GoCamEntity> AND EXTRA a  {
   a @<EvidenceClass> {1};
   source: xsd:string {1};
   with: xsd:string {0,1}


### PR DESCRIPTION
this is an improvement to the shex validator.  it will now correctly fail validation when property assertions are added that are not specified in the Shex Shape corresponding to rdf type of the node being validated.  

there is also a bug fix that should clean up some of the cascading errors when something does not validate. 