### PR TITLE
using git-commit-plugin that is compatible with java8

### DIFF
--- a/minerva-cli/pom.xml
+++ b/minerva-cli/pom.xml
@@ -14,7 +14,7 @@
 			<plugin>
 				<groupId>pl.project13.maven</groupId>
 				<artifactId>git-commit-id-plugin</artifactId>
-				<version>2.1.13</version>
+                                <version>4.0.3</version>
 				<executions>
 					<execution>
 						<id>git-commit-id</id>


### PR DESCRIPTION
a) see compatibility chart https://github.com/git-commit-id/git-commit-id-maven-plugin
b) with this version  we can build minerva-cli when using docker build.