### PR TITLE
Allow skipping ShEx in --validate-go-cams when --shex is omitted

### DIFF
--- a/minerva-cli/src/main/java/org/geneontology/minerva/cli/CommandLineInterface.java
+++ b/minerva-cli/src/main/java/org/geneontology/minerva/cli/CommandLineInterface.java
@@ -920,13 +920,13 @@ public class CommandLineInterface {
 			// TODO Auto-generated catch block
 			e1.printStackTrace();
 		}  
+		
 		if(checkShex) {
-			if(checkShex) {
-				shex.setActive(true);
-			}else {
-				shex.setActive(false);
-			}
+			shex.setActive(true);
+		}else {
+			shex.setActive(false);
 		}
+		
 		//shex validator is ready, now build the inference provider (which provides access to the shex validator and provides inferences useful for shex)
 		String reasonerOpt = "arachne"; 
 		LOGGER.info("Building OWL inference provider: "+reasonerOpt);

--- a/minerva-core/src/main/java/org/geneontology/minerva/validation/ShexValidationReport.java
+++ b/minerva-core/src/main/java/org/geneontology/minerva/validation/ShexValidationReport.java
@@ -36,8 +36,8 @@ public class ShexValidationReport extends ModelValidationReport{
 	/**
 	 * 
 	 */
-	public ShexValidationReport(String id, Model model) {
-		super(id, tracker, rulefile);
+	public ShexValidationReport() {
+		super(null, tracker, rulefile);
 	}
 
 	public String getAsText() {

--- a/minerva-core/src/main/java/org/geneontology/minerva/validation/ShexValidator.java
+++ b/minerva-core/src/main/java/org/geneontology/minerva/validation/ShexValidator.java
@@ -148,7 +148,7 @@ public class ShexValidator {
 
 	public ShexValidationReport runShapeMapValidation(Model test_model) {
 		boolean explain = true;
-		ShexValidationReport r = new ShexValidationReport(null, test_model);	
+		ShexValidationReport r = new ShexValidationReport();	
 		JenaRDF jr = new JenaRDF();
 		//this shex implementation likes to use the commons JenaRDF interface, nothing exciting here
 		JenaGraph shexy_graph = jr.asGraph(test_model);
@@ -282,7 +282,7 @@ public class ShexValidator {
 
 
 	public ShexValidationReport runShapeMapValidationWithRecursiveSingleNodeValidation(Model test_model, boolean stream_output) throws Exception {		
-		ShexValidationReport r = new ShexValidationReport(null, test_model);	
+		ShexValidationReport r = new ShexValidationReport();	
 		JenaRDF jr = new JenaRDF();
 		//this shex implementation likes to use the commons JenaRDF interface, nothing exciting here
 		JenaGraph shexy_graph = jr.asGraph(test_model);

--- a/minerva-server/src/main/java/org/geneontology/minerva/server/inferences/MapInferenceProvider.java
+++ b/minerva-server/src/main/java/org/geneontology/minerva/server/inferences/MapInferenceProvider.java
@@ -79,7 +79,7 @@ public class MapInferenceProvider implements InferenceProvider {
 			reasoner_validation.addViolation(i_v);
 		}
 		//shex
-		ShexValidationReport shex_validation = null;
+		ShexValidationReport shex_validation = new ShexValidationReport();
 		if(shex.isActive()) {
 			//generate an RDF model			
 			Model model = JenaOwlTool.getJenaModel(ont);	


### PR DESCRIPTION
This came out of a request by @ukemi for OWL consistency checks to be run on the MGI import models. But since we're still working on a [ShEx validator bug](https://github.com/geneontology/minerva/issues/399) exposed in these models, my attempt to bypass `--shex` in `--validate-go-cams` (and thus only running OWL checks) didn't seem to be working. ShEx checks were still performed and eventually broke on a model due to aforementioned [validator issue](https://github.com/geneontology/minerva/issues/399).

This PR is to allow validation w/o ShEx, which I know is not the desired attitude in the MOD imports project but this was necessary to get out the OWL checks. So, up to you @balhoff if you want to merge this "feature".