### PR TITLE
Added ART for stored model

### DIFF
--- a/minerva-core/src/main/java/org/geneontology/minerva/BlazegraphMolecularModelManager.java
+++ b/minerva-core/src/main/java/org/geneontology/minerva/BlazegraphMolecularModelManager.java
@@ -551,9 +551,12 @@ public class BlazegraphMolecularModelManager<METADATA> extends CoreMolecularMode
 		}
 	}
 
-
 	@Override
 	public OWLOntology loadModelABox(IRI modelId) throws OWLOntologyCreationException {
+		return loadModelABox(modelId, null);
+	}
+	@Override
+	public OWLOntology loadModelABox(IRI modelId, OWLOntologyManager manager) throws OWLOntologyCreationException {
 		LOG.info("Load model abox: " + modelId + " from database");
 		try {
 			BigdataSailRepositoryConnection connection = repo.getReadOnlyConnection();
@@ -568,7 +571,13 @@ public class BlazegraphMolecularModelManager<METADATA> extends CoreMolecularMode
 						connection.getStatements(null, null, null, false, new URIImpl(modelId.toString()));
 				//setting minimal to true will give an OWL abox with triples that won't be connected to the tbox, hence e.g. object properties might not be recognized.  
 				boolean minimal = true;
-				OWLOntology abox = loadOntologyDocumentSource(new RioMemoryTripleSource(statements), minimal);
+				OWLOntology abox;
+				if(manager ==null) {
+					abox = loadOntologyDocumentSource(new RioMemoryTripleSource(statements), minimal);
+				} else {
+					abox = loadOntologyDocumentSource(new RioMemoryTripleSource(statements), minimal, manager);
+				}
+			
 				statements.close();
 				abox = postLoadFileFilter(abox);
 				return abox;

--- a/minerva-core/src/main/java/org/geneontology/minerva/CoreMolecularModelManager.java
+++ b/minerva-core/src/main/java/org/geneontology/minerva/CoreMolecularModelManager.java
@@ -840,6 +840,14 @@ public abstract class CoreMolecularModelManager<METADATA> {
 	 * @throws OWLOntologyCreationException
 	 */
 	protected abstract OWLOntology loadModelABox(IRI modelId) throws OWLOntologyCreationException;
+	
+	/**
+	 * @param modelId
+	 * @param manager
+	 * @return ontology
+	 * @throws OWLOntologyCreationException
+	 */
+	protected abstract OWLOntology loadModelABox(IRI modelId, OWLOntologyManager manager) throws OWLOntologyCreationException;
 
 	/**
 	 * @param id

--- a/minerva-server/.gitignore
+++ b/minerva-server/.gitignore
@@ -1,1 +1,2 @@
 target/
+.temp*

--- a/minerva-server/src/main/java/org/geneontology/minerva/server/StartUpTool.java
+++ b/minerva-server/src/main/java/org/geneontology/minerva/server/StartUpTool.java
@@ -451,12 +451,14 @@ public class StartUpTool {
 		//		JsonOrJsonpSeedHandler seedHandler = new JsonOrJsonpSeedHandler(models, conf.defaultModelState, conf.golrSeedUrl, ecoMapper );
 	//	SPARQLHandler sparqlHandler = new SPARQLHandler(models, conf.sparqlEndpointTimeout);
 		ModelSearchHandler searchHandler = new ModelSearchHandler(models);
+		ModelARTHandler artHandler = new ModelARTHandler(models, ipc);
+
 		LocalDate d = LocalDate.now();
 		LocalTime t = LocalTime.now(); 
 		String startup = d.toString()+" "+t.toString();
 		StatusHandler statusHandler = new StatusHandler(conf, ont_annos, startup); 
 		TaxonHandler taxonHandler = new TaxonHandler(models);
-		resourceConfig = resourceConfig.registerInstances(batchHandler, searchHandler, statusHandler, taxonHandler);
+		resourceConfig = resourceConfig.registerInstances(batchHandler, searchHandler,artHandler, statusHandler, taxonHandler);
 
 		// setup jetty server port, buffers and context path
 		Server server = new Server();

--- a/minerva-server/src/main/java/org/geneontology/minerva/server/handler/ModelARTHandler.java
+++ b/minerva-server/src/main/java/org/geneontology/minerva/server/handler/ModelARTHandler.java
@@ -1,0 +1,161 @@
+/**
+ * 
+ */
+package org.geneontology.minerva.server.handler;
+
+import static org.geneontology.minerva.server.handler.OperationsTools.createModelRenderer;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.FormParam;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+
+import org.apache.commons.io.IOUtils;
+import org.geneontology.minerva.BlazegraphMolecularModelManager;
+import org.geneontology.minerva.BlazegraphOntologyManager;
+import org.geneontology.minerva.ModelContainer;
+import org.geneontology.minerva.MolecularModelManager.UnknownIdentifierException;
+import org.geneontology.minerva.curie.CurieHandler;
+import org.geneontology.minerva.json.InferenceProvider;
+import org.geneontology.minerva.json.JsonModel;
+import org.geneontology.minerva.json.MolecularModelJsonRenderer;
+import org.geneontology.minerva.server.handler.M3BatchHandler.M3BatchResponse;
+import org.geneontology.minerva.server.handler.M3BatchHandler.M3BatchResponse.ResponseData;
+import org.geneontology.minerva.server.inferences.InferenceProviderCreator;
+import org.openrdf.query.Binding;
+import org.openrdf.query.BindingSet;
+import org.openrdf.query.MalformedQueryException;
+import org.openrdf.query.QueryEvaluationException; 
+import org.openrdf.query.QueryResult;
+import org.openrdf.query.TupleQueryResult;
+import org.openrdf.repository.RepositoryException;
+import org.semanticweb.owlapi.apibinding.OWLManager;
+import org.semanticweb.owlapi.model.IRI;
+import org.semanticweb.owlapi.model.OWLAxiom;
+import org.semanticweb.owlapi.model.OWLNamedIndividual;
+import org.semanticweb.owlapi.model.OWLOntology;
+import org.semanticweb.owlapi.model.OWLOntologyCreationException;
+import org.semanticweb.owlapi.model.OWLOntologyManager;
+import org.semanticweb.owlapi.model.parameters.OntologyCopy;
+
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * Gets Model readonly data for Annotation Review Tool
+ * Uses Jersey + JSONP
+ *
+ *
+ */
+@Path("/search/stored") //using store endpoint temporarily because thats what barista allows
+public class ModelARTHandler {
+
+	private final BlazegraphMolecularModelManager<?> m3;
+	private final BlazegraphOntologyManager go_lego;
+	private final CurieHandler curieHandler;
+	private final InferenceProviderCreator ipc;
+	/**
+	 * 
+	 */
+	public ModelARTHandler(BlazegraphMolecularModelManager<?> m3, InferenceProviderCreator ipc) {
+		this.m3 = m3;
+		this.go_lego  = m3.getGolego_repo();
+		this.curieHandler = m3.getCuriHandler();
+		this.ipc = ipc;
+	}
+
+	public class ModelArtResult {
+		private String id;
+		private JsonModel storedModel;
+		private JsonModel activeModel;
+		private JsonModel diffModel;
+
+		public String getId() {
+			return id;
+		}
+		
+		public void setId(String id) {
+			this.id = id;
+		}
+		
+		public void setStoredModel(JsonModel storedModel) {
+			this.storedModel = storedModel;
+		}
+		
+		public JsonModel getStroredModel() {
+			return this.storedModel;
+		}
+		
+		public void setActiveModel(JsonModel activeModel) {
+			this.activeModel = activeModel;
+		}
+		
+		public JsonModel getActiveModel() {
+			return this.activeModel;
+		}
+	}	
+	
+
+	@GET
+	@Produces(MediaType.APPLICATION_JSON)
+	public ModelArtResult storedGet(
+			@QueryParam("id") Set<String> id
+			) throws Exception{
+		ModelArtResult result = new ModelArtResult();
+		result = stored(id);
+		return result;
+	}
+
+	public ModelArtResult stored(Set<String> ids) throws Exception {
+		ModelArtResult result = new ModelArtResult();
+		
+		for(String mid : ids) {
+			addToModel(mid, result);
+		}		
+		
+		return result;
+	}
+	
+	private void addToModel(String modelId, ModelArtResult result) throws Exception {
+		
+		IRI modelIri = curieHandler.getIRI(modelId);
+		OWLOntologyManager manager = OWLManager.createOWLOntologyManager();
+		OWLOntology currentOntology = m3.getModelAbox(modelIri);
+		OWLOntology storedOntology = m3.loadModelABox(modelIri, manager);
+		
+		//OWLOntology stored_ontology = man1.copyOntology(storedOntology, OntologyCopy.DEEP);	
+		ModelContainer storedMC = new ModelContainer(modelIri, null, storedOntology);		
+		final MolecularModelJsonRenderer storedRenderer = createModelRenderer(storedMC, go_lego, null, curieHandler);
+		JsonModel jsonStoredModel = storedRenderer.renderModel();			
+		
+		ModelContainer activeMC = new ModelContainer(modelIri, null, currentOntology);		
+		InferenceProvider inferenceProvider = ipc.create(activeMC);
+		final MolecularModelJsonRenderer renderer = createModelRenderer(activeMC, go_lego, inferenceProvider, curieHandler);
+		JsonModel jsonActiveModel = renderer.renderModel();	
+		
+		result.storedModel = jsonStoredModel;
+		result.activeModel = jsonActiveModel;
+		result.diffModel = getDiff(jsonStoredModel, jsonActiveModel);
+	
+	}
+	
+	private JsonModel getDiff(JsonModel storedOntology, JsonModel activeOntology) {
+		return new JsonModel();
+	}
+	
+}

--- a/minerva-server/src/main/java/org/geneontology/minerva/server/handler/ModelARTHandler.java
+++ b/minerva-server/src/main/java/org/geneontology/minerva/server/handler/ModelARTHandler.java
@@ -79,7 +79,7 @@ public class ModelARTHandler {
 		this.ipc = ipc;
 	}
 
-	public class ModelArtResult {
+	public class ModelARTResult {
 		private String id;
 		private JsonModel storedModel;
 		private JsonModel activeModel;
@@ -97,7 +97,7 @@ public class ModelARTHandler {
 			this.storedModel = storedModel;
 		}
 		
-		public JsonModel getStroredModel() {
+		public JsonModel getStoredModel() {
 			return this.storedModel;
 		}
 		
@@ -113,16 +113,16 @@ public class ModelARTHandler {
 
 	@GET
 	@Produces(MediaType.APPLICATION_JSON)
-	public ModelArtResult storedGet(
+	public ModelARTResult storedGet(
 			@QueryParam("id") Set<String> id
 			) throws Exception{
-		ModelArtResult result = new ModelArtResult();
+		ModelARTResult result = new ModelARTResult();
 		result = stored(id);
 		return result;
 	}
 
-	public ModelArtResult stored(Set<String> ids) throws Exception {
-		ModelArtResult result = new ModelArtResult();
+	public ModelARTResult stored(Set<String> ids) throws Exception {
+		ModelARTResult result = new ModelARTResult();
 		
 		for(String mid : ids) {
 			addToModel(mid, result);
@@ -131,7 +131,7 @@ public class ModelARTHandler {
 		return result;
 	}
 	
-	private void addToModel(String modelId, ModelArtResult result) throws Exception {
+	private void addToModel(String modelId, ModelARTResult result) throws Exception {
 		
 		IRI modelIri = curieHandler.getIRI(modelId);
 		OWLOntologyManager manager = OWLManager.createOWLOntologyManager();

--- a/minerva-server/src/test/java/org/geneontology/minerva/server/handler/ARTHandlerTest.java
+++ b/minerva-server/src/test/java/org/geneontology/minerva/server/handler/ARTHandlerTest.java
@@ -1,0 +1,309 @@
+/**
+ * 
+ */
+package org.geneontology.minerva.server.handler;
+
+import static org.junit.Assert.*;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
+import org.apache.http.client.entity.UrlEncodedFormEntity;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.utils.URIBuilder;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.message.BasicNameValuePair;
+import org.apache.http.util.EntityUtils;
+import org.apache.log4j.Logger;
+import org.eclipse.jetty.server.HttpConfiguration;
+import org.eclipse.jetty.server.HttpConnectionFactory;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.servlet.ServletContextHandler;
+import org.eclipse.jetty.servlet.ServletHolder;
+import org.geneontology.minerva.BlazegraphMolecularModelManager;
+import org.geneontology.minerva.MolecularModelManager.UnknownIdentifierException;
+import org.geneontology.minerva.UndoAwareMolecularModelManager;
+import org.geneontology.minerva.curie.CurieHandler;
+import org.geneontology.minerva.curie.CurieMappings;
+import org.geneontology.minerva.curie.DefaultCurieHandler;
+import org.geneontology.minerva.curie.MappedCurieHandler;
+import org.geneontology.minerva.lookup.ExternalLookupService;
+import org.geneontology.minerva.server.GsonMessageBodyHandler;
+import org.geneontology.minerva.server.RequireJsonpFilter;
+import org.geneontology.minerva.server.StartUpTool;
+import org.geneontology.minerva.server.StartUpTool.MinervaStartUpConfig;
+import org.geneontology.minerva.server.handler.M3BatchHandler.Entity;
+import org.geneontology.minerva.server.handler.M3BatchHandler.M3Argument;
+import org.geneontology.minerva.server.handler.M3BatchHandler.M3BatchResponse;
+import org.geneontology.minerva.server.handler.M3BatchHandler.M3Request;
+import org.geneontology.minerva.server.handler.M3BatchHandler.Operation;
+import org.geneontology.minerva.server.handler.ModelARTHandler.ModelARTResult;
+import org.geneontology.minerva.server.inferences.InferenceProviderCreator;
+import org.geneontology.minerva.server.validation.MinervaShexValidator;
+import org.glassfish.jersey.server.ResourceConfig;
+import org.glassfish.jersey.servlet.ServletContainer;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.openrdf.repository.RepositoryException;
+import org.openrdf.rio.RDFHandlerException;
+import org.openrdf.rio.RDFParseException;
+import org.semanticweb.owlapi.apibinding.OWLManager;
+import org.semanticweb.owlapi.model.IRI;
+import org.semanticweb.owlapi.model.OWLObjectProperty;
+import org.semanticweb.owlapi.model.OWLOntology;
+import org.semanticweb.owlapi.model.OWLOntologyCreationException;
+import org.semanticweb.owlapi.model.OWLOntologyManager;
+import org.semanticweb.owlapi.model.OWLOntologyStorageException;
+
+import com.google.gson.Gson;
+
+import owltools.gaf.eco.EcoMapperFactory;
+import owltools.gaf.eco.SimpleEcoMapper;
+
+/**
+ * @author tremaynemushayahama
+ *
+ */
+public class ARTHandlerTest {
+	private static final Logger LOGGER = Logger.getLogger(ARTHandlerTest.class);
+	static Server server;
+	static final String ontologyIRI = "http://purl.obolibrary.org/obo/go/extensions/go-lego.owl";
+	static final String modelIdcurie = "http://model.geneontology.org/";
+	static final String modelIdPrefix = "gomodel";
+	static final String go_lego_journal_file = "/tmp/test-go-lego-blazegraph.jnl";
+	static final String valid_model_folder = "src/test/resources/models/art-simple/";
+	static final String model_save =         "src/test/resources/models/tmp/";	
+	static final String shexFileUrl = "https://raw.githubusercontent.com/geneontology/go-shapes/master/shapes/go-cam-shapes.shex";
+	static final String goshapemapFileUrl = "https://raw.githubusercontent.com/geneontology/go-shapes/master/shapes/go-cam-shapes.shapeMap";
+		
+	static OWLOntology tbox_ontology;
+	static CurieHandler curieHandler;	
+	static UndoAwareMolecularModelManager models;
+	private static JsonOrJsonpBatchHandler handler;
+
+	@ClassRule
+	public static TemporaryFolder tmp = new TemporaryFolder();
+
+	/**
+	 * @throws java.lang.Exception
+	 */
+	@BeforeClass
+	public static void setUpBeforeClass() throws Exception {			
+				
+		LOGGER.info("Setup shex.");
+		URL shex_schema_url = new URL(shexFileUrl);
+		File shex_schema_file = new File("src/test/resources/validate.shex"); 
+		org.apache.commons.io.FileUtils.copyURLToFile(shex_schema_url, shex_schema_file);	
+		URL shex_map_url = new URL(goshapemapFileUrl);
+		File shex_map_file = new File("src/test/resources/validate.shapemap");
+		org.apache.commons.io.FileUtils.copyURLToFile(shex_map_url, shex_map_file);
+		
+		LOGGER.info("Set up molecular model manager - loading files into a journal");
+		// set curie handler	
+		final CurieMappings localMappings = new CurieMappings.SimpleCurieMappings(Collections.singletonMap(modelIdcurie, modelIdPrefix));
+		curieHandler = new MappedCurieHandler(DefaultCurieHandler.loadDefaultMappings(), localMappings);		
+		String inputDB = makeBlazegraphJournal(valid_model_folder);			
+		OWLOntologyManager ontman = OWLManager.createOWLOntologyManager();
+		tbox_ontology = ontman.createOntology(IRI.create("http://example.org/dummy"));//empty tbox
+		models = new UndoAwareMolecularModelManager(tbox_ontology, curieHandler, modelIdPrefix, inputDB, model_save, go_lego_journal_file);
+		models.addTaxonMetadata();
+
+		LOGGER.info("Setup Jetty config.");
+		ResourceConfig resourceConfig = new ResourceConfig();
+		resourceConfig.register(GsonMessageBodyHandler.class);
+		resourceConfig.register(RequireJsonpFilter.class);
+				
+		MinervaShexValidator shex = new MinervaShexValidator(shex_schema_file, shex_map_file, curieHandler, models.getGolego_repo());
+		shex.setActive(true);
+		
+		//setup the config for the startup tool. 
+		MinervaStartUpConfig conf = new MinervaStartUpConfig();
+		conf.reasonerOpt = "arachne";
+		conf.shex = shex;
+		conf.port = 6800;
+		conf.contextString = "/";			
+		
+		InferenceProviderCreator ipc = StartUpTool.createInferenceProviderCreator(conf.reasonerOpt, models, conf.shex); 
+
+		ModelARTHandler artHandler = new ModelARTHandler(models, ipc);
+		//set up a handler for testing with M3BatchRequest service
+		handler = new JsonOrJsonpBatchHandler(models, "development", ipc,
+						Collections.<OWLObjectProperty>emptySet(), (ExternalLookupService) null);
+		
+		
+		resourceConfig = resourceConfig.registerInstances(artHandler);
+
+		// setup jetty server port, buffers and context path
+		server = new Server();
+		// create connector with port and custom buffer sizes
+
+		HttpConfiguration http_config = new HttpConfiguration();  
+		
+		http_config.setRequestHeaderSize(conf.requestHeaderSize);
+		ServerConnector connector = new ServerConnector(server, new HttpConnectionFactory(http_config));
+		connector.setPort(conf.port);
+		server.addConnector(connector);
+		ServletContextHandler context = new ServletContextHandler(ServletContextHandler.SESSIONS);
+		context.setContextPath(conf.contextString);
+		server.setHandler(context);
+		ServletHolder h = new ServletHolder(new ServletContainer(resourceConfig));
+		context.addServlet(h, "/*");
+
+		// start jetty server
+		LOGGER.info("Start server on port: "+conf.port+" context: "+conf.contextString);
+		server.start();		
+		
+	}
+
+	/**
+	 * @throws java.lang.Exception
+	 */
+	@AfterClass
+	public static void tearDownAfterClass() throws Exception {
+		models.dispose();
+		server.stop();
+		if (handler != null) {
+			handler = null;
+		}
+	}
+
+	/**
+	 * @throws java.lang.Exception
+	 */
+	@Before
+	public void setUp() throws Exception {
+	}
+
+	/**
+	 * @throws java.lang.Exception
+	 */
+	@After
+	public void tearDown() throws Exception {
+	}
+	
+	@Test
+	public final void testStoredModel() throws URISyntaxException, IOException, OWLOntologyStorageException, OWLOntologyCreationException, RepositoryException, UnknownIdentifierException {
+		//get a hold of a test model
+		String mid = "5fbeae9c00000008";
+		final String modelId = "http://model.geneontology.org/"+mid;
+		
+		//save it to the database using the m3 api
+		M3Request r = BatchTestTools.addIndividual(modelId, "GO:0003674");
+		List<M3Request> batch = Collections.singletonList(r);
+		M3BatchResponse response = handler.m3Batch("test-user", Collections.emptySet(), "test-intention", "foo-packet-id",
+				batch.toArray(new M3Request[batch.size()]), false, true);
+				
+		r = new M3Request();
+		r.entity = Entity.model;
+		r.operation = Operation.storeModel;
+		r.arguments = new M3Argument();
+		r.arguments.modelId = modelId;
+		batch = Collections.singletonList(r);
+		response = handler.m3Batch("test-user", Collections.emptySet(), "test-intention", "foo-packet-id",
+		batch.toArray(new M3Request[batch.size()]), false, true);
+			
+		
+		//run a art query, show that the model found has not been modified
+		URIBuilder builder = new URIBuilder("http://127.0.0.1:6800/search/stored");
+		builder.addParameter("id", "gomodel:"+mid);
+		URI arturi = builder.build();
+		String json_result = getJsonStringFromUri(arturi);
+		Gson g = new Gson();
+		ModelARTResult result = g.fromJson(json_result, ModelARTResult.class);
+		
+		//test if stored ontology = active ontology
+				
+		// check that response indicates modified
+		LOGGER.info("Model Stored Model "+json_result);
+		LOGGER.info("Model Active Model "+result.getActiveModel().toString());
+		LOGGER.info("Model Stored Model "+result.getStoredModel().toString());
+		//assertTrue(result.getActiveModel().equals(result.getStoredModel())); 
+
+		
+		// check that response now indicates not modified
+		assertFalse(response.data.modifiedFlag);		
+				
+		//don't need to undo changes as the database is rebuilt each time from files and never flushed to file here.
+	}
+
+
+	private static String makeBlazegraphJournal(String input_folder) throws IOException, OWLOntologyCreationException, RepositoryException, RDFParseException, RDFHandlerException {
+		String inputDB = tmp.newFile().getAbsolutePath(); 
+		File i = new File(input_folder);
+		if(i.exists()) {
+			//remove anything that existed earlier
+			File bgdb = new File(inputDB);
+			if(bgdb.exists()) {
+				bgdb.delete();
+			}
+			//load everything into a bg journal
+			OWLOntology dummy = OWLManager.createOWLOntologyManager().createOntology(IRI.create("http://example.org/dummy"));
+			BlazegraphMolecularModelManager<Void> m3 = new BlazegraphMolecularModelManager<>(dummy, curieHandler, modelIdPrefix, inputDB, null, go_lego_journal_file);
+			if(i.isDirectory()) {
+				FileUtils.listFiles(i, null, true).parallelStream().parallel().forEach(file-> {
+					if(file.getName().endsWith(".ttl")||file.getName().endsWith("owl")) {
+						LOGGER.info("Loading " + file);
+						try {
+							String modeluri = m3.importModelToDatabase(file, true);
+						} catch (OWLOntologyCreationException | RepositoryException | RDFParseException
+								| RDFHandlerException | IOException e) {
+							// TODO Auto-generated catch block
+							e.printStackTrace();
+						}
+					} 
+				});
+			}else {
+				LOGGER.info("Loading " + i);
+				m3.importModelToDatabase(i, true);
+			}
+			LOGGER.info("loaded files into blazegraph journal: "+input_folder);
+			m3.dispose();
+		}
+		return inputDB;
+	}
+
+	private static String getJsonStringFromUri(URI uri) throws IOException {
+		final URL url = uri.toURL();
+		final HttpURLConnection connection;
+		InputStream response = null;
+		// setup and open (actual connection)
+		connection = (HttpURLConnection) url.openConnection();
+		connection.setInstanceFollowRedirects(true); // warning does not follow redirects from http to https
+		response = connection.getInputStream(); // opens the connection to the server		
+		// get string response from stream
+		String json = IOUtils.toString(response);
+
+		return json;
+	}
+
+
+	private	static String getJsonStringFromPost(HttpPost post) throws IOException {
+
+		CloseableHttpClient httpClient = HttpClients.createDefault();
+		CloseableHttpResponse response = httpClient.execute(post);
+		String json = EntityUtils.toString(response.getEntity());
+
+		return json;
+	}
+
+}

--- a/minerva-server/src/test/resources/models/art-simple/gp-mf-simple.ttl
+++ b/minerva-server/src/test/resources/models/art-simple/gp-mf-simple.ttl
@@ -1,0 +1,113 @@
+@prefix : <http://model.geneontology.org/5fbeae9c00000008#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@base <http://model.geneontology.org/5fbeae9c00000008> .
+
+<http://model.geneontology.org/5fbeae9c00000008> rdf:type owl:Ontology ;
+                                                  owl:versionIRI <http://model.geneontology.org/5fbeae9c00000008> ;
+                                                  <http://geneontology.org/lego/modelstate> "development" ;
+                                                  <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-2874-6934"^^xsd:string ;
+                                                  <http://purl.org/dc/elements/1.1/date> "2021-01-05"^^xsd:string ;
+                                                  <http://purl.org/dc/elements/1.1/title> "enabled by ABCA1 Hsap"^^xsd:string ;
+                                                  <http://purl.org/pav/providedBy> "http://geneontology.org" .
+
+#################################################################
+#    Annotation properties
+#################################################################
+
+###  http://geneontology.org/lego/evidence
+<http://geneontology.org/lego/evidence> rdf:type owl:AnnotationProperty .
+
+
+###  http://geneontology.org/lego/modelstate
+<http://geneontology.org/lego/modelstate> rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/dc/elements/1.1/contributor
+<http://purl.org/dc/elements/1.1/contributor> rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/dc/elements/1.1/date
+<http://purl.org/dc/elements/1.1/date> rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/dc/elements/1.1/source
+<http://purl.org/dc/elements/1.1/source> rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/dc/elements/1.1/title
+<http://purl.org/dc/elements/1.1/title> rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/pav/providedBy
+<http://purl.org/pav/providedBy> rdf:type owl:AnnotationProperty .
+
+
+#################################################################
+#    Object Properties
+#################################################################
+
+###  http://purl.obolibrary.org/obo/RO_0002333
+<http://purl.obolibrary.org/obo/RO_0002333> rdf:type owl:ObjectProperty .
+
+
+#################################################################
+#    Classes
+#################################################################
+
+###  http://identifiers.org/uniprot/O95477
+<http://identifiers.org/uniprot/O95477> rdf:type owl:Class .
+
+
+###  http://purl.obolibrary.org/obo/ECO_0007005
+<http://purl.obolibrary.org/obo/ECO_0007005> rdf:type owl:Class .
+
+
+###  http://purl.obolibrary.org/obo/GO_0005319
+<http://purl.obolibrary.org/obo/GO_0005319> rdf:type owl:Class .
+
+
+#################################################################
+#    Individuals
+#################################################################
+
+###  http://model.geneontology.org/5fbeae9c00000008/5fbeae9c00000009
+<http://model.geneontology.org/5fbeae9c00000008/5fbeae9c00000009> rdf:type owl:NamedIndividual ,
+                                                                           <http://purl.obolibrary.org/obo/GO_0005319> ;
+                                                                  <http://purl.obolibrary.org/obo/RO_0002333> <http://model.geneontology.org/5fbeae9c00000008/5fbeae9c00000010> ;
+                                                                  <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-2874-6934"^^xsd:string ;
+                                                                  <http://purl.org/dc/elements/1.1/date> "2021-01-05"^^xsd:string ;
+                                                                  <http://purl.org/pav/providedBy> "http://geneontology.org" .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource <http://model.geneontology.org/5fbeae9c00000008/5fbeae9c00000009> ;
+   owl:annotatedProperty <http://purl.obolibrary.org/obo/RO_0002333> ;
+   owl:annotatedTarget <http://model.geneontology.org/5fbeae9c00000008/5fbeae9c00000010> ;
+   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/5fbeae9c00000008/5fbeae9c00000011> ;
+   <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-2874-6934"^^xsd:string ;
+   <http://purl.org/dc/elements/1.1/date> "2021-01-05"^^xsd:string ;
+   <http://purl.org/pav/providedBy> "http://geneontology.org"
+ ] .
+
+
+###  http://model.geneontology.org/5fbeae9c00000008/5fbeae9c00000010
+<http://model.geneontology.org/5fbeae9c00000008/5fbeae9c00000010> rdf:type owl:NamedIndividual ,
+                                                                           <http://identifiers.org/uniprot/O95477> ;
+                                                                  <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-2874-6934"^^xsd:string ;
+                                                                  <http://purl.org/dc/elements/1.1/date> "2021-01-05"^^xsd:string ;
+                                                                  <http://purl.org/pav/providedBy> "http://geneontology.org" .
+
+
+###  http://model.geneontology.org/5fbeae9c00000008/5fbeae9c00000011
+<http://model.geneontology.org/5fbeae9c00000008/5fbeae9c00000011> rdf:type owl:NamedIndividual ,
+                                                                           <http://purl.obolibrary.org/obo/ECO_0007005> ;
+                                                                  <http://purl.org/dc/elements/1.1/contributor> "http://orcid.org/0000-0002-2874-6934"^^xsd:string ;
+                                                                  <http://purl.org/dc/elements/1.1/date> "2021-01-05"^^xsd:string ;
+                                                                  <http://purl.org/dc/elements/1.1/source> "PMID:12345"^^xsd:string ;
+                                                                  <http://purl.org/pav/providedBy> "http://geneontology.org" .
+
+
+###  Generated by the OWL API (version 4.5.15) https://github.com/owlcs/owlapi


### PR DESCRIPTION
@lpalbou and I worked on making temporary stored model api until diff as per this comment https://github.com/geneontology/minerva/issues/364

This is to show sample code. This is a working art api to get the stored model

The approach of separate API doesn't cause any side effect as it is readonly and easy to extend without hustles. It uses the same concept as searchAPI with jetty. Take a look how it is decoupled with m3Batch

to get the store endpoint is

from minerva http://localhost:6800/search/stored?id=gomodel:5fdc2fda00000000
from barista http://localhost:3400/search/stored?id=gomodel:5fdc2fda00000000

reason for search endpoint is temporary testing as barista only allows search proxy

tagging @lpalbou  @balhoff @kltm 