### PR TITLE
fix title search: replaced with a simple string search

### DIFF
--- a/minerva-server/src/main/java/org/geneontology/minerva/server/handler/ModelSearchHandler.java
+++ b/minerva-server/src/main/java/org/geneontology/minerva/server/handler/ModelSearchHandler.java
@@ -396,14 +396,8 @@ public class ModelSearchHandler {
 		//			taxa_constraint = model_filter;
 		//		}
 		String title_search_constraint = "";
-		if(title_search!=null) {
-			title_search_constraint = "?title <http://www.bigdata.com/rdf/search#search> \""+title_search+"\" .\n";
-			if(!title_search.contains("*")) {
-				title_search_constraint+=" ?title <http://www.bigdata.com/rdf/search#matchAllTerms> \""+"true"+"\" . \n";
-			}
-			//			if(exact_match) {
-			//				title_search_constraint+=" ?title <http://www.bigdata.com/rdf/search#matchExact>  \""+"true"+"\" . \n";
-			//			}
+		if(title_search!=null) {			
+			title_search_constraint = "filter contains( lcase(?title), \""+title_search.toLowerCase()+"\") .\n";
 		}
 		String state_search_constraint = "";
 		if(state_search!=null&&state_search.size()>0) {


### PR DESCRIPTION
Fixed the title search. Made a simple filter string search in favor of sparql bigData

Replaced  ?title <http://www.bigdata.com/rdf/search#search> "*enabled by ABCA3 Hsap*" . with  filter contains( lcase(?title), "enabled by abca3 hsap") .  I also put in lowercase (non-locale) for any naming inconsistences

More on ticket https://github.com/geneontology/minerva/issues/368

Lemme know if its an okay PR, I need to change landing page as well to remove the "*" *around title text* for old API in order for it to match string
tagging @kltm @lpalbou @balhoff @ukemi @vanaukenk 