### PR TITLE
Don’t filter out GPAD annotations for 'do not annotate' violations.

### DIFF
--- a/minerva-cli/src/main/java/org/geneontology/minerva/cli/CommandLineInterface.java
+++ b/minerva-cli/src/main/java/org/geneontology/minerva/cli/CommandLineInterface.java
@@ -744,7 +744,7 @@ public class CommandLineInterface {
 		m3.getAvailableModelIds().stream().parallel().forEach(modelIRI -> {
 			try {
 				//TODO investigate whether changing to a neo-lite model has an impact on this - may need to make use of ontology journal
-				String gpad = new GPADSPARQLExport(curieHandler, m3.getLegacyRelationShorthandIndex(), m3.getTboxShorthandIndex(), m3.getDoNotAnnotateSubset()).exportGPAD(m3.createInferredModel(modelIRI), modelIRI);
+				String gpad = new GPADSPARQLExport(curieHandler, m3.getLegacyRelationShorthandIndex(), m3.getTboxShorthandIndex()).exportGPAD(m3.createInferredModel(modelIRI), modelIRI);
 				String fileName = StringUtils.replaceOnce(modelIRI.toString(), immutableModelIdPrefix, "") + ".gpad";
 				Writer writer = new OutputStreamWriter(new FileOutputStream(Paths.get(immutableGpadOutputFolder, fileName).toFile()), StandardCharsets.UTF_8);
 				writer.write(gpad);
@@ -1038,7 +1038,7 @@ public class CommandLineInterface {
 				int n_rows_gpad = 0;
 				if(isConsistent) {
 					try {
-						Set<GPADData> gpad = new GPADSPARQLExport(curieHandler, m3.getLegacyRelationShorthandIndex(), m3.getTboxShorthandIndex(), m3.getDoNotAnnotateSubset()).getGPAD(m3.createInferredModel(modelIRI), modelIRI);
+						Set<GPADData> gpad = new GPADSPARQLExport(curieHandler, m3.getLegacyRelationShorthandIndex(), m3.getTboxShorthandIndex()).getGPAD(m3.createInferredModel(modelIRI), modelIRI);
 						if(gpad!=null) {
 							n_rows_gpad = gpad.size();
 						}

--- a/minerva-converter/src/main/java/org/geneontology/minerva/legacy/sparql/GPADSPARQLExport.java
+++ b/minerva-converter/src/main/java/org/geneontology/minerva/legacy/sparql/GPADSPARQLExport.java
@@ -96,13 +96,11 @@ public class GPADSPARQLExport {
 	private final CurieHandler curieHandler;
 	private final Map<IRI, String> relationShorthandIndex;
 	private final Map<IRI, String> tboxShorthandIndex;
-	private final Set<IRI> doNotAnnotateSubset;
 
-	public GPADSPARQLExport(CurieHandler handler, Map<IRI, String> shorthandIndex, Map<IRI, String> tboxShorthandIndex, Set<IRI> doNotAnnotateSubset) {
+	public GPADSPARQLExport(CurieHandler handler, Map<IRI, String> shorthandIndex, Map<IRI, String> tboxShorthandIndex) {
 		this.curieHandler = handler;
 		this.relationShorthandIndex = shorthandIndex;
 		this.tboxShorthandIndex = tboxShorthandIndex;
-		this.doNotAnnotateSubset = doNotAnnotateSubset;
 	}
 
 	public String exportGPAD(WorkingMemory wm, IRI modelIRI) throws InconsistentOntologyException {
@@ -181,12 +179,8 @@ public class GPADSPARQLExport {
 						if (rootTerms.contains(annotation.getOntologyClass().toString())) {
 							rootViolation = !ND.equals(currentEvidence.getEvidence().toString());
 						} else { rootViolation = false; }
-						final boolean doNotAnnotateViolation;
-						if (doNotAnnotateSubset.contains(annotation.getOntologyClass())) {
-							doNotAnnotateViolation = true;
-						} else { doNotAnnotateViolation = false; }
 						final boolean rootMFWithBP = annotation.getOntologyClass().toString().equals(MF) && gpNodesWithOtherThanRootMF.contains(annotation.getObjectNode());
-						if (!rootViolation && !doNotAnnotateViolation && !rootMFWithBP) {
+						if (!rootViolation && !rootMFWithBP) {
 							DefaultGPADData defaultGPADData = new DefaultGPADData(annotation.getObject(), annotation.getQualifier(), annotation.getOntologyClass(), goodExtensions, 
 									reference, currentEvidence.getEvidence(), currentEvidence.getWithOrFrom(), Optional.empty(), currentEvidence.getModificationDate(),
 									currentEvidence.getAssignedBy(), currentEvidence.getAnnotations());

--- a/minerva-converter/src/test/java/org/geneontology/minerva/legacy/sparql/GPADSPARQLTest.java
+++ b/minerva-converter/src/test/java/org/geneontology/minerva/legacy/sparql/GPADSPARQLTest.java
@@ -43,7 +43,7 @@ public class GPADSPARQLTest {
 	@BeforeClass
 	public static void setupExporter() {
 		JenaSystem.init();
-		exporter = new GPADSPARQLExport(DefaultCurieHandler.getDefaultHandler(), new HashMap<IRI, String>(), new HashMap<IRI, String>(), Collections.emptySet());
+		exporter = new GPADSPARQLExport(DefaultCurieHandler.getDefaultHandler(), new HashMap<IRI, String>(), new HashMap<IRI, String>());
 	}
 
 	@Test

--- a/minerva-server/src/main/java/org/geneontology/minerva/server/handler/OperationsImpl.java
+++ b/minerva-server/src/main/java/org/geneontology/minerva/server/handler/OperationsImpl.java
@@ -722,7 +722,7 @@ abstract class OperationsImpl extends ModelCreator {
 		if ("gpad".equals(format)) {
 			initMetaResponse(response);
 			try {
-				GPADSPARQLExport exporter = new GPADSPARQLExport(curieHandler, m3.getLegacyRelationShorthandIndex(), m3.getTboxShorthandIndex(), m3.getDoNotAnnotateSubset());
+				GPADSPARQLExport exporter = new GPADSPARQLExport(curieHandler, m3.getLegacyRelationShorthandIndex(), m3.getTboxShorthandIndex());
 				WorkingMemory wm = m3.createCanonicalInferredModel(model.getModelId());
 				response.data.exportModel = exporter.exportGPAD(wm, model.getModelId());				
 		//		response.data.exportModel = new GPADSPARQLExport(curieHandler, m3.getLegacyRelationShorthandIndex(), m3.getTboxShorthandIndex(), m3.getDoNotAnnotateSubset()).exportGPAD(


### PR DESCRIPTION
Fixes #417.