### PR TITLE
Suppress UBERON annotation extensions when an EMAPA structure is present.

### DIFF
--- a/minerva-converter/src/main/java/org/geneontology/minerva/legacy/sparql/GPADSPARQLExport.java
+++ b/minerva-converter/src/main/java/org/geneontology/minerva/legacy/sparql/GPADSPARQLExport.java
@@ -54,6 +54,8 @@ public class GPADSPARQLExport {
 	private static final String BP = "http://purl.obolibrary.org/obo/GO_0008150";
 	private static final String CC = "http://purl.obolibrary.org/obo/GO_0005575";
 	private static final Set<String> rootTerms = new HashSet<>(Arrays.asList(MF, BP, CC));
+	private static final String EMAPA_NAMESPACE = "http://purl.obolibrary.org/obo/EMAPA_";
+	private static final String UBERON_NAMESPACE = "http://purl.obolibrary.org/obo/UBERON_";
 	private static final String inconsistentQuery = 
 			"PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>" + 
 					"PREFIX owl: <http://www.w3.org/2002/07/owl#>" +
@@ -171,6 +173,9 @@ public class GPADSPARQLExport {
 								}
 							}
 						}
+						// Handle special case of EMAPA; don't include Uberon extensions
+						final boolean isMouseExtension = goodExtensions.stream().anyMatch(e -> e.getFiller().toString().startsWith(EMAPA_NAMESPACE));
+						if (isMouseExtension) goodExtensions.removeIf(e -> e.getFiller().toString().startsWith(UBERON_NAMESPACE));
 						final boolean rootViolation;
 						if (rootTerms.contains(annotation.getOntologyClass().toString())) {
 							rootViolation = !ND.equals(currentEvidence.getEvidence().toString());

--- a/minerva-converter/src/test/java/org/geneontology/minerva/legacy/sparql/GPADSPARQLTest.java
+++ b/minerva-converter/src/test/java/org/geneontology/minerva/legacy/sparql/GPADSPARQLTest.java
@@ -64,6 +64,22 @@ public class GPADSPARQLTest {
 		Assert.assertTrue("Should produce annotations", lines > 2);
 	}
 
+
+	/**
+	 * This test needs improvements; the current background axioms used in the tests are resulting in the Uberon inference we're trying to avoid
+	 * @throws Exception
+	 */
+	@Test
+	public void testSuppressUberonExtensionsWhenEMAPA() throws Exception {
+		Model model = ModelFactory.createDefaultModel();
+		model.read(this.getClass().getResourceAsStream("/no_uberon_with_emapa.ttl"), "", "ttl");
+		Set<Triple> triples = model.listStatements().toList().stream().map(s -> Bridge.tripleFromJena(s.asTriple())).collect(Collectors.toSet());
+		WorkingMemory mem = arachne.processTriples(JavaConverters.asScalaSetConverter(triples).asScala());
+		Set<GPADData> annotations = exporter.getGPAD(mem, IRI.create("http://test.org"));
+		Assert.assertTrue(annotations.stream().anyMatch(a -> a.getAnnotationExtensions().stream().anyMatch(e -> e.getFiller().toString().startsWith("http://purl.obolibrary.org/obo/EMAPA_"))));
+		Assert.assertTrue(annotations.stream().noneMatch(a -> a.getAnnotationExtensions().stream().anyMatch(e -> e.getFiller().toString().startsWith("http://purl.obolibrary.org/obo/UBERON_"))));
+	}
+
 	/**
 	 * Test whether the GPAD output contains all required entries and rows without any spurious results.
 	 * Example Input file: the owl dump from http://noctua-dev.berkeleybop.org/editor/graph/gomodel:59d1072300000074

--- a/minerva-converter/src/test/resources/no_uberon_with_emapa.ttl
+++ b/minerva-converter/src/test/resources/no_uberon_with_emapa.ttl
@@ -1,0 +1,1703 @@
+@prefix : <http://model.geneontology.org/MGI_MGI_2676312#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@base <http://model.geneontology.org/MGI_MGI_2676312> .
+
+<http://model.geneontology.org/MGI_MGI_2676312> rdf:type owl:Ontology ;
+                                                 owl:versionIRI <http://model.geneontology.org/MGI_MGI_2676312> ;
+                                                 <http://geneontology.org/lego/modelstate> "production" ;
+                                                 <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X"^^xsd:string ,
+                                                                                               "https://orcid.org/0000-0001-7476-6306"^^xsd:string ,
+                                                                                               "https://orcid.org/0000-0003-2689-5511" ;
+                                                 <http://purl.org/dc/elements/1.1/date> "2021-06-10" ;
+                                                 <http://purl.org/dc/elements/1.1/title> "Abca12 (MGI:MGI:2676312)" ;
+                                                 <http://purl.org/pav/providedBy> "http://informatics.jax.org"^^xsd:string ;
+                                                 <https://w3id.org/biolink/vocab/in_taxon> <http://purl.obolibrary.org/obo/NCBITaxon_10090> .
+
+#################################################################
+#    Annotation properties
+#################################################################
+
+###  http://geneontology.org/lego/evidence
+<http://geneontology.org/lego/evidence> rdf:type owl:AnnotationProperty .
+
+
+###  http://geneontology.org/lego/evidence-with
+<http://geneontology.org/lego/evidence-with> rdf:type owl:AnnotationProperty .
+
+
+###  http://geneontology.org/lego/modelstate
+<http://geneontology.org/lego/modelstate> rdf:type owl:AnnotationProperty .
+
+
+###  http://geneontology.org/lego/hint/layout/x
+<http://geneontology.org/lego/hint/layout/x> rdf:type owl:AnnotationProperty .
+
+
+###  http://geneontology.org/lego/hint/layout/y
+<http://geneontology.org/lego/hint/layout/y> rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/dc/elements/1.1/contributor
+<http://purl.org/dc/elements/1.1/contributor> rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/dc/elements/1.1/date
+<http://purl.org/dc/elements/1.1/date> rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/dc/elements/1.1/source
+<http://purl.org/dc/elements/1.1/source> rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/dc/elements/1.1/title
+<http://purl.org/dc/elements/1.1/title> rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/pav/providedBy
+<http://purl.org/pav/providedBy> rdf:type owl:AnnotationProperty .
+
+
+###  https://w3id.org/biolink/vocab/in_taxon
+<https://w3id.org/biolink/vocab/in_taxon> rdf:type owl:AnnotationProperty .
+
+
+#################################################################
+#    Object Properties
+#################################################################
+
+###  http://purl.obolibrary.org/obo/BFO_0000050
+<http://purl.obolibrary.org/obo/BFO_0000050> rdf:type owl:ObjectProperty .
+
+
+###  http://purl.obolibrary.org/obo/BFO_0000066
+<http://purl.obolibrary.org/obo/BFO_0000066> rdf:type owl:ObjectProperty .
+
+
+###  http://purl.obolibrary.org/obo/RO_0001025
+<http://purl.obolibrary.org/obo/RO_0001025> rdf:type owl:ObjectProperty .
+
+
+###  http://purl.obolibrary.org/obo/RO_0002213
+<http://purl.obolibrary.org/obo/RO_0002213> rdf:type owl:ObjectProperty .
+
+
+###  http://purl.obolibrary.org/obo/RO_0002233
+<http://purl.obolibrary.org/obo/RO_0002233> rdf:type owl:ObjectProperty .
+
+
+###  http://purl.obolibrary.org/obo/RO_0002296
+<http://purl.obolibrary.org/obo/RO_0002296> rdf:type owl:ObjectProperty .
+
+
+###  http://purl.obolibrary.org/obo/RO_0002315
+<http://purl.obolibrary.org/obo/RO_0002315> rdf:type owl:ObjectProperty .
+
+
+###  http://purl.obolibrary.org/obo/RO_0002333
+<http://purl.obolibrary.org/obo/RO_0002333> rdf:type owl:ObjectProperty .
+
+
+###  http://purl.obolibrary.org/obo/RO_0002418
+<http://purl.obolibrary.org/obo/RO_0002418> rdf:type owl:ObjectProperty .
+
+
+#################################################################
+#    Classes
+#################################################################
+
+###  http://identifiers.org/mgi/MGI:2676312
+<http://identifiers.org/mgi/MGI:2676312> rdf:type owl:Class .
+
+
+###  http://purl.obolibrary.org/obo/CL_0000082
+<http://purl.obolibrary.org/obo/CL_0000082> rdf:type owl:Class .
+
+
+###  http://purl.obolibrary.org/obo/CL_0000091
+<http://purl.obolibrary.org/obo/CL_0000091> rdf:type owl:Class .
+
+
+###  http://purl.obolibrary.org/obo/CL_0000312
+<http://purl.obolibrary.org/obo/CL_0000312> rdf:type owl:Class .
+
+
+###  http://purl.obolibrary.org/obo/ECO_0000314
+<http://purl.obolibrary.org/obo/ECO_0000314> rdf:type owl:Class .
+
+
+###  http://purl.obolibrary.org/obo/ECO_0000315
+<http://purl.obolibrary.org/obo/ECO_0000315> rdf:type owl:Class .
+
+
+###  http://purl.obolibrary.org/obo/ECO_0000316
+<http://purl.obolibrary.org/obo/ECO_0000316> rdf:type owl:Class .
+
+
+###  http://purl.obolibrary.org/obo/ECO_0000353
+<http://purl.obolibrary.org/obo/ECO_0000353> rdf:type owl:Class .
+
+
+###  http://purl.obolibrary.org/obo/ECO_0007005
+<http://purl.obolibrary.org/obo/ECO_0007005> rdf:type owl:Class .
+
+
+###  http://purl.obolibrary.org/obo/EMAPA_16728
+<http://purl.obolibrary.org/obo/EMAPA_16728> rdf:type owl:Class .
+
+
+###  http://purl.obolibrary.org/obo/EMAPA_17525
+<http://purl.obolibrary.org/obo/EMAPA_17525> rdf:type owl:Class .
+
+
+###  http://purl.obolibrary.org/obo/EMAPA_32692
+<http://purl.obolibrary.org/obo/EMAPA_32692> rdf:type owl:Class .
+
+
+###  http://purl.obolibrary.org/obo/GO_0003674
+<http://purl.obolibrary.org/obo/GO_0003674> rdf:type owl:Class .
+
+
+###  http://purl.obolibrary.org/obo/GO_0005515
+<http://purl.obolibrary.org/obo/GO_0005515> rdf:type owl:Class .
+
+
+###  http://purl.obolibrary.org/obo/GO_0005743
+<http://purl.obolibrary.org/obo/GO_0005743> rdf:type owl:Class .
+
+
+###  http://purl.obolibrary.org/obo/GO_0005829
+<http://purl.obolibrary.org/obo/GO_0005829> rdf:type owl:Class .
+
+
+###  http://purl.obolibrary.org/obo/GO_0010875
+<http://purl.obolibrary.org/obo/GO_0010875> rdf:type owl:Class .
+
+
+###  http://purl.obolibrary.org/obo/GO_0030216
+<http://purl.obolibrary.org/obo/GO_0030216> rdf:type owl:Class .
+
+
+###  http://purl.obolibrary.org/obo/GO_0031424
+<http://purl.obolibrary.org/obo/GO_0031424> rdf:type owl:Class .
+
+
+###  http://purl.obolibrary.org/obo/GO_0033344
+<http://purl.obolibrary.org/obo/GO_0033344> rdf:type owl:Class .
+
+
+###  http://purl.obolibrary.org/obo/GO_0035627
+<http://purl.obolibrary.org/obo/GO_0035627> rdf:type owl:Class .
+
+
+###  http://purl.obolibrary.org/obo/GO_0043129
+<http://purl.obolibrary.org/obo/GO_0043129> rdf:type owl:Class .
+
+
+###  http://purl.obolibrary.org/obo/GO_0048286
+<http://purl.obolibrary.org/obo/GO_0048286> rdf:type owl:Class .
+
+
+###  http://purl.obolibrary.org/obo/GO_0055088
+<http://purl.obolibrary.org/obo/GO_0055088> rdf:type owl:Class .
+
+
+###  http://purl.obolibrary.org/obo/GO_0061436
+<http://purl.obolibrary.org/obo/GO_0061436> rdf:type owl:Class .
+
+
+###  http://purl.obolibrary.org/obo/GO_2000010
+<http://purl.obolibrary.org/obo/GO_2000010> rdf:type owl:Class .
+
+
+###  http://purl.obolibrary.org/obo/PR_P41233
+<http://purl.obolibrary.org/obo/PR_P41233> rdf:type owl:Class .
+
+
+###  http://purl.obolibrary.org/obo/PR_Q60644
+<http://purl.obolibrary.org/obo/PR_Q60644> rdf:type owl:Class .
+
+
+#################################################################
+#    Individuals
+#################################################################
+
+###  http://model.geneontology.org/MGI_MGI_2676312/a544a242-c396-465b-9246-04422d46526b
+<http://model.geneontology.org/MGI_MGI_2676312/a544a242-c396-465b-9246-04422d46526b> rdf:type owl:NamedIndividual ,
+                                                                                              <http://purl.obolibrary.org/obo/ECO_0000316> ;
+                                                                                     <http://geneontology.org/lego/evidence-with> "MGI:MGI:1352463" ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X" ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2013-10-25" ;
+                                                                                     <http://purl.org/dc/elements/1.1/source> "PMID:23931754" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+                                                                                     rdfs:comment "RAW 264.7" ,
+                                                                                                  "cell type TIB-71   permanent cell line cell ; CLO:0000019" .
+
+
+###  http://model.geneontology.org/MGI_MGI_2676312/ab518c5e-ce62-4125-99ef-492138fdc320
+<http://model.geneontology.org/MGI_MGI_2676312/ab518c5e-ce62-4125-99ef-492138fdc320> rdf:type owl:NamedIndividual ,
+                                                                                              <http://purl.obolibrary.org/obo/ECO_0000315> ;
+                                                                                     <http://geneontology.org/lego/evidence-with> "MGI:MGI:3528440" ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X" ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2012-10-17" ;
+                                                                                     <http://purl.org/dc/elements/1.1/source> "PMID:18957418" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+                                                                                     rdfs:comment "anatomy lung ; MA:0000415" ,
+                                                                                                  "cell type type II pneumocyte ; CL:0002063" ,
+                                                                                                  "has_participant(CL:0002063)" .
+
+
+###  http://model.geneontology.org/MGI_MGI_2676312/af2339e9-927f-41c2-ac2c-696092aa1c3b
+<http://model.geneontology.org/MGI_MGI_2676312/af2339e9-927f-41c2-ac2c-696092aa1c3b> rdf:type owl:NamedIndividual ,
+                                                                                              <http://identifiers.org/mgi/MGI:2676312> ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X" ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2013-10-25" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org" .
+
+
+###  http://model.geneontology.org/MGI_MGI_2676312/af6586ba-592e-4cef-aa41-e6d50b2933bd
+<http://model.geneontology.org/MGI_MGI_2676312/af6586ba-592e-4cef-aa41-e6d50b2933bd> rdf:type owl:NamedIndividual ,
+                                                                                              <http://purl.obolibrary.org/obo/EMAPA_32692> ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X" ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2012-10-17" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org" .
+
+
+###  http://model.geneontology.org/MGI_MGI_2676312/af9dfad9-ba97-48cb-8062-460cfafd2eea
+<http://model.geneontology.org/MGI_MGI_2676312/af9dfad9-ba97-48cb-8062-460cfafd2eea> rdf:type owl:NamedIndividual ,
+                                                                                              <http://purl.obolibrary.org/obo/ECO_0000315> ;
+                                                                                     <http://geneontology.org/lego/evidence-with> "MGI:MGI:3528440" ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X" ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2012-10-17" ;
+                                                                                     <http://purl.org/dc/elements/1.1/source> "PMID:18957418" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+                                                                                     rdfs:comment "anatomy epidermis stratum corneum ; MA:0000804" ,
+                                                                                                  "has_participant(EMAPA:32787 TS28)" .
+
+
+###  http://model.geneontology.org/MGI_MGI_2676312/aff572ff-0afa-4041-b06c-c4394487a92d
+<http://model.geneontology.org/MGI_MGI_2676312/aff572ff-0afa-4041-b06c-c4394487a92d> rdf:type owl:NamedIndividual ,
+                                                                                              <http://purl.obolibrary.org/obo/ECO_0000314> ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X" ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2012-10-17" ;
+                                                                                     <http://purl.org/dc/elements/1.1/source> "PMID:18632686" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+                                                                                     rdfs:comment "cell type epithelial cell of lung ; CL:0000082" .
+
+
+###  http://model.geneontology.org/MGI_MGI_2676312/b4d11b66-291c-4642-9654-7bc228bd69e1
+<http://model.geneontology.org/MGI_MGI_2676312/b4d11b66-291c-4642-9654-7bc228bd69e1> rdf:type owl:NamedIndividual ,
+                                                                                              <http://purl.obolibrary.org/obo/ECO_0000315> ;
+                                                                                     <http://geneontology.org/lego/evidence-with> "MGI:MGI:4461044" ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X" ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2012-10-17" ;
+                                                                                     <http://purl.org/dc/elements/1.1/source> "PMID:18802465" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+                                                                                     rdfs:comment "cell type keratinocyte ; CL:0000312" .
+
+
+###  http://model.geneontology.org/MGI_MGI_2676312/b5550c2d-744c-4c82-bf09-9d085348eb5f
+<http://model.geneontology.org/MGI_MGI_2676312/b5550c2d-744c-4c82-bf09-9d085348eb5f> rdf:type owl:NamedIndividual ,
+                                                                                              <http://purl.obolibrary.org/obo/GO_0003674> ;
+                                                                                     <http://purl.obolibrary.org/obo/RO_0002333> <http://model.geneontology.org/MGI_MGI_2676312/f61de7a6-b27f-4197-97a5-db8f277e3ad2> ;
+                                                                                     <http://purl.obolibrary.org/obo/RO_0002418> <http://model.geneontology.org/MGI_MGI_2676312/01159f74-69be-4c19-bc6b-be19e3b766ef> ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X"^^xsd:string ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2012-10-17" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org"^^xsd:string .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource <http://model.geneontology.org/MGI_MGI_2676312/b5550c2d-744c-4c82-bf09-9d085348eb5f> ;
+   owl:annotatedProperty <http://purl.obolibrary.org/obo/RO_0002333> ;
+   owl:annotatedTarget <http://model.geneontology.org/MGI_MGI_2676312/f61de7a6-b27f-4197-97a5-db8f277e3ad2> ;
+   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_2676312/fae12149-d928-4983-9e68-3aceeddc56fc> ;
+   <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X"^^xsd:string ;
+   <http://purl.org/dc/elements/1.1/date> "2012-10-17" ;
+   <http://purl.org/pav/providedBy> "http://informatics.jax.org"^^xsd:string ;
+   rdfs:comment "MGI:MGI:2676312  RO:0002264 GO:0035627 MGI:MGI:3829841|PMID:18957418 ECO:0000315 MGI:MGI:3528440  2012-10-17 MGI BFO:0000066(EMAPA:17525) creation-date=2012-10-17|modification-date=2012-10-17|comment=anatomy skin ; MA:0000151|contributor-id=https://orcid.org/0000-0001-5501-853X"
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource <http://model.geneontology.org/MGI_MGI_2676312/b5550c2d-744c-4c82-bf09-9d085348eb5f> ;
+   owl:annotatedProperty <http://purl.obolibrary.org/obo/RO_0002418> ;
+   owl:annotatedTarget <http://model.geneontology.org/MGI_MGI_2676312/01159f74-69be-4c19-bc6b-be19e3b766ef> ;
+   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_2676312/cd741a06-b933-4052-a600-47ca4ac02924> ;
+   <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X"^^xsd:string ;
+   <http://purl.org/dc/elements/1.1/date> "2012-10-17" ;
+   <http://purl.org/pav/providedBy> "http://informatics.jax.org"^^xsd:string ;
+   rdfs:comment "MGI:MGI:2676312  RO:0002264 GO:0035627 MGI:MGI:3829841|PMID:18957418 ECO:0000315 MGI:MGI:3528440  2012-10-17 MGI BFO:0000066(EMAPA:17525) creation-date=2012-10-17|modification-date=2012-10-17|comment=anatomy skin ; MA:0000151|contributor-id=https://orcid.org/0000-0001-5501-853X"
+ ] .
+
+
+###  http://model.geneontology.org/MGI_MGI_2676312/b5ca744c-577f-4f95-a75a-2ec170a0630d
+<http://model.geneontology.org/MGI_MGI_2676312/b5ca744c-577f-4f95-a75a-2ec170a0630d> rdf:type owl:NamedIndividual ,
+                                                                                              <http://purl.obolibrary.org/obo/ECO_0000315> ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X" ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2013-10-25" ;
+                                                                                     <http://purl.org/dc/elements/1.1/source> "PMID:23931754" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+                                                                                     rdfs:comment "RAW 264.7" ,
+                                                                                                  "cell type TIB-71   permanent cell line cell ; CLO:0000019" ,
+                                                                                                  "evidence RNAi evidence ; ECO:0000019" ,
+                                                                                                  "target UniProtKB:P41233" .
+
+
+###  http://model.geneontology.org/MGI_MGI_2676312/b9f59cbd-8003-47a0-82f8-90ba74569fa7
+<http://model.geneontology.org/MGI_MGI_2676312/b9f59cbd-8003-47a0-82f8-90ba74569fa7> rdf:type owl:NamedIndividual ,
+                                                                                              <http://purl.obolibrary.org/obo/GO_0003674> ;
+                                                                                     <http://purl.obolibrary.org/obo/RO_0002333> <http://model.geneontology.org/MGI_MGI_2676312/6b5e2e28-99fd-4532-8e47-e8a7ca098557> ;
+                                                                                     <http://purl.obolibrary.org/obo/RO_0002418> <http://model.geneontology.org/MGI_MGI_2676312/4bf2f8ea-5c77-4c7c-9c3a-ca5168c9df9b> ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X"^^xsd:string ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2013-10-25" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org"^^xsd:string .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource <http://model.geneontology.org/MGI_MGI_2676312/b9f59cbd-8003-47a0-82f8-90ba74569fa7> ;
+   owl:annotatedProperty <http://purl.obolibrary.org/obo/RO_0002333> ;
+   owl:annotatedTarget <http://model.geneontology.org/MGI_MGI_2676312/6b5e2e28-99fd-4532-8e47-e8a7ca098557> ;
+   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_2676312/4d5de41f-a7f9-4ab3-b3ee-8719ea857332> ;
+   <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X"^^xsd:string ;
+   <http://purl.org/dc/elements/1.1/date> "2013-10-25" ;
+   <http://purl.org/pav/providedBy> "http://informatics.jax.org"^^xsd:string ;
+   rdfs:comment "MGI:MGI:2676312  RO:0002264 GO:0010875 MGI:MGI:5510615|PMID:23931754 ECO:0000315 MGI:MGI:4461044  2013-10-25 MGI GOREL:0001004(CL:0000091) creation-date=2013-10-25|modification-date=2013-10-25|comment=cell type Kupffer cell ; CL:0000091   primary cell line cell ; CL:0000001|contributor-id=https://orcid.org/0000-0001-5501-853X"
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource <http://model.geneontology.org/MGI_MGI_2676312/b9f59cbd-8003-47a0-82f8-90ba74569fa7> ;
+   owl:annotatedProperty <http://purl.obolibrary.org/obo/RO_0002418> ;
+   owl:annotatedTarget <http://model.geneontology.org/MGI_MGI_2676312/4bf2f8ea-5c77-4c7c-9c3a-ca5168c9df9b> ;
+   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_2676312/95053efe-c54a-4b3d-a13f-50c0c376060e> ;
+   <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X"^^xsd:string ;
+   <http://purl.org/dc/elements/1.1/date> "2013-10-25" ;
+   <http://purl.org/pav/providedBy> "http://informatics.jax.org"^^xsd:string ;
+   rdfs:comment "MGI:MGI:2676312  RO:0002264 GO:0010875 MGI:MGI:5510615|PMID:23931754 ECO:0000315 MGI:MGI:4461044  2013-10-25 MGI GOREL:0001004(CL:0000091) creation-date=2013-10-25|modification-date=2013-10-25|comment=cell type Kupffer cell ; CL:0000091   primary cell line cell ; CL:0000001|contributor-id=https://orcid.org/0000-0001-5501-853X"
+ ] .
+
+
+###  http://model.geneontology.org/MGI_MGI_2676312/ba5d9d2d-de63-4ec7-9d15-a857cee51c97
+<http://model.geneontology.org/MGI_MGI_2676312/ba5d9d2d-de63-4ec7-9d15-a857cee51c97> rdf:type owl:NamedIndividual ,
+                                                                                              <http://identifiers.org/mgi/MGI:2676312> ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X" ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2012-10-17" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org" .
+
+
+###  http://model.geneontology.org/MGI_MGI_2676312/ba8bd87d-50cb-46ee-911d-f8c7cf786cea
+<http://model.geneontology.org/MGI_MGI_2676312/ba8bd87d-50cb-46ee-911d-f8c7cf786cea> rdf:type owl:NamedIndividual ,
+                                                                                              <http://identifiers.org/mgi/MGI:2676312> ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X" ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2012-10-17" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org" .
+
+
+###  http://model.geneontology.org/MGI_MGI_2676312/bbcd1c30-eafd-48d3-afa9-6d3c4289d293
+<http://model.geneontology.org/MGI_MGI_2676312/bbcd1c30-eafd-48d3-afa9-6d3c4289d293> rdf:type owl:NamedIndividual ,
+                                                                                              <http://identifiers.org/mgi/MGI:2676312> ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X" ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2013-10-25" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org" .
+
+
+###  http://model.geneontology.org/MGI_MGI_2676312/bc11cdd3-4eb7-4df0-b2f5-122965e8fd49
+<http://model.geneontology.org/MGI_MGI_2676312/bc11cdd3-4eb7-4df0-b2f5-122965e8fd49> rdf:type owl:NamedIndividual ,
+                                                                                              <http://purl.obolibrary.org/obo/GO_0003674> ;
+                                                                                     <http://purl.obolibrary.org/obo/RO_0002333> <http://model.geneontology.org/MGI_MGI_2676312/7c001801-621f-4ac5-abf2-eb1e12da5586> ;
+                                                                                     <http://purl.obolibrary.org/obo/RO_0002418> <http://model.geneontology.org/MGI_MGI_2676312/86d02de9-6ca4-4256-bbe1-8ca4e331e992> ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X"^^xsd:string ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2012-10-17" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org"^^xsd:string .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource <http://model.geneontology.org/MGI_MGI_2676312/bc11cdd3-4eb7-4df0-b2f5-122965e8fd49> ;
+   owl:annotatedProperty <http://purl.obolibrary.org/obo/RO_0002333> ;
+   owl:annotatedTarget <http://model.geneontology.org/MGI_MGI_2676312/7c001801-621f-4ac5-abf2-eb1e12da5586> ;
+   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_2676312/b4d11b66-291c-4642-9654-7bc228bd69e1> ;
+   <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X"^^xsd:string ;
+   <http://purl.org/dc/elements/1.1/date> "2012-10-17" ;
+   <http://purl.org/pav/providedBy> "http://informatics.jax.org"^^xsd:string ;
+   rdfs:comment "MGI:MGI:2676312  RO:0002264 GO:0030216 MGI:MGI:4460077|PMID:18802465 ECO:0000315 MGI:MGI:4461044  2012-10-17 MGI RO:0002315(CL:0000312) creation-date=2012-10-17|modification-date=2012-10-17|comment=cell type keratinocyte ; CL:0000312|contributor-id=https://orcid.org/0000-0001-5501-853X"
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource <http://model.geneontology.org/MGI_MGI_2676312/bc11cdd3-4eb7-4df0-b2f5-122965e8fd49> ;
+   owl:annotatedProperty <http://purl.obolibrary.org/obo/RO_0002418> ;
+   owl:annotatedTarget <http://model.geneontology.org/MGI_MGI_2676312/86d02de9-6ca4-4256-bbe1-8ca4e331e992> ;
+   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_2676312/4f9db452-eee5-43bd-b2a1-51a37d7be767> ;
+   <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X"^^xsd:string ;
+   <http://purl.org/dc/elements/1.1/date> "2012-10-17" ;
+   <http://purl.org/pav/providedBy> "http://informatics.jax.org"^^xsd:string ;
+   rdfs:comment "MGI:MGI:2676312  RO:0002264 GO:0030216 MGI:MGI:4460077|PMID:18802465 ECO:0000315 MGI:MGI:4461044  2012-10-17 MGI RO:0002315(CL:0000312) creation-date=2012-10-17|modification-date=2012-10-17|comment=cell type keratinocyte ; CL:0000312|contributor-id=https://orcid.org/0000-0001-5501-853X"
+ ] .
+
+
+###  http://model.geneontology.org/MGI_MGI_2676312/bf890116-ad7f-4ba6-8b47-e7aab408812c
+<http://model.geneontology.org/MGI_MGI_2676312/bf890116-ad7f-4ba6-8b47-e7aab408812c> rdf:type owl:NamedIndividual ,
+                                                                                              <http://purl.obolibrary.org/obo/GO_0005515> ;
+                                                                                     <http://purl.obolibrary.org/obo/RO_0002233> <http://model.geneontology.org/MGI_MGI_2676312/1590b8cb-9e60-4c78-93bb-f4f932c39e6b> ;
+                                                                                     <http://purl.obolibrary.org/obo/RO_0002333> <http://model.geneontology.org/MGI_MGI_2676312/7ac43336-bd20-40f1-adc0-19248c74a378> ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X"^^xsd:string ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2013-10-25" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org"^^xsd:string .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource <http://model.geneontology.org/MGI_MGI_2676312/bf890116-ad7f-4ba6-8b47-e7aab408812c> ;
+   owl:annotatedProperty <http://purl.obolibrary.org/obo/RO_0002233> ;
+   owl:annotatedTarget <http://model.geneontology.org/MGI_MGI_2676312/1590b8cb-9e60-4c78-93bb-f4f932c39e6b> ;
+   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_2676312/09370759-7ef4-463f-abbf-876d558c395c> ;
+   <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X"^^xsd:string ;
+   <http://purl.org/dc/elements/1.1/date> "2013-10-25" ;
+   <http://purl.org/pav/providedBy> "http://informatics.jax.org"^^xsd:string ;
+   rdfs:comment "MGI:MGI:2676312  RO:0002327 GO:0005515 MGI:MGI:5510615|PMID:23931754 ECO:0000353 PR:P41233  2013-10-25 MGI  creation-date=2013-10-25|modification-date=2013-10-25|comment=cell type TIB-71   permanent cell line cell ; CLO:0000019|comment=In situ proximity ligation assay|comment=RAW 264.7|contributor-id=https://orcid.org/0000-0001-5501-853X"
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource <http://model.geneontology.org/MGI_MGI_2676312/bf890116-ad7f-4ba6-8b47-e7aab408812c> ;
+   owl:annotatedProperty <http://purl.obolibrary.org/obo/RO_0002333> ;
+   owl:annotatedTarget <http://model.geneontology.org/MGI_MGI_2676312/7ac43336-bd20-40f1-adc0-19248c74a378> ;
+   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_2676312/83eea992-651a-4861-82ec-e483c134e360> ;
+   <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X"^^xsd:string ;
+   <http://purl.org/dc/elements/1.1/date> "2013-10-25" ;
+   <http://purl.org/pav/providedBy> "http://informatics.jax.org"^^xsd:string ;
+   rdfs:comment "MGI:MGI:2676312  RO:0002327 GO:0005515 MGI:MGI:5510615|PMID:23931754 ECO:0000353 PR:P41233  2013-10-25 MGI  creation-date=2013-10-25|modification-date=2013-10-25|comment=cell type TIB-71   permanent cell line cell ; CLO:0000019|comment=In situ proximity ligation assay|comment=RAW 264.7|contributor-id=https://orcid.org/0000-0001-5501-853X"
+ ] .
+
+
+###  http://model.geneontology.org/MGI_MGI_2676312/bfb248e7-8328-4592-9c42-09e35573cbdd
+<http://model.geneontology.org/MGI_MGI_2676312/bfb248e7-8328-4592-9c42-09e35573cbdd> rdf:type owl:NamedIndividual ,
+                                                                                              <http://purl.obolibrary.org/obo/ECO_0000315> ;
+                                                                                     <http://geneontology.org/lego/evidence-with> "MGI:MGI:4461044" ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X" ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2012-10-17" ;
+                                                                                     <http://purl.org/dc/elements/1.1/source> "PMID:18802465" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+                                                                                     rdfs:comment "anatomy TS24 epidermis ; EMAP:14190" ,
+                                                                                                  "has_participant(EMAPA:19660 TS26)" .
+
+
+###  http://model.geneontology.org/MGI_MGI_2676312/c2516f86-4f92-434f-bdd5-d35610474981
+<http://model.geneontology.org/MGI_MGI_2676312/c2516f86-4f92-434f-bdd5-d35610474981> rdf:type owl:NamedIndividual ,
+                                                                                              <http://purl.obolibrary.org/obo/ECO_0000315> ;
+                                                                                     <http://geneontology.org/lego/evidence-with> "MGI:MGI:4461044" ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X" ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2012-10-17" ;
+                                                                                     <http://purl.org/dc/elements/1.1/source> "PMID:18802465" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+                                                                                     rdfs:comment "anatomy TS26 epidermis stratum corneum ; EMAP:33921" ,
+                                                                                                  "has_participant(EMAPA:32787 TS26)" .
+
+
+###  http://model.geneontology.org/MGI_MGI_2676312/c3374c83-b41d-4969-b6b1-ca4a3a6acfec
+<http://model.geneontology.org/MGI_MGI_2676312/c3374c83-b41d-4969-b6b1-ca4a3a6acfec> rdf:type owl:NamedIndividual ,
+                                                                                              <http://purl.obolibrary.org/obo/ECO_0000315> ;
+                                                                                     <http://geneontology.org/lego/evidence-with> "MGI:MGI:3528440" ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X" ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2012-10-17" ;
+                                                                                     <http://purl.org/dc/elements/1.1/source> "PMID:18957418" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+                                                                                     rdfs:comment "anatomy lung ; MA:0000415" ,
+                                                                                                  "cell type type II pneumocyte ; CL:0002063" ,
+                                                                                                  "has_participant(CL:0002063)" .
+
+
+###  http://model.geneontology.org/MGI_MGI_2676312/c4ee40a4-6dc3-4f90-ae24-52281e5eb3e2
+<http://model.geneontology.org/MGI_MGI_2676312/c4ee40a4-6dc3-4f90-ae24-52281e5eb3e2> rdf:type owl:NamedIndividual ,
+                                                                                              <http://purl.obolibrary.org/obo/GO_0031424> ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X" ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2012-10-17" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org" .
+
+
+###  http://model.geneontology.org/MGI_MGI_2676312/c93c126d-c552-4dfb-9223-8cc38a0c1e2b
+<http://model.geneontology.org/MGI_MGI_2676312/c93c126d-c552-4dfb-9223-8cc38a0c1e2b> rdf:type owl:NamedIndividual ,
+                                                                                              <http://purl.obolibrary.org/obo/ECO_0000315> ;
+                                                                                     <http://geneontology.org/lego/evidence-with> "MGI:MGI:3809668" ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X" ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2012-10-17" ;
+                                                                                     <http://purl.org/dc/elements/1.1/source> "PMID:18632686" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+                                                                                     rdfs:comment "anatomy TS26 epidermis stratum corneum ; EMAP:33921" ,
+                                                                                                  "has_participant(EMAPA:32787 TS26)" .
+
+
+###  http://model.geneontology.org/MGI_MGI_2676312/cd71d27b-3350-40ab-9759-fa25e6921255
+<http://model.geneontology.org/MGI_MGI_2676312/cd71d27b-3350-40ab-9759-fa25e6921255> rdf:type owl:NamedIndividual ,
+                                                                                              <http://purl.obolibrary.org/obo/GO_0003674> ;
+                                                                                     <http://purl.obolibrary.org/obo/RO_0002333> <http://model.geneontology.org/MGI_MGI_2676312/bbcd1c30-eafd-48d3-afa9-6d3c4289d293> ;
+                                                                                     <http://purl.obolibrary.org/obo/RO_0002418> <http://model.geneontology.org/MGI_MGI_2676312/1173f672-db56-439d-99ae-2e30916d80a1> ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X"^^xsd:string ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2013-10-25" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org"^^xsd:string .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource <http://model.geneontology.org/MGI_MGI_2676312/cd71d27b-3350-40ab-9759-fa25e6921255> ;
+   owl:annotatedProperty <http://purl.obolibrary.org/obo/RO_0002418> ;
+   owl:annotatedTarget <http://model.geneontology.org/MGI_MGI_2676312/1173f672-db56-439d-99ae-2e30916d80a1> ;
+   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_2676312/a544a242-c396-465b-9246-04422d46526b> ;
+   <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X"^^xsd:string ;
+   <http://purl.org/dc/elements/1.1/date> "2013-10-25" ;
+   <http://purl.org/pav/providedBy> "http://informatics.jax.org"^^xsd:string ;
+   rdfs:comment "MGI:MGI:2676312  RO:0002264 GO:0010875 MGI:MGI:5510615|PMID:23931754 ECO:0000316 MGI:MGI:1352463  2013-10-25 MGI  creation-date=2013-10-25|modification-date=2013-10-25|comment=cell type TIB-71   permanent cell line cell ; CLO:0000019|comment=RAW 264.7|contributor-id=https://orcid.org/0000-0001-5501-853X"
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource <http://model.geneontology.org/MGI_MGI_2676312/cd71d27b-3350-40ab-9759-fa25e6921255> ;
+   owl:annotatedProperty <http://purl.obolibrary.org/obo/RO_0002333> ;
+   owl:annotatedTarget <http://model.geneontology.org/MGI_MGI_2676312/bbcd1c30-eafd-48d3-afa9-6d3c4289d293> ;
+   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_2676312/11bb88ce-4f9f-41d7-9f84-b28cc3ab2856> ;
+   <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X"^^xsd:string ;
+   <http://purl.org/dc/elements/1.1/date> "2013-10-25" ;
+   <http://purl.org/pav/providedBy> "http://informatics.jax.org"^^xsd:string ;
+   rdfs:comment "MGI:MGI:2676312  RO:0002264 GO:0010875 MGI:MGI:5510615|PMID:23931754 ECO:0000316 MGI:MGI:1352463  2013-10-25 MGI  creation-date=2013-10-25|modification-date=2013-10-25|comment=cell type TIB-71   permanent cell line cell ; CLO:0000019|comment=RAW 264.7|contributor-id=https://orcid.org/0000-0001-5501-853X"
+ ] .
+
+
+###  http://model.geneontology.org/MGI_MGI_2676312/cd741a06-b933-4052-a600-47ca4ac02924
+<http://model.geneontology.org/MGI_MGI_2676312/cd741a06-b933-4052-a600-47ca4ac02924> rdf:type owl:NamedIndividual ,
+                                                                                              <http://purl.obolibrary.org/obo/ECO_0000315> ;
+                                                                                     <http://geneontology.org/lego/evidence-with> "MGI:MGI:3528440" ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X" ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2012-10-17" ;
+                                                                                     <http://purl.org/dc/elements/1.1/source> "PMID:18957418" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+                                                                                     rdfs:comment "anatomy skin ; MA:0000151" .
+
+
+###  http://model.geneontology.org/MGI_MGI_2676312/ce7b3f09-ae6b-447a-b27f-b9954633ebc5
+<http://model.geneontology.org/MGI_MGI_2676312/ce7b3f09-ae6b-447a-b27f-b9954633ebc5> rdf:type owl:NamedIndividual ,
+                                                                                              <http://purl.obolibrary.org/obo/GO_0005743> ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ,
+                                                                                                                                   "https://orcid.org/0000-0003-2689-5511" ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2008-08-11" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org" .
+
+
+###  http://model.geneontology.org/MGI_MGI_2676312/d0d205ae-9096-4c73-a01a-734f9a5e67cd
+<http://model.geneontology.org/MGI_MGI_2676312/d0d205ae-9096-4c73-a01a-734f9a5e67cd> rdf:type owl:NamedIndividual ,
+                                                                                              <http://purl.obolibrary.org/obo/GO_0005829> ;
+                                                                                     <http://purl.obolibrary.org/obo/BFO_0000050> <http://model.geneontology.org/MGI_MGI_2676312/e059befb-70d0-4fc1-ac3e-18caec898507> ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X"^^xsd:string ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2012-10-17" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org"^^xsd:string .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource <http://model.geneontology.org/MGI_MGI_2676312/d0d205ae-9096-4c73-a01a-734f9a5e67cd> ;
+   owl:annotatedProperty <http://purl.obolibrary.org/obo/BFO_0000050> ;
+   owl:annotatedTarget <http://model.geneontology.org/MGI_MGI_2676312/e059befb-70d0-4fc1-ac3e-18caec898507> ;
+   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_2676312/aff572ff-0afa-4041-b06c-c4394487a92d> ;
+   <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X"^^xsd:string ;
+   <http://purl.org/dc/elements/1.1/date> "2012-10-17" ;
+   <http://purl.org/pav/providedBy> "http://informatics.jax.org"^^xsd:string ;
+   rdfs:comment "MGI:MGI:2676312  RO:0001025 GO:0005829 MGI:MGI:3807143|PMID:18632686 ECO:0000314   2012-10-17 MGI BFO:0000050(CL:0000082) creation-date=2012-10-17|modification-date=2012-10-17|comment=cell type epithelial cell of lung ; CL:0000082|contributor-id=https://orcid.org/0000-0001-5501-853X"
+ ] .
+
+
+###  http://model.geneontology.org/MGI_MGI_2676312/d68459b9-4221-4df0-9e15-cc579e038d73
+<http://model.geneontology.org/MGI_MGI_2676312/d68459b9-4221-4df0-9e15-cc579e038d73> rdf:type owl:NamedIndividual ,
+                                                                                              <http://purl.obolibrary.org/obo/CL_0000312> ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X" ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2012-10-17" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org" .
+
+
+###  http://model.geneontology.org/MGI_MGI_2676312/d707df52-6a0c-4dbd-a662-ee63a51a56ae
+<http://model.geneontology.org/MGI_MGI_2676312/d707df52-6a0c-4dbd-a662-ee63a51a56ae> rdf:type owl:NamedIndividual ,
+                                                                                              <http://purl.obolibrary.org/obo/GO_0043129> ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X" ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2012-10-17" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org" .
+
+
+###  http://model.geneontology.org/MGI_MGI_2676312/e059befb-70d0-4fc1-ac3e-18caec898507
+<http://model.geneontology.org/MGI_MGI_2676312/e059befb-70d0-4fc1-ac3e-18caec898507> rdf:type owl:NamedIndividual ,
+                                                                                              <http://purl.obolibrary.org/obo/CL_0000082> ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X" ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2012-10-17" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org" .
+
+
+###  http://model.geneontology.org/MGI_MGI_2676312/e0d82f74-4662-4f86-84c1-4090eaef0e4f
+<http://model.geneontology.org/MGI_MGI_2676312/e0d82f74-4662-4f86-84c1-4090eaef0e4f> rdf:type owl:NamedIndividual ,
+                                                                                              <http://purl.obolibrary.org/obo/ECO_0000315> ;
+                                                                                     <http://geneontology.org/lego/evidence-with> "MGI:MGI:3528440" ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X" ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2012-10-17" ;
+                                                                                     <http://purl.org/dc/elements/1.1/source> "PMID:18957418" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+                                                                                     rdfs:comment "anatomy lung ; MA:0000415" ,
+                                                                                                  "cell type type II pneumocyte ; CL:0002063" ,
+                                                                                                  "has_participant(CL:0002063)" .
+
+
+###  http://model.geneontology.org/MGI_MGI_2676312/e1767a03-d690-4527-87c1-648aa1c02881
+<http://model.geneontology.org/MGI_MGI_2676312/e1767a03-d690-4527-87c1-648aa1c02881> rdf:type owl:NamedIndividual ,
+                                                                                              <http://purl.obolibrary.org/obo/ECO_0000315> ;
+                                                                                     <http://geneontology.org/lego/evidence-with> "MGI:MGI:4461044" ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X" ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2013-10-25" ;
+                                                                                     <http://purl.org/dc/elements/1.1/source> "PMID:23931754" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+                                                                                     rdfs:comment "cell type Kupffer cell ; CL:0000091   primary cell line cell ; CL:0000001" .
+
+
+###  http://model.geneontology.org/MGI_MGI_2676312/e1b97bc0-a147-4eff-99b2-c4ec44d47a7e
+<http://model.geneontology.org/MGI_MGI_2676312/e1b97bc0-a147-4eff-99b2-c4ec44d47a7e> rdf:type owl:NamedIndividual ,
+                                                                                              <http://purl.obolibrary.org/obo/ECO_0000315> ;
+                                                                                     <http://geneontology.org/lego/evidence-with> "MGI:MGI:3528440" ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X" ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2012-10-17" ;
+                                                                                     <http://purl.org/dc/elements/1.1/source> "PMID:18957418" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+                                                                                     rdfs:comment "anatomy lung ; MA:0000415" ,
+                                                                                                  "cell type type II pneumocyte ; CL:0002063" ,
+                                                                                                  "has_participant(CL:0002063)" .
+
+
+###  http://model.geneontology.org/MGI_MGI_2676312/e6166c68-5316-46ec-bac7-c1a963beeae0
+<http://model.geneontology.org/MGI_MGI_2676312/e6166c68-5316-46ec-bac7-c1a963beeae0> rdf:type owl:NamedIndividual ,
+                                                                                              [ rdf:type owl:Class ;
+                                                                                                owl:complementOf <http://purl.obolibrary.org/obo/GO_0048286>
+                                                                                              ] ;
+                                                                                     <http://purl.obolibrary.org/obo/RO_0002296> <http://model.geneontology.org/MGI_MGI_2676312/71c26b83-0f41-48bc-852a-2f4379803c60> ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X"^^xsd:string ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2012-10-17" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org"^^xsd:string .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource <http://model.geneontology.org/MGI_MGI_2676312/e6166c68-5316-46ec-bac7-c1a963beeae0> ;
+   owl:annotatedProperty <http://purl.obolibrary.org/obo/RO_0002296> ;
+   owl:annotatedTarget <http://model.geneontology.org/MGI_MGI_2676312/71c26b83-0f41-48bc-852a-2f4379803c60> ;
+   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_2676312/53855a60-2d7c-4bb1-98a8-460c0f84d27b> ;
+   <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X"^^xsd:string ;
+   <http://purl.org/dc/elements/1.1/date> "2012-10-17" ;
+   <http://purl.org/pav/providedBy> "http://informatics.jax.org"^^xsd:string ;
+   rdfs:comment "MGI:MGI:2676312 NOT RO:0002264 GO:0048286 MGI:MGI:3829841|PMID:18957418 ECO:0000315 MGI:MGI:3528440  2012-10-17 MGI RO:0002296(EMAPA:16728) creation-date=2012-10-17|modification-date=2012-10-17|comment=anatomy lung ; MA:0000415|comment=cell type type II pneumocyte ; CL:0002063|comment=has_participant(CL:0002063)|contributor-id=https://orcid.org/0000-0001-5501-853X"
+ ] .
+
+
+###  http://model.geneontology.org/MGI_MGI_2676312/e701b59b-9b84-468b-8357-4632f0a7a3b3
+<http://model.geneontology.org/MGI_MGI_2676312/e701b59b-9b84-468b-8357-4632f0a7a3b3> rdf:type owl:NamedIndividual ,
+                                                                                              <http://purl.obolibrary.org/obo/ECO_0000315> ;
+                                                                                     <http://geneontology.org/lego/evidence-with> "MGI:MGI:4461044" ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X" ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2012-10-17" ;
+                                                                                     <http://purl.org/dc/elements/1.1/source> "PMID:18802465" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+                                                                                     rdfs:comment "anatomy TS26 epidermis stratum corneum ; EMAP:33921" ,
+                                                                                                  "has_participant(EMAPA:32787 TS26)" .
+
+
+###  http://model.geneontology.org/MGI_MGI_2676312/e8affde6-c74e-4d05-ae70-716849ce7e8d
+<http://model.geneontology.org/MGI_MGI_2676312/e8affde6-c74e-4d05-ae70-716849ce7e8d> rdf:type owl:NamedIndividual ,
+                                                                                              <http://purl.obolibrary.org/obo/ECO_0000315> ;
+                                                                                     <http://geneontology.org/lego/evidence-with> "MGI:MGI:3528440" ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X" ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2012-10-17" ;
+                                                                                     <http://purl.org/dc/elements/1.1/source> "PMID:18957418" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+                                                                                     rdfs:comment "anatomy TS26 epidermis stratum corneum ; EMAP:33921" ,
+                                                                                                  "has_participant(EMAPA:32787 TS26)" .
+
+
+###  http://model.geneontology.org/MGI_MGI_2676312/e9238e4e-d0eb-492f-8054-93517f157ac9
+<http://model.geneontology.org/MGI_MGI_2676312/e9238e4e-d0eb-492f-8054-93517f157ac9> rdf:type owl:NamedIndividual ,
+                                                                                              <http://purl.obolibrary.org/obo/GO_0061436> ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X" ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2012-10-17" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org" .
+
+
+###  http://model.geneontology.org/MGI_MGI_2676312/e9c436bf-a6ec-48aa-9f1f-d7816abc0cef
+<http://model.geneontology.org/MGI_MGI_2676312/e9c436bf-a6ec-48aa-9f1f-d7816abc0cef> rdf:type owl:NamedIndividual ,
+                                                                                              <http://purl.obolibrary.org/obo/ECO_0000315> ;
+                                                                                     <http://geneontology.org/lego/evidence-with> "MGI:MGI:4461044" ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X" ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2012-10-17" ;
+                                                                                     <http://purl.org/dc/elements/1.1/source> "PMID:18802465" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+                                                                                     rdfs:comment "anatomy TS24 epidermis ; EMAP:14190" ,
+                                                                                                  "has_participant(EMAPA:19660 TS26)" .
+
+
+###  http://model.geneontology.org/MGI_MGI_2676312/ef7cff45-2cdf-44ac-bec3-b5fb14bc71b2
+<http://model.geneontology.org/MGI_MGI_2676312/ef7cff45-2cdf-44ac-bec3-b5fb14bc71b2> rdf:type owl:NamedIndividual ,
+                                                                                              <http://purl.obolibrary.org/obo/GO_0005515> ;
+                                                                                     <http://purl.obolibrary.org/obo/RO_0002233> <http://model.geneontology.org/MGI_MGI_2676312/f8eccfda-7585-480e-82d1-67eed863885c> ;
+                                                                                     <http://purl.obolibrary.org/obo/RO_0002333> <http://model.geneontology.org/MGI_MGI_2676312/af2339e9-927f-41c2-ac2c-696092aa1c3b> ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X"^^xsd:string ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2013-10-25" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org"^^xsd:string .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource <http://model.geneontology.org/MGI_MGI_2676312/ef7cff45-2cdf-44ac-bec3-b5fb14bc71b2> ;
+   owl:annotatedProperty <http://purl.obolibrary.org/obo/RO_0002233> ;
+   owl:annotatedTarget <http://model.geneontology.org/MGI_MGI_2676312/f8eccfda-7585-480e-82d1-67eed863885c> ;
+   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_2676312/52863d8e-6687-4b96-922f-e3cfb92e1c17> ;
+   <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X"^^xsd:string ;
+   <http://purl.org/dc/elements/1.1/date> "2013-10-25" ;
+   <http://purl.org/pav/providedBy> "http://informatics.jax.org"^^xsd:string ;
+   rdfs:comment "MGI:MGI:2676312  RO:0002327 GO:0005515 MGI:MGI:5510615|PMID:23931754 ECO:0000353 PR:Q60644  2013-10-25 MGI  creation-date=2013-10-25|modification-date=2013-10-25|comment=cell type TIB-71   permanent cell line cell ; CLO:0000019|comment=In situ proximity ligation assay|comment=RAW 264.7|contributor-id=https://orcid.org/0000-0001-5501-853X"
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource <http://model.geneontology.org/MGI_MGI_2676312/ef7cff45-2cdf-44ac-bec3-b5fb14bc71b2> ;
+   owl:annotatedProperty <http://purl.obolibrary.org/obo/RO_0002333> ;
+   owl:annotatedTarget <http://model.geneontology.org/MGI_MGI_2676312/af2339e9-927f-41c2-ac2c-696092aa1c3b> ;
+   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_2676312/3a2a2874-d4ef-4831-bb8a-067ab78c2917> ;
+   <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X"^^xsd:string ;
+   <http://purl.org/dc/elements/1.1/date> "2013-10-25" ;
+   <http://purl.org/pav/providedBy> "http://informatics.jax.org"^^xsd:string ;
+   rdfs:comment "MGI:MGI:2676312  RO:0002327 GO:0005515 MGI:MGI:5510615|PMID:23931754 ECO:0000353 PR:Q60644  2013-10-25 MGI  creation-date=2013-10-25|modification-date=2013-10-25|comment=cell type TIB-71   permanent cell line cell ; CLO:0000019|comment=In situ proximity ligation assay|comment=RAW 264.7|contributor-id=https://orcid.org/0000-0001-5501-853X"
+ ] .
+
+
+###  http://model.geneontology.org/MGI_MGI_2676312/f3e93138-f661-4752-a418-49cd83d205e3
+<http://model.geneontology.org/MGI_MGI_2676312/f3e93138-f661-4752-a418-49cd83d205e3> rdf:type owl:NamedIndividual ,
+                                                                                              <http://purl.obolibrary.org/obo/GO_0003674> ;
+                                                                                     <http://purl.obolibrary.org/obo/RO_0002333> <http://model.geneontology.org/MGI_MGI_2676312/3071056e-8d64-49f7-a8c1-bd61af387fce> ;
+                                                                                     <http://purl.obolibrary.org/obo/RO_0002418> <http://model.geneontology.org/MGI_MGI_2676312/787df50a-9120-45b9-9301-c19d7f2a1037> ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X"^^xsd:string ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2013-10-25" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org"^^xsd:string .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource <http://model.geneontology.org/MGI_MGI_2676312/f3e93138-f661-4752-a418-49cd83d205e3> ;
+   owl:annotatedProperty <http://purl.obolibrary.org/obo/RO_0002333> ;
+   owl:annotatedTarget <http://model.geneontology.org/MGI_MGI_2676312/3071056e-8d64-49f7-a8c1-bd61af387fce> ;
+   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_2676312/b5ca744c-577f-4f95-a75a-2ec170a0630d> ;
+   <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X"^^xsd:string ;
+   <http://purl.org/dc/elements/1.1/date> "2013-10-25" ;
+   <http://purl.org/pav/providedBy> "http://informatics.jax.org"^^xsd:string ;
+   rdfs:comment "MGI:MGI:2676312  RO:0002264 GO:2000010 MGI:MGI:5510615|PMID:23931754 ECO:0000315   2013-10-25 MGI  creation-date=2013-10-25|modification-date=2013-10-25|comment=cell type TIB-71   permanent cell line cell ; CLO:0000019|comment=evidence RNAi evidence ; ECO:0000019|comment=target UniProtKB:P41233|comment=RAW 264.7|contributor-id=https://orcid.org/0000-0001-5501-853X"
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource <http://model.geneontology.org/MGI_MGI_2676312/f3e93138-f661-4752-a418-49cd83d205e3> ;
+   owl:annotatedProperty <http://purl.obolibrary.org/obo/RO_0002418> ;
+   owl:annotatedTarget <http://model.geneontology.org/MGI_MGI_2676312/787df50a-9120-45b9-9301-c19d7f2a1037> ;
+   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_2676312/1ca1136f-d4eb-467c-ae83-1e0d44eb70e7> ;
+   <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X"^^xsd:string ;
+   <http://purl.org/dc/elements/1.1/date> "2013-10-25" ;
+   <http://purl.org/pav/providedBy> "http://informatics.jax.org"^^xsd:string ;
+   rdfs:comment "MGI:MGI:2676312  RO:0002264 GO:2000010 MGI:MGI:5510615|PMID:23931754 ECO:0000315   2013-10-25 MGI  creation-date=2013-10-25|modification-date=2013-10-25|comment=cell type TIB-71   permanent cell line cell ; CLO:0000019|comment=evidence RNAi evidence ; ECO:0000019|comment=target UniProtKB:P41233|comment=RAW 264.7|contributor-id=https://orcid.org/0000-0001-5501-853X"
+ ] .
+
+
+###  http://model.geneontology.org/MGI_MGI_2676312/f61de7a6-b27f-4197-97a5-db8f277e3ad2
+<http://model.geneontology.org/MGI_MGI_2676312/f61de7a6-b27f-4197-97a5-db8f277e3ad2> rdf:type owl:NamedIndividual ,
+                                                                                              <http://identifiers.org/mgi/MGI:2676312> ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X" ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2012-10-17" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org" .
+
+
+###  http://model.geneontology.org/MGI_MGI_2676312/f8eccfda-7585-480e-82d1-67eed863885c
+<http://model.geneontology.org/MGI_MGI_2676312/f8eccfda-7585-480e-82d1-67eed863885c> rdf:type owl:NamedIndividual ,
+                                                                                              <http://purl.obolibrary.org/obo/PR_Q60644> ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X" ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2013-10-25" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org" .
+
+
+###  http://model.geneontology.org/MGI_MGI_2676312/fae12149-d928-4983-9e68-3aceeddc56fc
+<http://model.geneontology.org/MGI_MGI_2676312/fae12149-d928-4983-9e68-3aceeddc56fc> rdf:type owl:NamedIndividual ,
+                                                                                              <http://purl.obolibrary.org/obo/ECO_0000315> ;
+                                                                                     <http://geneontology.org/lego/evidence-with> "MGI:MGI:3528440" ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X" ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2012-10-17" ;
+                                                                                     <http://purl.org/dc/elements/1.1/source> "PMID:18957418" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+                                                                                     rdfs:comment "anatomy skin ; MA:0000151" .
+
+
+###  http://model.geneontology.org/MGI_MGI_2676312/fb56d6de-3da5-4bab-bc20-7577889ebfef
+<http://model.geneontology.org/MGI_MGI_2676312/fb56d6de-3da5-4bab-bc20-7577889ebfef> rdf:type owl:NamedIndividual ,
+                                                                                              <http://purl.obolibrary.org/obo/CL_0000091> ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X" ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2013-10-25" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org" .
+
+
+###  http://model.geneontology.org/MGI_MGI_2676312/fef6454f-b218-4b29-86a3-82c023014aef
+<http://model.geneontology.org/MGI_MGI_2676312/fef6454f-b218-4b29-86a3-82c023014aef> rdf:type owl:NamedIndividual ,
+                                                                                              <http://purl.obolibrary.org/obo/ECO_0000315> ;
+                                                                                     <http://geneontology.org/lego/evidence-with> "MGI:MGI:4461044" ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X" ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2012-10-17" ;
+                                                                                     <http://purl.org/dc/elements/1.1/source> "PMID:18802465" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+                                                                                     rdfs:comment "anatomy TS26 epidermis stratum corneum ; EMAP:33921" ,
+                                                                                                  "cell type skin fibroblast ; CL:0002620" ,
+                                                                                                  "has_participant(CL:0002620)" ,
+                                                                                                  "has_participant(EMAPA:32787 TS26)" .
+
+
+###  http://model.geneontology.org/MGI_MGI_2676312/0fa8be2b-4b46-4e4d-9763-18d11c445be8
+<http://model.geneontology.org/MGI_MGI_2676312/0fa8be2b-4b46-4e4d-9763-18d11c445be8> rdf:type owl:NamedIndividual ,
+                                                                                              <http://identifiers.org/mgi/MGI:2676312> ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X" ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2012-10-17" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org" .
+
+
+###  http://model.geneontology.org/MGI_MGI_2676312/01159f74-69be-4c19-bc6b-be19e3b766ef
+<http://model.geneontology.org/MGI_MGI_2676312/01159f74-69be-4c19-bc6b-be19e3b766ef> rdf:type owl:NamedIndividual ,
+                                                                                              <http://purl.obolibrary.org/obo/GO_0035627> ;
+                                                                                     <http://purl.obolibrary.org/obo/BFO_0000066> <http://model.geneontology.org/MGI_MGI_2676312/70e6fbf9-76b8-4c2e-967a-c4cc99f29b1f> ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X"^^xsd:string ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2012-10-17" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org"^^xsd:string .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource <http://model.geneontology.org/MGI_MGI_2676312/01159f74-69be-4c19-bc6b-be19e3b766ef> ;
+   owl:annotatedProperty <http://purl.obolibrary.org/obo/BFO_0000066> ;
+   owl:annotatedTarget <http://model.geneontology.org/MGI_MGI_2676312/70e6fbf9-76b8-4c2e-967a-c4cc99f29b1f> ;
+   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_2676312/829c3fb3-3000-48ce-a0a8-94630fa9dbed> ;
+   <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X"^^xsd:string ;
+   <http://purl.org/dc/elements/1.1/date> "2012-10-17" ;
+   <http://purl.org/pav/providedBy> "http://informatics.jax.org"^^xsd:string ;
+   rdfs:comment "MGI:MGI:2676312  RO:0002264 GO:0035627 MGI:MGI:3829841|PMID:18957418 ECO:0000315 MGI:MGI:3528440  2012-10-17 MGI BFO:0000066(EMAPA:17525) creation-date=2012-10-17|modification-date=2012-10-17|comment=anatomy skin ; MA:0000151|contributor-id=https://orcid.org/0000-0001-5501-853X"
+ ] .
+
+
+###  http://model.geneontology.org/MGI_MGI_2676312/01193371-59df-46b1-b96a-2287fba6cc08
+<http://model.geneontology.org/MGI_MGI_2676312/01193371-59df-46b1-b96a-2287fba6cc08> rdf:type owl:NamedIndividual ,
+                                                                                              <http://purl.obolibrary.org/obo/ECO_0000315> ;
+                                                                                     <http://geneontology.org/lego/evidence-with> "MGI:MGI:3528440" ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X" ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2012-10-17" ;
+                                                                                     <http://purl.org/dc/elements/1.1/source> "PMID:18957418" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+                                                                                     rdfs:comment "anatomy lung ; MA:0000415" ,
+                                                                                                  "cell type type II pneumocyte ; CL:0002063" ,
+                                                                                                  "has_participant(CL:0002063)" .
+
+
+###  http://model.geneontology.org/MGI_MGI_2676312/020dc26f-02ee-485a-a8e5-1ff054df710f
+<http://model.geneontology.org/MGI_MGI_2676312/020dc26f-02ee-485a-a8e5-1ff054df710f> rdf:type owl:NamedIndividual ,
+                                                                                              <http://purl.obolibrary.org/obo/EMAPA_16728> ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X" ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2012-10-17" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org" .
+
+
+###  http://model.geneontology.org/MGI_MGI_2676312/048dfd19-a9d9-4508-85c0-45538d2258fd
+<http://model.geneontology.org/MGI_MGI_2676312/048dfd19-a9d9-4508-85c0-45538d2258fd> rdf:type owl:NamedIndividual ,
+                                                                                              <http://purl.obolibrary.org/obo/ECO_0000315> ;
+                                                                                     <http://geneontology.org/lego/evidence-with> "MGI:MGI:3809668" ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X" ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2012-10-17" ;
+                                                                                     <http://purl.org/dc/elements/1.1/source> "PMID:18632686" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+                                                                                     rdfs:comment "anatomy TS26 embryo ; EMAP:11159" ,
+                                                                                                  "anatomy epidermis stratum corneum ; MA:0000804" ,
+                                                                                                  "cell type keratinocyte ; CL:0000312" ,
+                                                                                                  "has_participant(CL:0000312)" ,
+                                                                                                  "has_participant(EMAPA:16039 TS26)" ,
+                                                                                                  "has_participant(EMAPA:32787 TS28)" .
+
+
+###  http://model.geneontology.org/MGI_MGI_2676312/066d6682-5a9d-4d14-8c06-4aac82c419b1
+<http://model.geneontology.org/MGI_MGI_2676312/066d6682-5a9d-4d14-8c06-4aac82c419b1> rdf:type owl:NamedIndividual ,
+                                                                                              <http://purl.obolibrary.org/obo/ECO_0000315> ;
+                                                                                     <http://geneontology.org/lego/evidence-with> "MGI:MGI:3809668" ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X" ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2012-10-17" ;
+                                                                                     <http://purl.org/dc/elements/1.1/source> "PMID:18632686" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+                                                                                     rdfs:comment "anatomy TS26 embryo ; EMAP:11159" ,
+                                                                                                  "anatomy epidermis stratum corneum ; MA:0000804" ,
+                                                                                                  "cell type keratinocyte ; CL:0000312" ,
+                                                                                                  "has_participant(CL:0000312)" ,
+                                                                                                  "has_participant(EMAPA:16039 TS26)" ,
+                                                                                                  "has_participant(EMAPA:32787 TS28)" .
+
+
+###  http://model.geneontology.org/MGI_MGI_2676312/0899e7c3-2378-4266-9ac6-35b2a616b6df
+<http://model.geneontology.org/MGI_MGI_2676312/0899e7c3-2378-4266-9ac6-35b2a616b6df> rdf:type owl:NamedIndividual ,
+                                                                                              <http://identifiers.org/mgi/MGI:2676312> ;
+                                                                                     <http://purl.obolibrary.org/obo/RO_0001025> <http://model.geneontology.org/MGI_MGI_2676312/ce7b3f09-ae6b-447a-b27f-b9954633ebc5> ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306"^^xsd:string ,
+                                                                                                                                   "https://orcid.org/0000-0003-2689-5511" ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2008-08-11" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org"^^xsd:string .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource <http://model.geneontology.org/MGI_MGI_2676312/0899e7c3-2378-4266-9ac6-35b2a616b6df> ;
+   owl:annotatedProperty <http://purl.obolibrary.org/obo/RO_0001025> ;
+   owl:annotatedTarget <http://model.geneontology.org/MGI_MGI_2676312/ce7b3f09-ae6b-447a-b27f-b9954633ebc5> ;
+   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_2676312/6807efa7-b3b8-4b5b-a41b-c2ecc41b17fc> ;
+   <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306"^^xsd:string ,
+                                                 "https://orcid.org/0000-0003-2689-5511" ;
+   <http://purl.org/dc/elements/1.1/date> "2008-08-11" ;
+   <http://purl.org/pav/providedBy> "http://informatics.jax.org"^^xsd:string ;
+   rdfs:comment "MGI:MGI:2676312  RO:0001025 GO:0005743 MGI:MGI:3590069|PMID:12865426 ECO:0007005   2008-08-11 MGI  creation-date=2005-10-24|modification-date=2008-08-11|comment=ENSMUSP00000027392|contributor-id=https://orcid.org/0000-0001-7476-6306|contributor-id=https://orcid.org/0000-0003-2689-5511"
+ ] .
+
+
+###  http://model.geneontology.org/MGI_MGI_2676312/09370759-7ef4-463f-abbf-876d558c395c
+<http://model.geneontology.org/MGI_MGI_2676312/09370759-7ef4-463f-abbf-876d558c395c> rdf:type owl:NamedIndividual ,
+                                                                                              <http://purl.obolibrary.org/obo/ECO_0000353> ;
+                                                                                     <http://geneontology.org/lego/evidence-with> "PR:P41233" ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X" ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2013-10-25" ;
+                                                                                     <http://purl.org/dc/elements/1.1/source> "PMID:23931754" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+                                                                                     rdfs:comment "In situ proximity ligation assay" ,
+                                                                                                  "RAW 264.7" ,
+                                                                                                  "cell type TIB-71   permanent cell line cell ; CLO:0000019" .
+
+
+###  http://model.geneontology.org/MGI_MGI_2676312/1ca1136f-d4eb-467c-ae83-1e0d44eb70e7
+<http://model.geneontology.org/MGI_MGI_2676312/1ca1136f-d4eb-467c-ae83-1e0d44eb70e7> rdf:type owl:NamedIndividual ,
+                                                                                              <http://purl.obolibrary.org/obo/ECO_0000315> ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X" ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2013-10-25" ;
+                                                                                     <http://purl.org/dc/elements/1.1/source> "PMID:23931754" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+                                                                                     rdfs:comment "RAW 264.7" ,
+                                                                                                  "cell type TIB-71   permanent cell line cell ; CLO:0000019" ,
+                                                                                                  "evidence RNAi evidence ; ECO:0000019" ,
+                                                                                                  "target UniProtKB:P41233" .
+
+
+###  http://model.geneontology.org/MGI_MGI_2676312/11bb88ce-4f9f-41d7-9f84-b28cc3ab2856
+<http://model.geneontology.org/MGI_MGI_2676312/11bb88ce-4f9f-41d7-9f84-b28cc3ab2856> rdf:type owl:NamedIndividual ,
+                                                                                              <http://purl.obolibrary.org/obo/ECO_0000316> ;
+                                                                                     <http://geneontology.org/lego/evidence-with> "MGI:MGI:1352463" ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X" ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2013-10-25" ;
+                                                                                     <http://purl.org/dc/elements/1.1/source> "PMID:23931754" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+                                                                                     rdfs:comment "RAW 264.7" ,
+                                                                                                  "cell type TIB-71   permanent cell line cell ; CLO:0000019" .
+
+
+###  http://model.geneontology.org/MGI_MGI_2676312/1173f672-db56-439d-99ae-2e30916d80a1
+<http://model.geneontology.org/MGI_MGI_2676312/1173f672-db56-439d-99ae-2e30916d80a1> rdf:type owl:NamedIndividual ,
+                                                                                              <http://purl.obolibrary.org/obo/GO_0010875> ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X" ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2013-10-25" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org" .
+
+
+###  http://model.geneontology.org/MGI_MGI_2676312/1590b8cb-9e60-4c78-93bb-f4f932c39e6b
+<http://model.geneontology.org/MGI_MGI_2676312/1590b8cb-9e60-4c78-93bb-f4f932c39e6b> rdf:type owl:NamedIndividual ,
+                                                                                              <http://purl.obolibrary.org/obo/PR_P41233> ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X" ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2013-10-25" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org" .
+
+
+###  http://model.geneontology.org/MGI_MGI_2676312/16b5262f-4d46-4752-91da-db74b73e31a2
+<http://model.geneontology.org/MGI_MGI_2676312/16b5262f-4d46-4752-91da-db74b73e31a2> rdf:type owl:NamedIndividual ,
+                                                                                              <http://purl.obolibrary.org/obo/ECO_0000315> ;
+                                                                                     <http://geneontology.org/lego/evidence-with> "MGI:MGI:4461044" ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X" ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2013-10-25" ;
+                                                                                     <http://purl.org/dc/elements/1.1/source> "PMID:23931754" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+                                                                                     rdfs:comment "cell type Kupffer cell ; CL:0000091   primary cell line cell ; CL:0000001" .
+
+
+###  http://model.geneontology.org/MGI_MGI_2676312/19f42861-1508-4210-93a1-44027944ed5e
+<http://model.geneontology.org/MGI_MGI_2676312/19f42861-1508-4210-93a1-44027944ed5e> rdf:type owl:NamedIndividual ,
+                                                                                              <http://purl.obolibrary.org/obo/ECO_0000315> ;
+                                                                                     <http://geneontology.org/lego/evidence-with> "MGI:MGI:3809668" ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X" ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2012-10-17" ;
+                                                                                     <http://purl.org/dc/elements/1.1/source> "PMID:18632686" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+                                                                                     rdfs:comment "anatomy alveolar system ;  MA:0000416" ,
+                                                                                                  "cell type type II pneumocyte ; CL:0002063" ,
+                                                                                                  "has_participant(CL:0002063)" .
+
+
+###  http://model.geneontology.org/MGI_MGI_2676312/23f25bff-c3cd-4daa-a663-3931f1625037
+<http://model.geneontology.org/MGI_MGI_2676312/23f25bff-c3cd-4daa-a663-3931f1625037> rdf:type owl:NamedIndividual ,
+                                                                                              <http://purl.obolibrary.org/obo/GO_0003674> ;
+                                                                                     <http://purl.obolibrary.org/obo/RO_0002333> <http://model.geneontology.org/MGI_MGI_2676312/ba5d9d2d-de63-4ec7-9d15-a857cee51c97> ;
+                                                                                     <http://purl.obolibrary.org/obo/RO_0002418> <http://model.geneontology.org/MGI_MGI_2676312/c4ee40a4-6dc3-4f90-ae24-52281e5eb3e2> ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X"^^xsd:string ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2012-10-17" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org"^^xsd:string .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource <http://model.geneontology.org/MGI_MGI_2676312/23f25bff-c3cd-4daa-a663-3931f1625037> ;
+   owl:annotatedProperty <http://purl.obolibrary.org/obo/RO_0002333> ;
+   owl:annotatedTarget <http://model.geneontology.org/MGI_MGI_2676312/ba5d9d2d-de63-4ec7-9d15-a857cee51c97> ;
+   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_2676312/bfb248e7-8328-4592-9c42-09e35573cbdd> ,
+                                           <http://model.geneontology.org/MGI_MGI_2676312/c93c126d-c552-4dfb-9223-8cc38a0c1e2b> ,
+                                           <http://model.geneontology.org/MGI_MGI_2676312/7b7f6c79-1016-4f37-9d74-77d445262d4e> ;
+   <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X"^^xsd:string ;
+   <http://purl.org/dc/elements/1.1/date> "2012-10-17" ;
+   <http://purl.org/pav/providedBy> "http://informatics.jax.org"^^xsd:string ;
+   rdfs:comment "MGI:MGI:2676312  RO:0002264 GO:0031424 MGI:MGI:3807143|PMID:18632686 ECO:0000315 MGI:MGI:3809668  2012-10-17 MGI  creation-date=2012-10-17|modification-date=2012-10-17|comment=anatomy TS26 epidermis stratum corneum ; EMAP:33921|comment=has_participant(EMAPA:32787 TS26)|contributor-id=https://orcid.org/0000-0001-5501-853X" ,
+                "MGI:MGI:2676312  RO:0002264 GO:0031424 MGI:MGI:3829841|PMID:18957418 ECO:0000315 MGI:MGI:3528440  2012-10-17 MGI  creation-date=2012-10-17|modification-date=2012-10-17|comment=anatomy epidermis stratum corneum ; MA:0000804|comment=has_participant(EMAPA:32787 TS28)|contributor-id=https://orcid.org/0000-0001-5501-853X" ,
+                "MGI:MGI:2676312  RO:0002264 GO:0031424 MGI:MGI:4460077|PMID:18802465 ECO:0000315 MGI:MGI:4461044  2012-10-17 MGI  creation-date=2012-10-17|modification-date=2012-10-17|comment=anatomy TS24 epidermis ; EMAP:14190|comment=has_participant(EMAPA:19660 TS26)|contributor-id=https://orcid.org/0000-0001-5501-853X"
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource <http://model.geneontology.org/MGI_MGI_2676312/23f25bff-c3cd-4daa-a663-3931f1625037> ;
+   owl:annotatedProperty <http://purl.obolibrary.org/obo/RO_0002418> ;
+   owl:annotatedTarget <http://model.geneontology.org/MGI_MGI_2676312/c4ee40a4-6dc3-4f90-ae24-52281e5eb3e2> ;
+   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_2676312/af9dfad9-ba97-48cb-8062-460cfafd2eea> ,
+                                           <http://model.geneontology.org/MGI_MGI_2676312/e9c436bf-a6ec-48aa-9f1f-d7816abc0cef> ,
+                                           <http://model.geneontology.org/MGI_MGI_2676312/8a05e73f-7416-42fc-bcf3-c9f3e24c9af1> ;
+   <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X"^^xsd:string ;
+   <http://purl.org/dc/elements/1.1/date> "2012-10-17" ;
+   <http://purl.org/pav/providedBy> "http://informatics.jax.org"^^xsd:string ;
+   rdfs:comment "MGI:MGI:2676312  RO:0002264 GO:0031424 MGI:MGI:3807143|PMID:18632686 ECO:0000315 MGI:MGI:3809668  2012-10-17 MGI  creation-date=2012-10-17|modification-date=2012-10-17|comment=anatomy TS26 epidermis stratum corneum ; EMAP:33921|comment=has_participant(EMAPA:32787 TS26)|contributor-id=https://orcid.org/0000-0001-5501-853X" ,
+                "MGI:MGI:2676312  RO:0002264 GO:0031424 MGI:MGI:3829841|PMID:18957418 ECO:0000315 MGI:MGI:3528440  2012-10-17 MGI  creation-date=2012-10-17|modification-date=2012-10-17|comment=anatomy epidermis stratum corneum ; MA:0000804|comment=has_participant(EMAPA:32787 TS28)|contributor-id=https://orcid.org/0000-0001-5501-853X" ,
+                "MGI:MGI:2676312  RO:0002264 GO:0031424 MGI:MGI:4460077|PMID:18802465 ECO:0000315 MGI:MGI:4461044  2012-10-17 MGI  creation-date=2012-10-17|modification-date=2012-10-17|comment=anatomy TS24 epidermis ; EMAP:14190|comment=has_participant(EMAPA:19660 TS26)|contributor-id=https://orcid.org/0000-0001-5501-853X"
+ ] .
+
+
+###  http://model.geneontology.org/MGI_MGI_2676312/241092aa-39c8-4308-a164-e9074a6a59e2
+<http://model.geneontology.org/MGI_MGI_2676312/241092aa-39c8-4308-a164-e9074a6a59e2> rdf:type owl:NamedIndividual ,
+                                                                                              <http://purl.obolibrary.org/obo/GO_0003674> ;
+                                                                                     <http://purl.obolibrary.org/obo/RO_0002333> <http://model.geneontology.org/MGI_MGI_2676312/483de97c-0a16-478c-8e55-e65d498554f3> ;
+                                                                                     <http://purl.obolibrary.org/obo/RO_0002418> <http://model.geneontology.org/MGI_MGI_2676312/e6166c68-5316-46ec-bac7-c1a963beeae0> ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X"^^xsd:string ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2012-10-17" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org"^^xsd:string .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource <http://model.geneontology.org/MGI_MGI_2676312/241092aa-39c8-4308-a164-e9074a6a59e2> ;
+   owl:annotatedProperty <http://purl.obolibrary.org/obo/RO_0002333> ;
+   owl:annotatedTarget <http://model.geneontology.org/MGI_MGI_2676312/483de97c-0a16-478c-8e55-e65d498554f3> ;
+   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_2676312/e1b97bc0-a147-4eff-99b2-c4ec44d47a7e> ;
+   <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X"^^xsd:string ;
+   <http://purl.org/dc/elements/1.1/date> "2012-10-17" ;
+   <http://purl.org/pav/providedBy> "http://informatics.jax.org"^^xsd:string ;
+   rdfs:comment "MGI:MGI:2676312 NOT RO:0002264 GO:0048286 MGI:MGI:3829841|PMID:18957418 ECO:0000315 MGI:MGI:3528440  2012-10-17 MGI RO:0002296(EMAPA:16728) creation-date=2012-10-17|modification-date=2012-10-17|comment=anatomy lung ; MA:0000415|comment=cell type type II pneumocyte ; CL:0002063|comment=has_participant(CL:0002063)|contributor-id=https://orcid.org/0000-0001-5501-853X"
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource <http://model.geneontology.org/MGI_MGI_2676312/241092aa-39c8-4308-a164-e9074a6a59e2> ;
+   owl:annotatedProperty <http://purl.obolibrary.org/obo/RO_0002418> ;
+   owl:annotatedTarget <http://model.geneontology.org/MGI_MGI_2676312/e6166c68-5316-46ec-bac7-c1a963beeae0> ;
+   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_2676312/ab518c5e-ce62-4125-99ef-492138fdc320> ;
+   <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X"^^xsd:string ;
+   <http://purl.org/dc/elements/1.1/date> "2012-10-17" ;
+   <http://purl.org/pav/providedBy> "http://informatics.jax.org"^^xsd:string ;
+   rdfs:comment "MGI:MGI:2676312 NOT RO:0002264 GO:0048286 MGI:MGI:3829841|PMID:18957418 ECO:0000315 MGI:MGI:3528440  2012-10-17 MGI RO:0002296(EMAPA:16728) creation-date=2012-10-17|modification-date=2012-10-17|comment=anatomy lung ; MA:0000415|comment=cell type type II pneumocyte ; CL:0002063|comment=has_participant(CL:0002063)|contributor-id=https://orcid.org/0000-0001-5501-853X"
+ ] .
+
+
+###  http://model.geneontology.org/MGI_MGI_2676312/26f02155-72b3-4f48-be3c-703245dae2cc
+<http://model.geneontology.org/MGI_MGI_2676312/26f02155-72b3-4f48-be3c-703245dae2cc> rdf:type owl:NamedIndividual ,
+                                                                                              <http://identifiers.org/mgi/MGI:2676312> ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X" ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2012-10-17" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org" .
+
+
+###  http://model.geneontology.org/MGI_MGI_2676312/287f851e-bcb4-44db-91d4-263abb9e3180
+<http://model.geneontology.org/MGI_MGI_2676312/287f851e-bcb4-44db-91d4-263abb9e3180> rdf:type owl:NamedIndividual ,
+                                                                                              <http://identifiers.org/mgi/MGI:2676312> ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X" ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2012-10-17" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org" .
+
+
+###  http://model.geneontology.org/MGI_MGI_2676312/3a2a2874-d4ef-4831-bb8a-067ab78c2917
+<http://model.geneontology.org/MGI_MGI_2676312/3a2a2874-d4ef-4831-bb8a-067ab78c2917> rdf:type owl:NamedIndividual ,
+                                                                                              <http://purl.obolibrary.org/obo/ECO_0000353> ;
+                                                                                     <http://geneontology.org/lego/evidence-with> "PR:Q60644" ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X" ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2013-10-25" ;
+                                                                                     <http://purl.org/dc/elements/1.1/source> "PMID:23931754" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+                                                                                     rdfs:comment "In situ proximity ligation assay" ,
+                                                                                                  "RAW 264.7" ,
+                                                                                                  "cell type TIB-71   permanent cell line cell ; CLO:0000019" .
+
+
+###  http://model.geneontology.org/MGI_MGI_2676312/3071056e-8d64-49f7-a8c1-bd61af387fce
+<http://model.geneontology.org/MGI_MGI_2676312/3071056e-8d64-49f7-a8c1-bd61af387fce> rdf:type owl:NamedIndividual ,
+                                                                                              <http://identifiers.org/mgi/MGI:2676312> ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X" ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2013-10-25" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org" .
+
+
+###  http://model.geneontology.org/MGI_MGI_2676312/349e8a05-8633-4254-9db3-c8cf0a4af608
+<http://model.geneontology.org/MGI_MGI_2676312/349e8a05-8633-4254-9db3-c8cf0a4af608> rdf:type owl:NamedIndividual ,
+                                                                                              <http://purl.obolibrary.org/obo/ECO_0000315> ;
+                                                                                     <http://geneontology.org/lego/evidence-with> "MGI:MGI:3809668" ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X" ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2012-10-17" ;
+                                                                                     <http://purl.org/dc/elements/1.1/source> "PMID:18632686" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+                                                                                     rdfs:comment "anatomy alveolar system ;  MA:0000416" ,
+                                                                                                  "cell type type II pneumocyte ; CL:0002063" ,
+                                                                                                  "has_participant(CL:0002063)" .
+
+
+###  http://model.geneontology.org/MGI_MGI_2676312/4bdc4a5f-0a8d-4158-b563-eb79b2063c53
+<http://model.geneontology.org/MGI_MGI_2676312/4bdc4a5f-0a8d-4158-b563-eb79b2063c53> rdf:type owl:NamedIndividual ,
+                                                                                              <http://purl.obolibrary.org/obo/GO_0048286> ;
+                                                                                     <http://purl.obolibrary.org/obo/RO_0002296> <http://model.geneontology.org/MGI_MGI_2676312/af6586ba-592e-4cef-aa41-e6d50b2933bd> ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X"^^xsd:string ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2012-10-17" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org"^^xsd:string .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource <http://model.geneontology.org/MGI_MGI_2676312/4bdc4a5f-0a8d-4158-b563-eb79b2063c53> ;
+   owl:annotatedProperty <http://purl.obolibrary.org/obo/RO_0002296> ;
+   owl:annotatedTarget <http://model.geneontology.org/MGI_MGI_2676312/af6586ba-592e-4cef-aa41-e6d50b2933bd> ;
+   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_2676312/19f42861-1508-4210-93a1-44027944ed5e> ;
+   <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X"^^xsd:string ;
+   <http://purl.org/dc/elements/1.1/date> "2012-10-17" ;
+   <http://purl.org/pav/providedBy> "http://informatics.jax.org"^^xsd:string ;
+   rdfs:comment "MGI:MGI:2676312  RO:0002264 GO:0048286 MGI:MGI:3807143|PMID:18632686 ECO:0000315 MGI:MGI:3809668  2012-10-17 MGI RO:0002296(EMAPA:32692) creation-date=2012-10-17|modification-date=2012-10-17|comment=anatomy alveolar system ;  MA:0000416|comment=cell type type II pneumocyte ; CL:0002063|comment=has_participant(CL:0002063)|contributor-id=https://orcid.org/0000-0001-5501-853X"
+ ] .
+
+
+###  http://model.geneontology.org/MGI_MGI_2676312/4bf2f8ea-5c77-4c7c-9c3a-ca5168c9df9b
+<http://model.geneontology.org/MGI_MGI_2676312/4bf2f8ea-5c77-4c7c-9c3a-ca5168c9df9b> rdf:type owl:NamedIndividual ,
+                                                                                              <http://purl.obolibrary.org/obo/GO_0010875> ;
+                                                                                     <http://purl.obolibrary.org/obo/RO_0002213> <http://model.geneontology.org/MGI_MGI_2676312/76124c42-7904-4058-80e3-16187710aeb5> ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X"^^xsd:string ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2013-10-25" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org"^^xsd:string .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource <http://model.geneontology.org/MGI_MGI_2676312/4bf2f8ea-5c77-4c7c-9c3a-ca5168c9df9b> ;
+   owl:annotatedProperty <http://purl.obolibrary.org/obo/RO_0002213> ;
+   owl:annotatedTarget <http://model.geneontology.org/MGI_MGI_2676312/76124c42-7904-4058-80e3-16187710aeb5> ;
+   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_2676312/e1767a03-d690-4527-87c1-648aa1c02881> ;
+   <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X"^^xsd:string ;
+   <http://purl.org/dc/elements/1.1/date> "2013-10-25" ;
+   <http://purl.org/pav/providedBy> "http://informatics.jax.org"^^xsd:string ;
+   rdfs:comment "MGI:MGI:2676312  RO:0002264 GO:0010875 MGI:MGI:5510615|PMID:23931754 ECO:0000315 MGI:MGI:4461044  2013-10-25 MGI GOREL:0001004(CL:0000091) creation-date=2013-10-25|modification-date=2013-10-25|comment=cell type Kupffer cell ; CL:0000091   primary cell line cell ; CL:0000001|contributor-id=https://orcid.org/0000-0001-5501-853X"
+ ] .
+
+
+###  http://model.geneontology.org/MGI_MGI_2676312/4d5de41f-a7f9-4ab3-b3ee-8719ea857332
+<http://model.geneontology.org/MGI_MGI_2676312/4d5de41f-a7f9-4ab3-b3ee-8719ea857332> rdf:type owl:NamedIndividual ,
+                                                                                              <http://purl.obolibrary.org/obo/ECO_0000315> ;
+                                                                                     <http://geneontology.org/lego/evidence-with> "MGI:MGI:4461044" ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X" ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2013-10-25" ;
+                                                                                     <http://purl.org/dc/elements/1.1/source> "PMID:23931754" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+                                                                                     rdfs:comment "cell type Kupffer cell ; CL:0000091   primary cell line cell ; CL:0000001" .
+
+
+###  http://model.geneontology.org/MGI_MGI_2676312/4f9db452-eee5-43bd-b2a1-51a37d7be767
+<http://model.geneontology.org/MGI_MGI_2676312/4f9db452-eee5-43bd-b2a1-51a37d7be767> rdf:type owl:NamedIndividual ,
+                                                                                              <http://purl.obolibrary.org/obo/ECO_0000315> ;
+                                                                                     <http://geneontology.org/lego/evidence-with> "MGI:MGI:4461044" ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X" ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2012-10-17" ;
+                                                                                     <http://purl.org/dc/elements/1.1/source> "PMID:18802465" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+                                                                                     rdfs:comment "cell type keratinocyte ; CL:0000312" .
+
+
+###  http://model.geneontology.org/MGI_MGI_2676312/4311db60-fe18-4fe8-a214-c4fa7dc5c058
+<http://model.geneontology.org/MGI_MGI_2676312/4311db60-fe18-4fe8-a214-c4fa7dc5c058> rdf:type owl:NamedIndividual ,
+                                                                                              <http://purl.obolibrary.org/obo/ECO_0000314> ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X" ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2012-10-17" ;
+                                                                                     <http://purl.org/dc/elements/1.1/source> "PMID:18632686" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+                                                                                     rdfs:comment "cell type epithelial cell of lung ; CL:0000082" .
+
+
+###  http://model.geneontology.org/MGI_MGI_2676312/483de97c-0a16-478c-8e55-e65d498554f3
+<http://model.geneontology.org/MGI_MGI_2676312/483de97c-0a16-478c-8e55-e65d498554f3> rdf:type owl:NamedIndividual ,
+                                                                                              <http://identifiers.org/mgi/MGI:2676312> ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X" ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2012-10-17" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org" .
+
+
+###  http://model.geneontology.org/MGI_MGI_2676312/5faa6a73-3a93-419c-96cc-d5d9cc9fd821
+<http://model.geneontology.org/MGI_MGI_2676312/5faa6a73-3a93-419c-96cc-d5d9cc9fd821> rdf:type owl:NamedIndividual ,
+                                                                                              <http://identifiers.org/mgi/MGI:2676312> ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X" ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2012-10-17" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org" .
+
+
+###  http://model.geneontology.org/MGI_MGI_2676312/52545d18-58c1-4120-b39d-68ddeccdf161
+<http://model.geneontology.org/MGI_MGI_2676312/52545d18-58c1-4120-b39d-68ddeccdf161> rdf:type owl:NamedIndividual ,
+                                                                                              [ rdf:type owl:Class ;
+                                                                                                owl:complementOf <http://purl.obolibrary.org/obo/GO_0043129>
+                                                                                              ] ;
+                                                                                     <http://purl.obolibrary.org/obo/BFO_0000066> <http://model.geneontology.org/MGI_MGI_2676312/020dc26f-02ee-485a-a8e5-1ff054df710f> ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X"^^xsd:string ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2012-10-17" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org"^^xsd:string .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource <http://model.geneontology.org/MGI_MGI_2676312/52545d18-58c1-4120-b39d-68ddeccdf161> ;
+   owl:annotatedProperty <http://purl.obolibrary.org/obo/BFO_0000066> ;
+   owl:annotatedTarget <http://model.geneontology.org/MGI_MGI_2676312/020dc26f-02ee-485a-a8e5-1ff054df710f> ;
+   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_2676312/c3374c83-b41d-4969-b6b1-ca4a3a6acfec> ;
+   <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X"^^xsd:string ;
+   <http://purl.org/dc/elements/1.1/date> "2012-10-17" ;
+   <http://purl.org/pav/providedBy> "http://informatics.jax.org"^^xsd:string ;
+   rdfs:comment "MGI:MGI:2676312 NOT RO:0002264 GO:0043129 MGI:MGI:3829841|PMID:18957418 ECO:0000315 MGI:MGI:3528440  2012-10-17 MGI BFO:0000066(EMAPA:16728) creation-date=2012-10-17|modification-date=2012-10-17|comment=anatomy lung ; MA:0000415|comment=cell type type II pneumocyte ; CL:0002063|comment=has_participant(CL:0002063)|contributor-id=https://orcid.org/0000-0001-5501-853X"
+ ] .
+
+
+###  http://model.geneontology.org/MGI_MGI_2676312/52863d8e-6687-4b96-922f-e3cfb92e1c17
+<http://model.geneontology.org/MGI_MGI_2676312/52863d8e-6687-4b96-922f-e3cfb92e1c17> rdf:type owl:NamedIndividual ,
+                                                                                              <http://purl.obolibrary.org/obo/ECO_0000353> ;
+                                                                                     <http://geneontology.org/lego/evidence-with> "PR:Q60644" ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X" ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2013-10-25" ;
+                                                                                     <http://purl.org/dc/elements/1.1/source> "PMID:23931754" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+                                                                                     rdfs:comment "In situ proximity ligation assay" ,
+                                                                                                  "RAW 264.7" ,
+                                                                                                  "cell type TIB-71   permanent cell line cell ; CLO:0000019" .
+
+
+###  http://model.geneontology.org/MGI_MGI_2676312/53855a60-2d7c-4bb1-98a8-460c0f84d27b
+<http://model.geneontology.org/MGI_MGI_2676312/53855a60-2d7c-4bb1-98a8-460c0f84d27b> rdf:type owl:NamedIndividual ,
+                                                                                              <http://purl.obolibrary.org/obo/ECO_0000315> ;
+                                                                                     <http://geneontology.org/lego/evidence-with> "MGI:MGI:3528440" ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X" ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2012-10-17" ;
+                                                                                     <http://purl.org/dc/elements/1.1/source> "PMID:18957418" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+                                                                                     rdfs:comment "anatomy lung ; MA:0000415" ,
+                                                                                                  "cell type type II pneumocyte ; CL:0002063" ,
+                                                                                                  "has_participant(CL:0002063)" .
+
+
+###  http://model.geneontology.org/MGI_MGI_2676312/5550f584-4899-4bb2-b4a2-04c885025ed2
+<http://model.geneontology.org/MGI_MGI_2676312/5550f584-4899-4bb2-b4a2-04c885025ed2> rdf:type owl:NamedIndividual ,
+                                                                                              <http://purl.obolibrary.org/obo/GO_0003674> ;
+                                                                                     <http://purl.obolibrary.org/obo/RO_0002333> <http://model.geneontology.org/MGI_MGI_2676312/ba8bd87d-50cb-46ee-911d-f8c7cf786cea> ;
+                                                                                     <http://purl.obolibrary.org/obo/RO_0002418> <http://model.geneontology.org/MGI_MGI_2676312/719fbc94-a938-4001-8651-abc84ae79666> ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X"^^xsd:string ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2012-10-17" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org"^^xsd:string .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource <http://model.geneontology.org/MGI_MGI_2676312/5550f584-4899-4bb2-b4a2-04c885025ed2> ;
+   owl:annotatedProperty <http://purl.obolibrary.org/obo/RO_0002333> ;
+   owl:annotatedTarget <http://model.geneontology.org/MGI_MGI_2676312/ba8bd87d-50cb-46ee-911d-f8c7cf786cea> ;
+   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_2676312/fef6454f-b218-4b29-86a3-82c023014aef> ;
+   <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X"^^xsd:string ;
+   <http://purl.org/dc/elements/1.1/date> "2012-10-17" ;
+   <http://purl.org/pav/providedBy> "http://informatics.jax.org"^^xsd:string ;
+   rdfs:comment "MGI:MGI:2676312  RO:0002264 GO:0055088 MGI:MGI:4460077|PMID:18802465 ECO:0000315 MGI:MGI:4461044  2012-10-17 MGI  creation-date=2012-10-17|modification-date=2012-10-17|comment=anatomy TS26 epidermis stratum corneum ; EMAP:33921|comment=cell type skin fibroblast ; CL:0002620|comment=has_participant(CL:0002620)|comment=has_participant(EMAPA:32787 TS26)|contributor-id=https://orcid.org/0000-0001-5501-853X"
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource <http://model.geneontology.org/MGI_MGI_2676312/5550f584-4899-4bb2-b4a2-04c885025ed2> ;
+   owl:annotatedProperty <http://purl.obolibrary.org/obo/RO_0002418> ;
+   owl:annotatedTarget <http://model.geneontology.org/MGI_MGI_2676312/719fbc94-a938-4001-8651-abc84ae79666> ;
+   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_2676312/79c56623-17aa-4ac6-8feb-776e0d246b7d> ;
+   <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X"^^xsd:string ;
+   <http://purl.org/dc/elements/1.1/date> "2012-10-17" ;
+   <http://purl.org/pav/providedBy> "http://informatics.jax.org"^^xsd:string ;
+   rdfs:comment "MGI:MGI:2676312  RO:0002264 GO:0055088 MGI:MGI:4460077|PMID:18802465 ECO:0000315 MGI:MGI:4461044  2012-10-17 MGI  creation-date=2012-10-17|modification-date=2012-10-17|comment=anatomy TS26 epidermis stratum corneum ; EMAP:33921|comment=cell type skin fibroblast ; CL:0002620|comment=has_participant(CL:0002620)|comment=has_participant(EMAPA:32787 TS26)|contributor-id=https://orcid.org/0000-0001-5501-853X"
+ ] .
+
+
+###  http://model.geneontology.org/MGI_MGI_2676312/6b5e2e28-99fd-4532-8e47-e8a7ca098557
+<http://model.geneontology.org/MGI_MGI_2676312/6b5e2e28-99fd-4532-8e47-e8a7ca098557> rdf:type owl:NamedIndividual ,
+                                                                                              <http://identifiers.org/mgi/MGI:2676312> ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X" ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2013-10-25" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org" .
+
+
+###  http://model.geneontology.org/MGI_MGI_2676312/65aaf6ae-9b1e-4b92-b3b5-fff892982d91
+<http://model.geneontology.org/MGI_MGI_2676312/65aaf6ae-9b1e-4b92-b3b5-fff892982d91> rdf:type owl:NamedIndividual ,
+                                                                                              <http://purl.obolibrary.org/obo/GO_0003674> ;
+                                                                                     <http://purl.obolibrary.org/obo/RO_0002333> <http://model.geneontology.org/MGI_MGI_2676312/26f02155-72b3-4f48-be3c-703245dae2cc> ;
+                                                                                     <http://purl.obolibrary.org/obo/RO_0002418> <http://model.geneontology.org/MGI_MGI_2676312/52545d18-58c1-4120-b39d-68ddeccdf161> ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X"^^xsd:string ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2012-10-17" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org"^^xsd:string .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource <http://model.geneontology.org/MGI_MGI_2676312/65aaf6ae-9b1e-4b92-b3b5-fff892982d91> ;
+   owl:annotatedProperty <http://purl.obolibrary.org/obo/RO_0002333> ;
+   owl:annotatedTarget <http://model.geneontology.org/MGI_MGI_2676312/26f02155-72b3-4f48-be3c-703245dae2cc> ;
+   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_2676312/01193371-59df-46b1-b96a-2287fba6cc08> ;
+   <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X"^^xsd:string ;
+   <http://purl.org/dc/elements/1.1/date> "2012-10-17" ;
+   <http://purl.org/pav/providedBy> "http://informatics.jax.org"^^xsd:string ;
+   rdfs:comment "MGI:MGI:2676312 NOT RO:0002264 GO:0043129 MGI:MGI:3829841|PMID:18957418 ECO:0000315 MGI:MGI:3528440  2012-10-17 MGI BFO:0000066(EMAPA:16728) creation-date=2012-10-17|modification-date=2012-10-17|comment=anatomy lung ; MA:0000415|comment=cell type type II pneumocyte ; CL:0002063|comment=has_participant(CL:0002063)|contributor-id=https://orcid.org/0000-0001-5501-853X"
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource <http://model.geneontology.org/MGI_MGI_2676312/65aaf6ae-9b1e-4b92-b3b5-fff892982d91> ;
+   owl:annotatedProperty <http://purl.obolibrary.org/obo/RO_0002418> ;
+   owl:annotatedTarget <http://model.geneontology.org/MGI_MGI_2676312/52545d18-58c1-4120-b39d-68ddeccdf161> ;
+   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_2676312/e0d82f74-4662-4f86-84c1-4090eaef0e4f> ;
+   <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X"^^xsd:string ;
+   <http://purl.org/dc/elements/1.1/date> "2012-10-17" ;
+   <http://purl.org/pav/providedBy> "http://informatics.jax.org"^^xsd:string ;
+   rdfs:comment "MGI:MGI:2676312 NOT RO:0002264 GO:0043129 MGI:MGI:3829841|PMID:18957418 ECO:0000315 MGI:MGI:3528440  2012-10-17 MGI BFO:0000066(EMAPA:16728) creation-date=2012-10-17|modification-date=2012-10-17|comment=anatomy lung ; MA:0000415|comment=cell type type II pneumocyte ; CL:0002063|comment=has_participant(CL:0002063)|contributor-id=https://orcid.org/0000-0001-5501-853X"
+ ] .
+
+
+###  http://model.geneontology.org/MGI_MGI_2676312/65597b2e-1475-46a3-85e3-7092f372e437
+<http://model.geneontology.org/MGI_MGI_2676312/65597b2e-1475-46a3-85e3-7092f372e437> rdf:type owl:NamedIndividual ,
+                                                                                              <http://purl.obolibrary.org/obo/GO_0003674> ;
+                                                                                     <http://purl.obolibrary.org/obo/RO_0002333> <http://model.geneontology.org/MGI_MGI_2676312/5faa6a73-3a93-419c-96cc-d5d9cc9fd821> ;
+                                                                                     <http://purl.obolibrary.org/obo/RO_0002418> <http://model.geneontology.org/MGI_MGI_2676312/d707df52-6a0c-4dbd-a662-ee63a51a56ae> ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X"^^xsd:string ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2012-10-17" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org"^^xsd:string .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource <http://model.geneontology.org/MGI_MGI_2676312/65597b2e-1475-46a3-85e3-7092f372e437> ;
+   owl:annotatedProperty <http://purl.obolibrary.org/obo/RO_0002333> ;
+   owl:annotatedTarget <http://model.geneontology.org/MGI_MGI_2676312/5faa6a73-3a93-419c-96cc-d5d9cc9fd821> ;
+   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_2676312/7d31bed1-40ee-4dfb-96ec-b9527ae62560> ;
+   <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X"^^xsd:string ;
+   <http://purl.org/dc/elements/1.1/date> "2012-10-17" ;
+   <http://purl.org/pav/providedBy> "http://informatics.jax.org"^^xsd:string ;
+   rdfs:comment "MGI:MGI:2676312  RO:0002264 GO:0043129 MGI:MGI:3807143|PMID:18632686 ECO:0000315 MGI:MGI:3809668  2012-10-17 MGI  creation-date=2012-10-17|modification-date=2012-10-17|comment=cell type epithelial cell of lung ; CL:0000082|comment=has_participant(CL:0000082)|contributor-id=https://orcid.org/0000-0001-5501-853X"
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource <http://model.geneontology.org/MGI_MGI_2676312/65597b2e-1475-46a3-85e3-7092f372e437> ;
+   owl:annotatedProperty <http://purl.obolibrary.org/obo/RO_0002418> ;
+   owl:annotatedTarget <http://model.geneontology.org/MGI_MGI_2676312/d707df52-6a0c-4dbd-a662-ee63a51a56ae> ;
+   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_2676312/9068171a-57f4-43c8-9546-a615e67fbebe> ;
+   <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X"^^xsd:string ;
+   <http://purl.org/dc/elements/1.1/date> "2012-10-17" ;
+   <http://purl.org/pav/providedBy> "http://informatics.jax.org"^^xsd:string ;
+   rdfs:comment "MGI:MGI:2676312  RO:0002264 GO:0043129 MGI:MGI:3807143|PMID:18632686 ECO:0000315 MGI:MGI:3809668  2012-10-17 MGI  creation-date=2012-10-17|modification-date=2012-10-17|comment=cell type epithelial cell of lung ; CL:0000082|comment=has_participant(CL:0000082)|contributor-id=https://orcid.org/0000-0001-5501-853X"
+ ] .
+
+
+###  http://model.geneontology.org/MGI_MGI_2676312/66af1bab-7d68-4d83-9b4b-9bb52116ce9a
+<http://model.geneontology.org/MGI_MGI_2676312/66af1bab-7d68-4d83-9b4b-9bb52116ce9a> rdf:type owl:NamedIndividual ,
+                                                                                              <http://purl.obolibrary.org/obo/ECO_0000315> ;
+                                                                                     <http://geneontology.org/lego/evidence-with> "MGI:MGI:4461044" ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X" ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2012-10-17" ;
+                                                                                     <http://purl.org/dc/elements/1.1/source> "PMID:18802465" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+                                                                                     rdfs:comment "cell type keratinocyte ; CL:0000312" .
+
+
+###  http://model.geneontology.org/MGI_MGI_2676312/6807efa7-b3b8-4b5b-a41b-c2ecc41b17fc
+<http://model.geneontology.org/MGI_MGI_2676312/6807efa7-b3b8-4b5b-a41b-c2ecc41b17fc> rdf:type owl:NamedIndividual ,
+                                                                                              <http://purl.obolibrary.org/obo/ECO_0007005> ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ,
+                                                                                                                                   "https://orcid.org/0000-0003-2689-5511" ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2008-08-11" ;
+                                                                                     <http://purl.org/dc/elements/1.1/source> "PMID:12865426" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+                                                                                     rdfs:comment "ENSMUSP00000027392" .
+
+
+###  http://model.geneontology.org/MGI_MGI_2676312/692fc6de-10c5-487c-85ac-330bc49220f2
+<http://model.geneontology.org/MGI_MGI_2676312/692fc6de-10c5-487c-85ac-330bc49220f2> rdf:type owl:NamedIndividual ,
+                                                                                              <http://purl.obolibrary.org/obo/GO_0003674> ;
+                                                                                     <http://purl.obolibrary.org/obo/RO_0002333> <http://model.geneontology.org/MGI_MGI_2676312/287f851e-bcb4-44db-91d4-263abb9e3180> ;
+                                                                                     <http://purl.obolibrary.org/obo/RO_0002418> <http://model.geneontology.org/MGI_MGI_2676312/4bdc4a5f-0a8d-4158-b563-eb79b2063c53> ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X"^^xsd:string ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2012-10-17" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org"^^xsd:string .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource <http://model.geneontology.org/MGI_MGI_2676312/692fc6de-10c5-487c-85ac-330bc49220f2> ;
+   owl:annotatedProperty <http://purl.obolibrary.org/obo/RO_0002333> ;
+   owl:annotatedTarget <http://model.geneontology.org/MGI_MGI_2676312/287f851e-bcb4-44db-91d4-263abb9e3180> ;
+   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_2676312/80a7d9fc-6e43-4057-b005-e3b87528f280> ;
+   <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X"^^xsd:string ;
+   <http://purl.org/dc/elements/1.1/date> "2012-10-17" ;
+   <http://purl.org/pav/providedBy> "http://informatics.jax.org"^^xsd:string ;
+   rdfs:comment "MGI:MGI:2676312  RO:0002264 GO:0048286 MGI:MGI:3807143|PMID:18632686 ECO:0000315 MGI:MGI:3809668  2012-10-17 MGI RO:0002296(EMAPA:32692) creation-date=2012-10-17|modification-date=2012-10-17|comment=anatomy alveolar system ;  MA:0000416|comment=cell type type II pneumocyte ; CL:0002063|comment=has_participant(CL:0002063)|contributor-id=https://orcid.org/0000-0001-5501-853X"
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource <http://model.geneontology.org/MGI_MGI_2676312/692fc6de-10c5-487c-85ac-330bc49220f2> ;
+   owl:annotatedProperty <http://purl.obolibrary.org/obo/RO_0002418> ;
+   owl:annotatedTarget <http://model.geneontology.org/MGI_MGI_2676312/4bdc4a5f-0a8d-4158-b563-eb79b2063c53> ;
+   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_2676312/349e8a05-8633-4254-9db3-c8cf0a4af608> ;
+   <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X"^^xsd:string ;
+   <http://purl.org/dc/elements/1.1/date> "2012-10-17" ;
+   <http://purl.org/pav/providedBy> "http://informatics.jax.org"^^xsd:string ;
+   rdfs:comment "MGI:MGI:2676312  RO:0002264 GO:0048286 MGI:MGI:3807143|PMID:18632686 ECO:0000315 MGI:MGI:3809668  2012-10-17 MGI RO:0002296(EMAPA:32692) creation-date=2012-10-17|modification-date=2012-10-17|comment=anatomy alveolar system ;  MA:0000416|comment=cell type type II pneumocyte ; CL:0002063|comment=has_participant(CL:0002063)|contributor-id=https://orcid.org/0000-0001-5501-853X"
+ ] .
+
+
+###  http://model.geneontology.org/MGI_MGI_2676312/7ac43336-bd20-40f1-adc0-19248c74a378
+<http://model.geneontology.org/MGI_MGI_2676312/7ac43336-bd20-40f1-adc0-19248c74a378> rdf:type owl:NamedIndividual ,
+                                                                                              <http://identifiers.org/mgi/MGI:2676312> ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X" ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2013-10-25" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org" .
+
+
+###  http://model.geneontology.org/MGI_MGI_2676312/7b7f6c79-1016-4f37-9d74-77d445262d4e
+<http://model.geneontology.org/MGI_MGI_2676312/7b7f6c79-1016-4f37-9d74-77d445262d4e> rdf:type owl:NamedIndividual ,
+                                                                                              <http://purl.obolibrary.org/obo/ECO_0000315> ;
+                                                                                     <http://geneontology.org/lego/evidence-with> "MGI:MGI:3528440" ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X" ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2012-10-17" ;
+                                                                                     <http://purl.org/dc/elements/1.1/source> "PMID:18957418" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+                                                                                     rdfs:comment "anatomy epidermis stratum corneum ; MA:0000804" ,
+                                                                                                  "has_participant(EMAPA:32787 TS28)" .
+
+
+###  http://model.geneontology.org/MGI_MGI_2676312/7c001801-621f-4ac5-abf2-eb1e12da5586
+<http://model.geneontology.org/MGI_MGI_2676312/7c001801-621f-4ac5-abf2-eb1e12da5586> rdf:type owl:NamedIndividual ,
+                                                                                              <http://identifiers.org/mgi/MGI:2676312> ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X" ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2012-10-17" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org" .
+
+
+###  http://model.geneontology.org/MGI_MGI_2676312/7d31bed1-40ee-4dfb-96ec-b9527ae62560
+<http://model.geneontology.org/MGI_MGI_2676312/7d31bed1-40ee-4dfb-96ec-b9527ae62560> rdf:type owl:NamedIndividual ,
+                                                                                              <http://purl.obolibrary.org/obo/ECO_0000315> ;
+                                                                                     <http://geneontology.org/lego/evidence-with> "MGI:MGI:3809668" ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X" ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2012-10-17" ;
+                                                                                     <http://purl.org/dc/elements/1.1/source> "PMID:18632686" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+                                                                                     rdfs:comment "cell type epithelial cell of lung ; CL:0000082" ,
+                                                                                                  "has_participant(CL:0000082)" .
+
+
+###  http://model.geneontology.org/MGI_MGI_2676312/7e770671-3c59-417d-8686-f91331fb941e
+<http://model.geneontology.org/MGI_MGI_2676312/7e770671-3c59-417d-8686-f91331fb941e> rdf:type owl:NamedIndividual ,
+                                                                                              <http://identifiers.org/mgi/MGI:2676312> ;
+                                                                                     <http://purl.obolibrary.org/obo/RO_0001025> <http://model.geneontology.org/MGI_MGI_2676312/d0d205ae-9096-4c73-a01a-734f9a5e67cd> ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X"^^xsd:string ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2012-10-17" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org"^^xsd:string .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource <http://model.geneontology.org/MGI_MGI_2676312/7e770671-3c59-417d-8686-f91331fb941e> ;
+   owl:annotatedProperty <http://purl.obolibrary.org/obo/RO_0001025> ;
+   owl:annotatedTarget <http://model.geneontology.org/MGI_MGI_2676312/d0d205ae-9096-4c73-a01a-734f9a5e67cd> ;
+   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_2676312/4311db60-fe18-4fe8-a214-c4fa7dc5c058> ;
+   <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X"^^xsd:string ;
+   <http://purl.org/dc/elements/1.1/date> "2012-10-17" ;
+   <http://purl.org/pav/providedBy> "http://informatics.jax.org"^^xsd:string ;
+   rdfs:comment "MGI:MGI:2676312  RO:0001025 GO:0005829 MGI:MGI:3807143|PMID:18632686 ECO:0000314   2012-10-17 MGI BFO:0000050(CL:0000082) creation-date=2012-10-17|modification-date=2012-10-17|comment=cell type epithelial cell of lung ; CL:0000082|contributor-id=https://orcid.org/0000-0001-5501-853X"
+ ] .
+
+
+###  http://model.geneontology.org/MGI_MGI_2676312/7fb29059-c264-478b-bb79-1cf97deca863
+<http://model.geneontology.org/MGI_MGI_2676312/7fb29059-c264-478b-bb79-1cf97deca863> rdf:type owl:NamedIndividual ,
+                                                                                              <http://purl.obolibrary.org/obo/GO_0003674> ;
+                                                                                     <http://purl.obolibrary.org/obo/RO_0002333> <http://model.geneontology.org/MGI_MGI_2676312/0fa8be2b-4b46-4e4d-9763-18d11c445be8> ;
+                                                                                     <http://purl.obolibrary.org/obo/RO_0002418> <http://model.geneontology.org/MGI_MGI_2676312/e9238e4e-d0eb-492f-8054-93517f157ac9> ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X"^^xsd:string ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2012-10-17" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org"^^xsd:string .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource <http://model.geneontology.org/MGI_MGI_2676312/7fb29059-c264-478b-bb79-1cf97deca863> ;
+   owl:annotatedProperty <http://purl.obolibrary.org/obo/RO_0002333> ;
+   owl:annotatedTarget <http://model.geneontology.org/MGI_MGI_2676312/0fa8be2b-4b46-4e4d-9763-18d11c445be8> ;
+   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_2676312/e701b59b-9b84-468b-8357-4632f0a7a3b3> ,
+                                           <http://model.geneontology.org/MGI_MGI_2676312/048dfd19-a9d9-4508-85c0-45538d2258fd> ,
+                                           <http://model.geneontology.org/MGI_MGI_2676312/71e9c89d-01b4-45b4-90cd-23bc3927780f> ;
+   <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X"^^xsd:string ;
+   <http://purl.org/dc/elements/1.1/date> "2012-10-17" ;
+   <http://purl.org/pav/providedBy> "http://informatics.jax.org"^^xsd:string ;
+   rdfs:comment "MGI:MGI:2676312  RO:0002264 GO:0061436 MGI:MGI:3807143|PMID:18632686 ECO:0000315 MGI:MGI:3809668  2012-10-17 MGI  creation-date=2012-10-17|modification-date=2012-10-17|comment=anatomy epidermis stratum corneum ; MA:0000804|comment=anatomy TS26 embryo ; EMAP:11159|comment=cell type keratinocyte ; CL:0000312|comment=has_participant(CL:0000312)|comment=has_participant(EMAPA:16039 TS26)|comment=has_participant(EMAPA:32787 TS28)|contributor-id=https://orcid.org/0000-0001-5501-853X" ,
+                "MGI:MGI:2676312  RO:0002264 GO:0061436 MGI:MGI:3829841|PMID:18957418 ECO:0000315 MGI:MGI:3528440  2012-10-17 MGI  creation-date=2012-10-17|modification-date=2012-10-17|comment=anatomy TS26 epidermis stratum corneum ; EMAP:33921|comment=has_participant(EMAPA:32787 TS26)|contributor-id=https://orcid.org/0000-0001-5501-853X" ,
+                "MGI:MGI:2676312  RO:0002264 GO:0061436 MGI:MGI:4460077|PMID:18802465 ECO:0000315 MGI:MGI:4461044  2012-10-17 MGI  creation-date=2012-10-17|modification-date=2012-10-17|comment=anatomy TS26 epidermis stratum corneum ; EMAP:33921|comment=has_participant(EMAPA:32787 TS26)|contributor-id=https://orcid.org/0000-0001-5501-853X"
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource <http://model.geneontology.org/MGI_MGI_2676312/7fb29059-c264-478b-bb79-1cf97deca863> ;
+   owl:annotatedProperty <http://purl.obolibrary.org/obo/RO_0002418> ;
+   owl:annotatedTarget <http://model.geneontology.org/MGI_MGI_2676312/e9238e4e-d0eb-492f-8054-93517f157ac9> ;
+   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_2676312/c2516f86-4f92-434f-bdd5-d35610474981> ,
+                                           <http://model.geneontology.org/MGI_MGI_2676312/e8affde6-c74e-4d05-ae70-716849ce7e8d> ,
+                                           <http://model.geneontology.org/MGI_MGI_2676312/066d6682-5a9d-4d14-8c06-4aac82c419b1> ;
+   <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X"^^xsd:string ;
+   <http://purl.org/dc/elements/1.1/date> "2012-10-17" ;
+   <http://purl.org/pav/providedBy> "http://informatics.jax.org"^^xsd:string ;
+   rdfs:comment "MGI:MGI:2676312  RO:0002264 GO:0061436 MGI:MGI:3807143|PMID:18632686 ECO:0000315 MGI:MGI:3809668  2012-10-17 MGI  creation-date=2012-10-17|modification-date=2012-10-17|comment=anatomy epidermis stratum corneum ; MA:0000804|comment=anatomy TS26 embryo ; EMAP:11159|comment=cell type keratinocyte ; CL:0000312|comment=has_participant(CL:0000312)|comment=has_participant(EMAPA:16039 TS26)|comment=has_participant(EMAPA:32787 TS28)|contributor-id=https://orcid.org/0000-0001-5501-853X" ,
+                "MGI:MGI:2676312  RO:0002264 GO:0061436 MGI:MGI:3829841|PMID:18957418 ECO:0000315 MGI:MGI:3528440  2012-10-17 MGI  creation-date=2012-10-17|modification-date=2012-10-17|comment=anatomy TS26 epidermis stratum corneum ; EMAP:33921|comment=has_participant(EMAPA:32787 TS26)|contributor-id=https://orcid.org/0000-0001-5501-853X" ,
+                "MGI:MGI:2676312  RO:0002264 GO:0061436 MGI:MGI:4460077|PMID:18802465 ECO:0000315 MGI:MGI:4461044  2012-10-17 MGI  creation-date=2012-10-17|modification-date=2012-10-17|comment=anatomy TS26 epidermis stratum corneum ; EMAP:33921|comment=has_participant(EMAPA:32787 TS26)|contributor-id=https://orcid.org/0000-0001-5501-853X"
+ ] .
+
+
+###  http://model.geneontology.org/MGI_MGI_2676312/70e6fbf9-76b8-4c2e-967a-c4cc99f29b1f
+<http://model.geneontology.org/MGI_MGI_2676312/70e6fbf9-76b8-4c2e-967a-c4cc99f29b1f> rdf:type owl:NamedIndividual ,
+                                                                                              <http://purl.obolibrary.org/obo/EMAPA_17525> ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X" ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2012-10-17" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org" .
+
+
+###  http://model.geneontology.org/MGI_MGI_2676312/71c26b83-0f41-48bc-852a-2f4379803c60
+<http://model.geneontology.org/MGI_MGI_2676312/71c26b83-0f41-48bc-852a-2f4379803c60> rdf:type owl:NamedIndividual ,
+                                                                                              <http://purl.obolibrary.org/obo/EMAPA_16728> ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X" ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2012-10-17" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org" .
+
+
+###  http://model.geneontology.org/MGI_MGI_2676312/71e9c89d-01b4-45b4-90cd-23bc3927780f
+<http://model.geneontology.org/MGI_MGI_2676312/71e9c89d-01b4-45b4-90cd-23bc3927780f> rdf:type owl:NamedIndividual ,
+                                                                                              <http://purl.obolibrary.org/obo/ECO_0000315> ;
+                                                                                     <http://geneontology.org/lego/evidence-with> "MGI:MGI:3528440" ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X" ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2012-10-17" ;
+                                                                                     <http://purl.org/dc/elements/1.1/source> "PMID:18957418" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+                                                                                     rdfs:comment "anatomy TS26 epidermis stratum corneum ; EMAP:33921" ,
+                                                                                                  "has_participant(EMAPA:32787 TS26)" .
+
+
+###  http://model.geneontology.org/MGI_MGI_2676312/719fbc94-a938-4001-8651-abc84ae79666
+<http://model.geneontology.org/MGI_MGI_2676312/719fbc94-a938-4001-8651-abc84ae79666> rdf:type owl:NamedIndividual ,
+                                                                                              <http://purl.obolibrary.org/obo/GO_0055088> ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X" ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2012-10-17" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org" .
+
+
+###  http://model.geneontology.org/MGI_MGI_2676312/76124c42-7904-4058-80e3-16187710aeb5
+<http://model.geneontology.org/MGI_MGI_2676312/76124c42-7904-4058-80e3-16187710aeb5> rdf:type owl:NamedIndividual ,
+                                                                                              <http://purl.obolibrary.org/obo/GO_0033344> ;
+                                                                                     <http://purl.obolibrary.org/obo/BFO_0000066> <http://model.geneontology.org/MGI_MGI_2676312/fb56d6de-3da5-4bab-bc20-7577889ebfef> ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X"^^xsd:string ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2013-10-25" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org"^^xsd:string .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource <http://model.geneontology.org/MGI_MGI_2676312/76124c42-7904-4058-80e3-16187710aeb5> ;
+   owl:annotatedProperty <http://purl.obolibrary.org/obo/BFO_0000066> ;
+   owl:annotatedTarget <http://model.geneontology.org/MGI_MGI_2676312/fb56d6de-3da5-4bab-bc20-7577889ebfef> ;
+   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_2676312/16b5262f-4d46-4752-91da-db74b73e31a2> ;
+   <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X"^^xsd:string ;
+   <http://purl.org/dc/elements/1.1/date> "2013-10-25" ;
+   <http://purl.org/pav/providedBy> "http://informatics.jax.org"^^xsd:string ;
+   rdfs:comment "MGI:MGI:2676312  RO:0002264 GO:0010875 MGI:MGI:5510615|PMID:23931754 ECO:0000315 MGI:MGI:4461044  2013-10-25 MGI GOREL:0001004(CL:0000091) creation-date=2013-10-25|modification-date=2013-10-25|comment=cell type Kupffer cell ; CL:0000091   primary cell line cell ; CL:0000001|contributor-id=https://orcid.org/0000-0001-5501-853X"
+ ] .
+
+
+###  http://model.geneontology.org/MGI_MGI_2676312/787df50a-9120-45b9-9301-c19d7f2a1037
+<http://model.geneontology.org/MGI_MGI_2676312/787df50a-9120-45b9-9301-c19d7f2a1037> rdf:type owl:NamedIndividual ,
+                                                                                              <http://purl.obolibrary.org/obo/GO_2000010> ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X" ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2013-10-25" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org" .
+
+
+###  http://model.geneontology.org/MGI_MGI_2676312/79c56623-17aa-4ac6-8feb-776e0d246b7d
+<http://model.geneontology.org/MGI_MGI_2676312/79c56623-17aa-4ac6-8feb-776e0d246b7d> rdf:type owl:NamedIndividual ,
+                                                                                              <http://purl.obolibrary.org/obo/ECO_0000315> ;
+                                                                                     <http://geneontology.org/lego/evidence-with> "MGI:MGI:4461044" ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X" ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2012-10-17" ;
+                                                                                     <http://purl.org/dc/elements/1.1/source> "PMID:18802465" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+                                                                                     rdfs:comment "anatomy TS26 epidermis stratum corneum ; EMAP:33921" ,
+                                                                                                  "cell type skin fibroblast ; CL:0002620" ,
+                                                                                                  "has_participant(CL:0002620)" ,
+                                                                                                  "has_participant(EMAPA:32787 TS26)" .
+
+
+###  http://model.geneontology.org/MGI_MGI_2676312/8a05e73f-7416-42fc-bcf3-c9f3e24c9af1
+<http://model.geneontology.org/MGI_MGI_2676312/8a05e73f-7416-42fc-bcf3-c9f3e24c9af1> rdf:type owl:NamedIndividual ,
+                                                                                              <http://purl.obolibrary.org/obo/ECO_0000315> ;
+                                                                                     <http://geneontology.org/lego/evidence-with> "MGI:MGI:3809668" ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X" ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2012-10-17" ;
+                                                                                     <http://purl.org/dc/elements/1.1/source> "PMID:18632686" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+                                                                                     rdfs:comment "anatomy TS26 epidermis stratum corneum ; EMAP:33921" ,
+                                                                                                  "has_participant(EMAPA:32787 TS26)" .
+
+
+###  http://model.geneontology.org/MGI_MGI_2676312/80a7d9fc-6e43-4057-b005-e3b87528f280
+<http://model.geneontology.org/MGI_MGI_2676312/80a7d9fc-6e43-4057-b005-e3b87528f280> rdf:type owl:NamedIndividual ,
+                                                                                              <http://purl.obolibrary.org/obo/ECO_0000315> ;
+                                                                                     <http://geneontology.org/lego/evidence-with> "MGI:MGI:3809668" ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X" ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2012-10-17" ;
+                                                                                     <http://purl.org/dc/elements/1.1/source> "PMID:18632686" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+                                                                                     rdfs:comment "anatomy alveolar system ;  MA:0000416" ,
+                                                                                                  "cell type type II pneumocyte ; CL:0002063" ,
+                                                                                                  "has_participant(CL:0002063)" .
+
+
+###  http://model.geneontology.org/MGI_MGI_2676312/829c3fb3-3000-48ce-a0a8-94630fa9dbed
+<http://model.geneontology.org/MGI_MGI_2676312/829c3fb3-3000-48ce-a0a8-94630fa9dbed> rdf:type owl:NamedIndividual ,
+                                                                                              <http://purl.obolibrary.org/obo/ECO_0000315> ;
+                                                                                     <http://geneontology.org/lego/evidence-with> "MGI:MGI:3528440" ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X" ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2012-10-17" ;
+                                                                                     <http://purl.org/dc/elements/1.1/source> "PMID:18957418" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+                                                                                     rdfs:comment "anatomy skin ; MA:0000151" .
+
+
+###  http://model.geneontology.org/MGI_MGI_2676312/83eea992-651a-4861-82ec-e483c134e360
+<http://model.geneontology.org/MGI_MGI_2676312/83eea992-651a-4861-82ec-e483c134e360> rdf:type owl:NamedIndividual ,
+                                                                                              <http://purl.obolibrary.org/obo/ECO_0000353> ;
+                                                                                     <http://geneontology.org/lego/evidence-with> "PR:P41233" ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X" ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2013-10-25" ;
+                                                                                     <http://purl.org/dc/elements/1.1/source> "PMID:23931754" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+                                                                                     rdfs:comment "In situ proximity ligation assay" ,
+                                                                                                  "RAW 264.7" ,
+                                                                                                  "cell type TIB-71   permanent cell line cell ; CLO:0000019" .
+
+
+###  http://model.geneontology.org/MGI_MGI_2676312/86d02de9-6ca4-4256-bbe1-8ca4e331e992
+<http://model.geneontology.org/MGI_MGI_2676312/86d02de9-6ca4-4256-bbe1-8ca4e331e992> rdf:type owl:NamedIndividual ,
+                                                                                              <http://purl.obolibrary.org/obo/GO_0030216> ;
+                                                                                     <http://purl.obolibrary.org/obo/RO_0002315> <http://model.geneontology.org/MGI_MGI_2676312/d68459b9-4221-4df0-9e15-cc579e038d73> ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X"^^xsd:string ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2012-10-17" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org"^^xsd:string .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource <http://model.geneontology.org/MGI_MGI_2676312/86d02de9-6ca4-4256-bbe1-8ca4e331e992> ;
+   owl:annotatedProperty <http://purl.obolibrary.org/obo/RO_0002315> ;
+   owl:annotatedTarget <http://model.geneontology.org/MGI_MGI_2676312/d68459b9-4221-4df0-9e15-cc579e038d73> ;
+   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_2676312/66af1bab-7d68-4d83-9b4b-9bb52116ce9a> ;
+   <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X"^^xsd:string ;
+   <http://purl.org/dc/elements/1.1/date> "2012-10-17" ;
+   <http://purl.org/pav/providedBy> "http://informatics.jax.org"^^xsd:string ;
+   rdfs:comment "MGI:MGI:2676312  RO:0002264 GO:0030216 MGI:MGI:4460077|PMID:18802465 ECO:0000315 MGI:MGI:4461044  2012-10-17 MGI RO:0002315(CL:0000312) creation-date=2012-10-17|modification-date=2012-10-17|comment=cell type keratinocyte ; CL:0000312|contributor-id=https://orcid.org/0000-0001-5501-853X"
+ ] .
+
+
+###  http://model.geneontology.org/MGI_MGI_2676312/9068171a-57f4-43c8-9546-a615e67fbebe
+<http://model.geneontology.org/MGI_MGI_2676312/9068171a-57f4-43c8-9546-a615e67fbebe> rdf:type owl:NamedIndividual ,
+                                                                                              <http://purl.obolibrary.org/obo/ECO_0000315> ;
+                                                                                     <http://geneontology.org/lego/evidence-with> "MGI:MGI:3809668" ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X" ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2012-10-17" ;
+                                                                                     <http://purl.org/dc/elements/1.1/source> "PMID:18632686" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+                                                                                     rdfs:comment "cell type epithelial cell of lung ; CL:0000082" ,
+                                                                                                  "has_participant(CL:0000082)" .
+
+
+###  http://model.geneontology.org/MGI_MGI_2676312/95053efe-c54a-4b3d-a13f-50c0c376060e
+<http://model.geneontology.org/MGI_MGI_2676312/95053efe-c54a-4b3d-a13f-50c0c376060e> rdf:type owl:NamedIndividual ,
+                                                                                              <http://purl.obolibrary.org/obo/ECO_0000315> ;
+                                                                                     <http://geneontology.org/lego/evidence-with> "MGI:MGI:4461044" ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-5501-853X" ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2013-10-25" ;
+                                                                                     <http://purl.org/dc/elements/1.1/source> "PMID:23931754" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+                                                                                     rdfs:comment "cell type Kupffer cell ; CL:0000091   primary cell line cell ; CL:0000001" .
+
+
+###  Generated by the OWL API (version 4.5.15) https://github.com/owlcs/owlapi


### PR DESCRIPTION
Fixes #395.