### PR TITLE
Exclude annotations to regulated terms

### DIFF
--- a/minerva-cli/src/main/java/org/geneontology/minerva/cli/CommandLineInterface.java
+++ b/minerva-cli/src/main/java/org/geneontology/minerva/cli/CommandLineInterface.java
@@ -744,7 +744,7 @@ public class CommandLineInterface {
 		m3.getAvailableModelIds().stream().parallel().forEach(modelIRI -> {
 			try {
 				//TODO investigate whether changing to a neo-lite model has an impact on this - may need to make use of ontology journal
-				String gpad = new GPADSPARQLExport(curieHandler, m3.getLegacyRelationShorthandIndex(), m3.getTboxShorthandIndex()).exportGPAD(m3.createInferredModel(modelIRI), modelIRI);
+				String gpad = new GPADSPARQLExport(curieHandler, m3.getLegacyRelationShorthandIndex(), m3.getTboxShorthandIndex(), m3.getGolego_repo().regulatorsToRegulated).exportGPAD(m3.createInferredModel(modelIRI), modelIRI);
 				String fileName = StringUtils.replaceOnce(modelIRI.toString(), immutableModelIdPrefix, "") + ".gpad";
 				Writer writer = new OutputStreamWriter(new FileOutputStream(Paths.get(immutableGpadOutputFolder, fileName).toFile()), StandardCharsets.UTF_8);
 				writer.write(gpad);
@@ -1038,7 +1038,7 @@ public class CommandLineInterface {
 				int n_rows_gpad = 0;
 				if(isConsistent) {
 					try {
-						Set<GPADData> gpad = new GPADSPARQLExport(curieHandler, m3.getLegacyRelationShorthandIndex(), m3.getTboxShorthandIndex()).getGPAD(m3.createInferredModel(modelIRI), modelIRI);
+						Set<GPADData> gpad = new GPADSPARQLExport(curieHandler, m3.getLegacyRelationShorthandIndex(), m3.getTboxShorthandIndex(), m3.getGolego_repo().regulatorsToRegulated).getGPAD(m3.createInferredModel(modelIRI), modelIRI);
 						if(gpad!=null) {
 							n_rows_gpad = gpad.size();
 						}

--- a/minerva-converter/src/main/java/org/geneontology/minerva/legacy/sparql/GPADSPARQLExport.java
+++ b/minerva-converter/src/main/java/org/geneontology/minerva/legacy/sparql/GPADSPARQLExport.java
@@ -46,6 +46,9 @@ import org.semanticweb.owlapi.reasoner.InconsistentOntologyException;
 
 import scala.collection.JavaConverters;
 
+import static java.util.stream.Collectors.mapping;
+import static java.util.stream.Collectors.toSet;
+
 /* 	 Note: the example GPAD files are available at this link: http://www.informatics.jax.org/downloads/reports/mgi.gpa.gz */
 public class GPADSPARQLExport {
 	private static final Logger LOG = Logger.getLogger(GPADSPARQLExport.class);
@@ -96,11 +99,13 @@ public class GPADSPARQLExport {
 	private final CurieHandler curieHandler;
 	private final Map<IRI, String> relationShorthandIndex;
 	private final Map<IRI, String> tboxShorthandIndex;
+	private final Map<IRI, Set<IRI>> regulators;
 
-	public GPADSPARQLExport(CurieHandler handler, Map<IRI, String> shorthandIndex, Map<IRI, String> tboxShorthandIndex) {
+	public GPADSPARQLExport(CurieHandler handler, Map<IRI, String> shorthandIndex, Map<IRI, String> tboxShorthandIndex, Map<IRI, Set<IRI>> regulators) {
 		this.curieHandler = handler;
 		this.relationShorthandIndex = shorthandIndex;
 		this.tboxShorthandIndex = tboxShorthandIndex;
+		this.regulators = regulators;
 	}
 
 	public String exportGPAD(WorkingMemory wm, IRI modelIRI) throws InconsistentOntologyException {
@@ -147,11 +152,15 @@ public class GPADSPARQLExport {
 		possibleExtensions.forEach(ae -> statementsToExplain.add(ae.getTriple()));
 		Map<Triple, Set<Explanation>> allExplanations = statementsToExplain.stream().collect(Collectors.toMap(Function.identity(), s -> toJava(wm.explain(Bridge.tripleFromJena(s)))));
 
-		Map<Triple, Set<GPADEvidence>> allEvidences = evidencesForFacts(allExplanations.values().stream().flatMap(es -> es.stream()).flatMap(e -> toJava(e.facts()).stream().map(t -> Bridge.jenaFromTriple(t))).collect(Collectors.toSet()), model, modelID, modelLevelAnnotations);
-		Set<Node> gpNodesWithOtherThanRootMF = basicAnnotations.stream().filter(a -> !a.getOntologyClass().toString().equals(MF)).map(a -> a.getObjectNode()).collect(Collectors.toSet());
+		Map<Triple, Set<GPADEvidence>> allEvidences = evidencesForFacts(allExplanations.values().stream().flatMap(es -> es.stream()).flatMap(e -> toJava(e.facts()).stream().map(t -> Bridge.jenaFromTriple(t))).collect(toSet()), model, modelID, modelLevelAnnotations);
+		Set<Node> gpNodesWithOtherThanRootMF = basicAnnotations.stream().filter(a -> !a.getOntologyClass().toString().equals(MF)).map(a -> a.getObjectNode()).collect(toSet());
+		Map<Node, Set<IRI>> nodesToOntologyClasses = basicAnnotations.stream().collect(Collectors.groupingBy(BasicGPADData::getObjectNode, mapping(BasicGPADData::getOntologyClass, toSet())));
 		for (BasicGPADData annotation : basicAnnotations) {
+			Set<IRI> termsRegulatedByAnnotationsForThisGPNode = nodesToOntologyClasses.get(annotation.getObjectNode()).stream().flatMap(term -> regulators.getOrDefault(term, Collections.emptySet()).stream()).collect(toSet());
+			boolean regulationViolation = termsRegulatedByAnnotationsForThisGPNode.contains(annotation.getOntologyClass());
+			if (regulationViolation) continue;
 			for (Explanation explanation : allExplanations.get(Triple.create(annotation.getObjectNode(), NodeFactory.createURI(annotation.getQualifier().toString()), annotation.getOntologyClassNode()))) {
-				Set<Triple> requiredFacts = toJava(explanation.facts()).stream().map(t -> Bridge.jenaFromTriple(t)).collect(Collectors.toSet());
+				Set<Triple> requiredFacts = toJava(explanation.facts()).stream().map(t -> Bridge.jenaFromTriple(t)).collect(toSet());
 				// Every statement in the explanation must have at least one evidence, unless the statement is a class assertion
 				if (requiredFacts.stream().filter(t -> !t.getPredicate().getURI().equals(RDF.type.getURI())).allMatch(f -> !(allEvidences.get(f).isEmpty()))) {
 					// The evidence used for the annotation must be on an edge to or from the target node
@@ -250,7 +259,7 @@ public class GPADSPARQLExport {
 				Optional<String> with = Optional.ofNullable(eqs.getLiteral("with")).map(Literal::getLexicalForm);
 				Set<Pair<String, String>> annotationAnnotations = new HashSet<>();
 				annotationAnnotations.add(Pair.of("noctua-model-id", modelID));
-				annotationAnnotations.addAll(getContributors(eqs).stream().map(c -> Pair.of("contributor", c)).collect(Collectors.toSet()));
+				annotationAnnotations.addAll(getContributors(eqs).stream().map(c -> Pair.of("contributor", c)).collect(toSet()));
 				String modificationDate = eqs.getLiteral("modification_date").getLexicalForm();
 				Optional<String> creationDate = Optional.ofNullable(eqs.getLiteral("creation_date")).map(Literal::getLexicalForm);
 				creationDate.ifPresent(date -> annotationAnnotations.add(Pair.of("creation-date", date)));

--- a/minerva-converter/src/test/resources/test_filter_regulated_process.ttl
+++ b/minerva-converter/src/test/resources/test_filter_regulated_process.ttl
@@ -1,0 +1,1081 @@
+@prefix : <http://model.geneontology.org/MGI_MGI_2148811#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@base <http://model.geneontology.org/MGI_MGI_2148811> .
+
+<http://model.geneontology.org/MGI_MGI_2148811> rdf:type owl:Ontology ;
+                                                 owl:versionIRI <http://model.geneontology.org/MGI_MGI_2148811> ;
+                                                 <http://geneontology.org/lego/modelstate> "production" ;
+                                                 <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ,
+                                                                                               "https://orcid.org/0000-0002-9796-7693" ,
+                                                                                               "https://orcid.org/0000-0003-2689-5511" ,
+                                                                                               "https://orcid.org/0000-0003-3394-9805" ;
+                                                 <http://purl.org/dc/elements/1.1/date> "2021-04-09"^^xsd:string ;
+                                                 <http://purl.org/dc/elements/1.1/title> "Npnt (MGI:MGI:2148811)" ;
+                                                 <http://purl.org/dc/terms/created> "2001-08-29" ;
+                                                 <http://purl.org/dc/terms/dateAccepted> "2021-09-29" ;
+                                                 <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+                                                 <https://w3id.org/biolink/vocab/in_taxon> <http://purl.obolibrary.org/obo/NCBITaxon_10090> .
+
+#################################################################
+#    Annotation properties
+#################################################################
+
+###  http://geneontology.org/lego/evidence
+<http://geneontology.org/lego/evidence> rdf:type owl:AnnotationProperty .
+
+
+###  http://geneontology.org/lego/evidence-with
+<http://geneontology.org/lego/evidence-with> rdf:type owl:AnnotationProperty .
+
+
+###  http://geneontology.org/lego/modelstate
+<http://geneontology.org/lego/modelstate> rdf:type owl:AnnotationProperty .
+
+
+###  http://geneontology.org/lego/hint/layout/x
+<http://geneontology.org/lego/hint/layout/x> rdf:type owl:AnnotationProperty .
+
+
+###  http://geneontology.org/lego/hint/layout/y
+<http://geneontology.org/lego/hint/layout/y> rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/dc/elements/1.1/contributor
+<http://purl.org/dc/elements/1.1/contributor> rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/dc/elements/1.1/date
+<http://purl.org/dc/elements/1.1/date> rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/dc/elements/1.1/source
+<http://purl.org/dc/elements/1.1/source> rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/dc/elements/1.1/title
+<http://purl.org/dc/elements/1.1/title> rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/dc/terms/created
+<http://purl.org/dc/terms/created> rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/dc/terms/dateAccepted
+<http://purl.org/dc/terms/dateAccepted> rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/pav/providedBy
+<http://purl.org/pav/providedBy> rdf:type owl:AnnotationProperty .
+
+
+###  https://w3id.org/biolink/vocab/in_taxon
+<https://w3id.org/biolink/vocab/in_taxon> rdf:type owl:AnnotationProperty .
+
+
+#################################################################
+#    Object Properties
+#################################################################
+
+###  http://purl.obolibrary.org/obo/BFO_0000050
+<http://purl.obolibrary.org/obo/BFO_0000050> rdf:type owl:ObjectProperty .
+
+
+###  http://purl.obolibrary.org/obo/BFO_0000066
+<http://purl.obolibrary.org/obo/BFO_0000066> rdf:type owl:ObjectProperty .
+
+
+###  http://purl.obolibrary.org/obo/RO_0001025
+<http://purl.obolibrary.org/obo/RO_0001025> rdf:type owl:ObjectProperty .
+
+
+###  http://purl.obolibrary.org/obo/RO_0002213
+<http://purl.obolibrary.org/obo/RO_0002213> rdf:type owl:ObjectProperty .
+
+
+###  http://purl.obolibrary.org/obo/RO_0002233
+<http://purl.obolibrary.org/obo/RO_0002233> rdf:type owl:ObjectProperty .
+
+
+###  http://purl.obolibrary.org/obo/RO_0002296
+<http://purl.obolibrary.org/obo/RO_0002296> rdf:type owl:ObjectProperty .
+
+
+###  http://purl.obolibrary.org/obo/RO_0002333
+<http://purl.obolibrary.org/obo/RO_0002333> rdf:type owl:ObjectProperty .
+
+
+###  http://purl.obolibrary.org/obo/RO_0002418
+<http://purl.obolibrary.org/obo/RO_0002418> rdf:type owl:ObjectProperty .
+
+
+#################################################################
+#    Classes
+#################################################################
+
+###  http://identifiers.org/mgi/MGI:2148811
+<http://identifiers.org/mgi/MGI:2148811> rdf:type owl:Class .
+
+
+###  http://purl.obolibrary.org/obo/ECO_0000314
+<http://purl.obolibrary.org/obo/ECO_0000314> rdf:type owl:Class .
+
+
+###  http://purl.obolibrary.org/obo/ECO_0000315
+<http://purl.obolibrary.org/obo/ECO_0000315> rdf:type owl:Class .
+
+
+###  http://purl.obolibrary.org/obo/ECO_0000353
+<http://purl.obolibrary.org/obo/ECO_0000353> rdf:type owl:Class .
+
+
+###  http://purl.obolibrary.org/obo/EMAPA_16039
+<http://purl.obolibrary.org/obo/EMAPA_16039> rdf:type owl:Class .
+
+
+###  http://purl.obolibrary.org/obo/EMAPA_17373
+<http://purl.obolibrary.org/obo/EMAPA_17373> rdf:type owl:Class .
+
+
+###  http://purl.obolibrary.org/obo/EMAPA_17376
+<http://purl.obolibrary.org/obo/EMAPA_17376> rdf:type owl:Class .
+
+
+###  http://purl.obolibrary.org/obo/GO_0001657
+<http://purl.obolibrary.org/obo/GO_0001657> rdf:type owl:Class .
+
+
+###  http://purl.obolibrary.org/obo/GO_0001658
+<http://purl.obolibrary.org/obo/GO_0001658> rdf:type owl:Class .
+
+
+###  http://purl.obolibrary.org/obo/GO_0003674
+<http://purl.obolibrary.org/obo/GO_0003674> rdf:type owl:Class .
+
+
+###  http://purl.obolibrary.org/obo/GO_0005178
+<http://purl.obolibrary.org/obo/GO_0005178> rdf:type owl:Class .
+
+
+###  http://purl.obolibrary.org/obo/GO_0005604
+<http://purl.obolibrary.org/obo/GO_0005604> rdf:type owl:Class .
+
+
+###  http://purl.obolibrary.org/obo/GO_0007160
+<http://purl.obolibrary.org/obo/GO_0007160> rdf:type owl:Class .
+
+
+###  http://purl.obolibrary.org/obo/GO_0007179
+<http://purl.obolibrary.org/obo/GO_0007179> rdf:type owl:Class .
+
+
+###  http://purl.obolibrary.org/obo/GO_0010811
+<http://purl.obolibrary.org/obo/GO_0010811> rdf:type owl:Class .
+
+
+###  http://purl.obolibrary.org/obo/GO_0030198
+<http://purl.obolibrary.org/obo/GO_0030198> rdf:type owl:Class .
+
+
+###  http://purl.obolibrary.org/obo/GO_0030511
+<http://purl.obolibrary.org/obo/GO_0030511> rdf:type owl:Class .
+
+
+###  http://purl.obolibrary.org/obo/GO_0031012
+<http://purl.obolibrary.org/obo/GO_0031012> rdf:type owl:Class .
+
+
+###  http://purl.obolibrary.org/obo/PR_Q3V3R4
+<http://purl.obolibrary.org/obo/PR_Q3V3R4> rdf:type owl:Class .
+
+
+#################################################################
+#    Individuals
+#################################################################
+
+###  http://model.geneontology.org/MGI_MGI_2148811/a2f8c100-f43e-4d22-a82e-c74b0506ecc9
+<http://model.geneontology.org/MGI_MGI_2148811/a2f8c100-f43e-4d22-a82e-c74b0506ecc9> rdf:type owl:NamedIndividual ,
+                                                                                              <http://purl.obolibrary.org/obo/ECO_0000315> ;
+                                                                                     <http://geneontology.org/lego/evidence-with> "MGI:MGI:3715213" ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2007-08-08" ;
+                                                                                     <http://purl.org/dc/elements/1.1/source> "PMID:17537792" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+                                                                                     rdfs:comment "anatomy ureteric bud ; EMAP:3844" ,
+                                                                                                  "bud outgrowth into metanephric mesenchyme" .
+
+
+###  http://model.geneontology.org/MGI_MGI_2148811/a6d63c10-8994-4174-a345-79a8089a8f05
+<http://model.geneontology.org/MGI_MGI_2148811/a6d63c10-8994-4174-a345-79a8089a8f05> rdf:type owl:NamedIndividual ,
+                                                                                              <http://purl.obolibrary.org/obo/GO_0005604> ;
+                                                                                     <http://purl.obolibrary.org/obo/BFO_0000050> <http://model.geneontology.org/MGI_MGI_2148811/621fe387-0962-4ad0-a291-be36555f56a4> ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0003-3394-9805" ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2008-12-05" ;
+                                                                                     <http://purl.org/dc/terms/created> "2008-12-05" ;
+                                                                                     <http://purl.org/dc/terms/dateAccepted> "2021-09-29" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org" .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource <http://model.geneontology.org/MGI_MGI_2148811/a6d63c10-8994-4174-a345-79a8089a8f05> ;
+   owl:annotatedProperty <http://purl.obolibrary.org/obo/BFO_0000050> ;
+   owl:annotatedTarget <http://model.geneontology.org/MGI_MGI_2148811/621fe387-0962-4ad0-a291-be36555f56a4> ;
+   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_2148811/3f3d0a30-b7ee-4389-930f-17a764eb1520> ;
+   <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0003-3394-9805" ;
+   <http://purl.org/dc/elements/1.1/date> "2008-12-05" ;
+   <http://purl.org/dc/terms/created> "2008-12-05" ;
+   <http://purl.org/dc/terms/dateAccepted> "2021-09-29" ;
+   <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+   rdfs:comment "MGI:MGI:2148811  RO:0001025 GO:0005604 MGI:MGI:3807344|PMID:18757743 ECO:0000314   2008-12-05 MGI BFO:0000050(EMAPA:16039) creation-date=2008-12-05|modification-date=2008-12-05|comment=anatomy Ts24\\  embryo ; EMAP:8439|contributor-id=https://orcid.org/0000-0003-3394-9805"
+ ] .
+
+
+###  http://model.geneontology.org/MGI_MGI_2148811/c104e977-4b3a-4a3f-bf5a-947197bbc70b
+<http://model.geneontology.org/MGI_MGI_2148811/c104e977-4b3a-4a3f-bf5a-947197bbc70b> rdf:type owl:NamedIndividual ,
+                                                                                              <http://purl.obolibrary.org/obo/ECO_0000315> ;
+                                                                                     <http://geneontology.org/lego/evidence-with> "MGI:MGI:3715213" ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2007-08-08" ;
+                                                                                     <http://purl.org/dc/elements/1.1/source> "PMID:17537792" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+                                                                                     rdfs:comment "anatomy ureteric bud ; EMAP:3844" ,
+                                                                                                  "bud outgrowth into metanephric mesenchyme" ,
+                                                                                                  "has_participant(EMAPA:17376 TS19)" .
+
+
+###  http://model.geneontology.org/MGI_MGI_2148811/c3687aea-756a-4053-bb0c-8f34509741f5
+<http://model.geneontology.org/MGI_MGI_2148811/c3687aea-756a-4053-bb0c-8f34509741f5> rdf:type owl:NamedIndividual ,
+                                                                                              <http://purl.obolibrary.org/obo/ECO_0000315> ;
+                                                                                     <http://geneontology.org/lego/evidence-with> "MGI:MGI:3715213" ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2007-08-08" ;
+                                                                                     <http://purl.org/dc/elements/1.1/source> "PMID:17537792" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+                                                                                     rdfs:comment "anatomy ureteric bud ; EMAP:3844" ,
+                                                                                                  "bud outgrowth into metanephric mesenchyme" .
+
+
+###  http://model.geneontology.org/MGI_MGI_2148811/c3d3dfe7-03a3-4645-b521-fa338fef7ed4
+<http://model.geneontology.org/MGI_MGI_2148811/c3d3dfe7-03a3-4645-b521-fa338fef7ed4> rdf:type owl:NamedIndividual ,
+                                                                                              <http://purl.obolibrary.org/obo/ECO_0000353> ;
+                                                                                     <http://geneontology.org/lego/evidence-with> "PR:Q3V3R4" ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ,
+                                                                                                                                   "https://orcid.org/0000-0002-9796-7693" ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2021-04-09" ;
+                                                                                     <http://purl.org/dc/elements/1.1/source> "PMID:11546798" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org" .
+
+
+###  http://model.geneontology.org/MGI_MGI_2148811/c50c9f1c-f2a6-499e-ad0e-437f8ea5e23b
+<http://model.geneontology.org/MGI_MGI_2148811/c50c9f1c-f2a6-499e-ad0e-437f8ea5e23b> rdf:type owl:NamedIndividual ,
+                                                                                              <http://purl.obolibrary.org/obo/ECO_0000314> ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2002-01-15" ;
+                                                                                     <http://purl.org/dc/elements/1.1/source> "PMID:11546798" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org" .
+
+
+###  http://model.geneontology.org/MGI_MGI_2148811/c818bb3e-7ad0-4cea-850c-3c5385908266
+<http://model.geneontology.org/MGI_MGI_2148811/c818bb3e-7ad0-4cea-850c-3c5385908266> rdf:type owl:NamedIndividual ,
+                                                                                              <http://purl.obolibrary.org/obo/GO_0003674> ;
+                                                                                     <http://purl.obolibrary.org/obo/RO_0002333> <http://model.geneontology.org/MGI_MGI_2148811/3ee16a2e-e3ba-42b0-a455-fee5d82f5f28> ;
+                                                                                     <http://purl.obolibrary.org/obo/RO_0002418> <http://model.geneontology.org/MGI_MGI_2148811/4830f5e7-7dc0-489c-b8ec-55a5a201e2c5> ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2007-08-08" ;
+                                                                                     <http://purl.org/dc/terms/created> "2007-08-08" ;
+                                                                                     <http://purl.org/dc/terms/dateAccepted> "2021-09-29" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org" .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource <http://model.geneontology.org/MGI_MGI_2148811/c818bb3e-7ad0-4cea-850c-3c5385908266> ;
+   owl:annotatedProperty <http://purl.obolibrary.org/obo/RO_0002333> ;
+   owl:annotatedTarget <http://model.geneontology.org/MGI_MGI_2148811/3ee16a2e-e3ba-42b0-a455-fee5d82f5f28> ;
+   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_2148811/f6005ff2-d828-4f5a-a08f-295114b06158> ;
+   <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ;
+   <http://purl.org/dc/elements/1.1/date> "2007-08-08" ;
+   <http://purl.org/dc/terms/created> "2007-08-08" ;
+   <http://purl.org/dc/terms/dateAccepted> "2021-09-29" ;
+   <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+   rdfs:comment "MGI:MGI:2148811  RO:0002264 GO:0030511 MGI:MGI:3714574|PMID:17537792 ECO:0000315 MGI:MGI:3715213  2007-08-08 MGI GOREL:0001004(EMAPA:17373) creation-date=2007-08-08|modification-date=2007-08-08|comment=anatomy metanephros ; EMAP:3841|comment=regulates_o_has_participant(MGI:107430)|comment=target Gdnf ; MGI:107430|contributor-id=https://orcid.org/0000-0001-7476-6306"
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource <http://model.geneontology.org/MGI_MGI_2148811/c818bb3e-7ad0-4cea-850c-3c5385908266> ;
+   owl:annotatedProperty <http://purl.obolibrary.org/obo/RO_0002418> ;
+   owl:annotatedTarget <http://model.geneontology.org/MGI_MGI_2148811/4830f5e7-7dc0-489c-b8ec-55a5a201e2c5> ;
+   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_2148811/4735aa1c-4e9d-4b87-a1ed-0527e41735b4> ;
+   <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ;
+   <http://purl.org/dc/elements/1.1/date> "2007-08-08" ;
+   <http://purl.org/dc/terms/created> "2007-08-08" ;
+   <http://purl.org/dc/terms/dateAccepted> "2021-09-29" ;
+   <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+   rdfs:comment "MGI:MGI:2148811  RO:0002264 GO:0030511 MGI:MGI:3714574|PMID:17537792 ECO:0000315 MGI:MGI:3715213  2007-08-08 MGI GOREL:0001004(EMAPA:17373) creation-date=2007-08-08|modification-date=2007-08-08|comment=anatomy metanephros ; EMAP:3841|comment=regulates_o_has_participant(MGI:107430)|comment=target Gdnf ; MGI:107430|contributor-id=https://orcid.org/0000-0001-7476-6306"
+ ] .
+
+
+###  http://model.geneontology.org/MGI_MGI_2148811/dd98ff87-bac9-43fe-907b-653fbc3bd516
+<http://model.geneontology.org/MGI_MGI_2148811/dd98ff87-bac9-43fe-907b-653fbc3bd516> rdf:type owl:NamedIndividual ,
+                                                                                              <http://purl.obolibrary.org/obo/ECO_0000353> ;
+                                                                                     <http://geneontology.org/lego/evidence-with> "UniProtKB:Q8BPT3" ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ,
+                                                                                                                                   "https://orcid.org/0000-0003-2689-5511" ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2005-10-03" ;
+                                                                                     <http://purl.org/dc/elements/1.1/source> "PMID:11470831" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org" .
+
+
+###  http://model.geneontology.org/MGI_MGI_2148811/de7d9352-cd52-4054-b751-29048f62da36
+<http://model.geneontology.org/MGI_MGI_2148811/de7d9352-cd52-4054-b751-29048f62da36> rdf:type owl:NamedIndividual ,
+                                                                                              <http://purl.obolibrary.org/obo/ECO_0000314> ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2002-01-15" ;
+                                                                                     <http://purl.org/dc/elements/1.1/source> "PMID:11546798" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org" .
+
+
+###  http://model.geneontology.org/MGI_MGI_2148811/e9c551ba-5ab2-491a-8170-2eeec69f3a65
+<http://model.geneontology.org/MGI_MGI_2148811/e9c551ba-5ab2-491a-8170-2eeec69f3a65> rdf:type owl:NamedIndividual ,
+                                                                                              <http://purl.obolibrary.org/obo/ECO_0000314> ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0003-3394-9805" ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2008-12-01" ;
+                                                                                     <http://purl.org/dc/elements/1.1/source> "PMID:18757743" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+                                                                                     rdfs:comment "evidence ECO:0000181" ,
+                                                                                                  "in vitro matrix assambly assays" .
+
+
+###  http://model.geneontology.org/MGI_MGI_2148811/f6005ff2-d828-4f5a-a08f-295114b06158
+<http://model.geneontology.org/MGI_MGI_2148811/f6005ff2-d828-4f5a-a08f-295114b06158> rdf:type owl:NamedIndividual ,
+                                                                                              <http://purl.obolibrary.org/obo/ECO_0000315> ;
+                                                                                     <http://geneontology.org/lego/evidence-with> "MGI:MGI:3715213" ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2007-08-08" ;
+                                                                                     <http://purl.org/dc/elements/1.1/source> "PMID:17537792" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+                                                                                     rdfs:comment "anatomy metanephros ; EMAP:3841" ,
+                                                                                                  "regulates_o_has_participant(MGI:107430)" ,
+                                                                                                  "target Gdnf ; MGI:107430" .
+
+
+###  http://model.geneontology.org/MGI_MGI_2148811/f7b050e4-17ed-450d-a54d-5b15cbedeb1a
+<http://model.geneontology.org/MGI_MGI_2148811/f7b050e4-17ed-450d-a54d-5b15cbedeb1a> rdf:type owl:NamedIndividual ,
+                                                                                              <http://purl.obolibrary.org/obo/GO_0031012> ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ,
+                                                                                                                                   "https://orcid.org/0000-0003-2689-5511" ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2005-10-03" ;
+                                                                                     <http://purl.org/dc/terms/created> "2001-08-29" ;
+                                                                                     <http://purl.org/dc/terms/dateAccepted> "2021-09-29" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org" .
+
+
+###  http://model.geneontology.org/MGI_MGI_2148811/f88beeba-8311-4dbb-9127-5754b3d0d277
+<http://model.geneontology.org/MGI_MGI_2148811/f88beeba-8311-4dbb-9127-5754b3d0d277> rdf:type owl:NamedIndividual ,
+                                                                                              <http://purl.obolibrary.org/obo/ECO_0000315> ;
+                                                                                     <http://geneontology.org/lego/evidence-with> "MGI:MGI:3715213" ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2007-08-08" ;
+                                                                                     <http://purl.org/dc/elements/1.1/source> "PMID:17537792" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+                                                                                     rdfs:comment "anatomy ureteric bud ; EMAP:3844" ,
+                                                                                                  "bud outgrowth into metanephric mesenchyme" ,
+                                                                                                  "has_participant(EMAPA:17376 TS19)" .
+
+
+###  http://model.geneontology.org/MGI_MGI_2148811/f92c4489-86e5-4f7b-b8fc-d7c9c5b66245
+<http://model.geneontology.org/MGI_MGI_2148811/f92c4489-86e5-4f7b-b8fc-d7c9c5b66245> rdf:type owl:NamedIndividual ,
+                                                                                              <http://purl.obolibrary.org/obo/GO_0003674> ;
+                                                                                     <http://purl.obolibrary.org/obo/RO_0002333> <http://model.geneontology.org/MGI_MGI_2148811/487bcb59-2b03-4677-964a-af94707640a6> ;
+                                                                                     <http://purl.obolibrary.org/obo/RO_0002418> <http://model.geneontology.org/MGI_MGI_2148811/2a26108c-b426-4734-aa54-23815a7bb189> ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0003-3394-9805" ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2008-12-01" ;
+                                                                                     <http://purl.org/dc/terms/created> "2008-12-01" ;
+                                                                                     <http://purl.org/dc/terms/dateAccepted> "2021-09-29" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org" .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource <http://model.geneontology.org/MGI_MGI_2148811/f92c4489-86e5-4f7b-b8fc-d7c9c5b66245> ;
+   owl:annotatedProperty <http://purl.obolibrary.org/obo/RO_0002333> ;
+   owl:annotatedTarget <http://model.geneontology.org/MGI_MGI_2148811/487bcb59-2b03-4677-964a-af94707640a6> ;
+   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_2148811/e9c551ba-5ab2-491a-8170-2eeec69f3a65> ;
+   <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0003-3394-9805" ;
+   <http://purl.org/dc/elements/1.1/date> "2008-12-01" ;
+   <http://purl.org/dc/terms/created> "2008-12-01" ;
+   <http://purl.org/dc/terms/dateAccepted> "2021-09-29" ;
+   <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+   rdfs:comment "MGI:MGI:2148811  RO:0002264 GO:0030198 MGI:MGI:3807344|PMID:18757743 ECO:0000314   2008-12-01 MGI  creation-date=2008-12-01|modification-date=2008-12-01|comment=evidence ECO:0000181|comment=in vitro matrix assambly assays|contributor-id=https://orcid.org/0000-0003-3394-9805"
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource <http://model.geneontology.org/MGI_MGI_2148811/f92c4489-86e5-4f7b-b8fc-d7c9c5b66245> ;
+   owl:annotatedProperty <http://purl.obolibrary.org/obo/RO_0002418> ;
+   owl:annotatedTarget <http://model.geneontology.org/MGI_MGI_2148811/2a26108c-b426-4734-aa54-23815a7bb189> ;
+   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_2148811/1c256d5c-0833-4d97-989f-66cb37e95c58> ;
+   <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0003-3394-9805" ;
+   <http://purl.org/dc/elements/1.1/date> "2008-12-01" ;
+   <http://purl.org/dc/terms/created> "2008-12-01" ;
+   <http://purl.org/dc/terms/dateAccepted> "2021-09-29" ;
+   <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+   rdfs:comment "MGI:MGI:2148811  RO:0002264 GO:0030198 MGI:MGI:3807344|PMID:18757743 ECO:0000314   2008-12-01 MGI  creation-date=2008-12-01|modification-date=2008-12-01|comment=evidence ECO:0000181|comment=in vitro matrix assambly assays|contributor-id=https://orcid.org/0000-0003-3394-9805"
+ ] .
+
+
+###  http://model.geneontology.org/MGI_MGI_2148811/0a0ee23f-9eca-43dc-942d-4cf343336e6d
+<http://model.geneontology.org/MGI_MGI_2148811/0a0ee23f-9eca-43dc-942d-4cf343336e6d> rdf:type owl:NamedIndividual ,
+                                                                                              <http://purl.obolibrary.org/obo/ECO_0000315> ;
+                                                                                     <http://geneontology.org/lego/evidence-with> "MGI:MGI:3715213" ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2007-08-08" ;
+                                                                                     <http://purl.org/dc/elements/1.1/source> "PMID:17537792" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+                                                                                     rdfs:comment "anatomy metanephros ; EMAP:3841" ,
+                                                                                                  "regulates_o_has_participant(MGI:107430)" ,
+                                                                                                  "target Gdnf ; MGI:107430" .
+
+
+###  http://model.geneontology.org/MGI_MGI_2148811/1c256d5c-0833-4d97-989f-66cb37e95c58
+<http://model.geneontology.org/MGI_MGI_2148811/1c256d5c-0833-4d97-989f-66cb37e95c58> rdf:type owl:NamedIndividual ,
+                                                                                              <http://purl.obolibrary.org/obo/ECO_0000314> ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0003-3394-9805" ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2008-12-01" ;
+                                                                                     <http://purl.org/dc/elements/1.1/source> "PMID:18757743" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+                                                                                     rdfs:comment "evidence ECO:0000181" ,
+                                                                                                  "in vitro matrix assambly assays" .
+
+
+###  http://model.geneontology.org/MGI_MGI_2148811/1dc908fd-295a-401d-938c-0099105a3693
+<http://model.geneontology.org/MGI_MGI_2148811/1dc908fd-295a-401d-938c-0099105a3693> rdf:type owl:NamedIndividual ,
+                                                                                              <http://identifiers.org/mgi/MGI:2148811> ;
+                                                                                     <http://purl.obolibrary.org/obo/RO_0001025> <http://model.geneontology.org/MGI_MGI_2148811/f7b050e4-17ed-450d-a54d-5b15cbedeb1a> ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ,
+                                                                                                                                   "https://orcid.org/0000-0003-2689-5511" ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2005-10-03" ;
+                                                                                     <http://purl.org/dc/terms/created> "2001-08-29" ;
+                                                                                     <http://purl.org/dc/terms/dateAccepted> "2021-09-29" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org" .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource <http://model.geneontology.org/MGI_MGI_2148811/1dc908fd-295a-401d-938c-0099105a3693> ;
+   owl:annotatedProperty <http://purl.obolibrary.org/obo/RO_0001025> ;
+   owl:annotatedTarget <http://model.geneontology.org/MGI_MGI_2148811/f7b050e4-17ed-450d-a54d-5b15cbedeb1a> ;
+   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_2148811/dd98ff87-bac9-43fe-907b-653fbc3bd516> ,
+                                           <http://model.geneontology.org/MGI_MGI_2148811/de7d9352-cd52-4054-b751-29048f62da36> ,
+                                           <http://model.geneontology.org/MGI_MGI_2148811/16afea91-a7d4-44b6-829c-c84bdbe495e3> ;
+   <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ,
+                                                 "https://orcid.org/0000-0003-2689-5511" ;
+   <http://purl.org/dc/elements/1.1/date> "2005-10-03" ;
+   <http://purl.org/dc/terms/created> "2001-08-29" ;
+   <http://purl.org/dc/terms/dateAccepted> "2021-09-29" ;
+   <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+   rdfs:comment "MGI:MGI:2148811  RO:0001025 GO:0031012 MGI:MGI:2137765|PMID:11470831 ECO:0000314   2001-08-29 MGI  creation-date=2001-08-29|modification-date=2001-08-29|contributor-id=https://orcid.org/0000-0001-7476-6306" ,
+                "MGI:MGI:2148811  RO:0001025 GO:0031012 MGI:MGI:2137765|PMID:11470831 ECO:0000353 UniProtKB:Q8BPT3  2005-10-03 MGI  creation-date=2001-08-29|modification-date=2005-10-03|contributor-id=https://orcid.org/0000-0001-7476-6306|contributor-id=https://orcid.org/0000-0003-2689-5511" ,
+                "MGI:MGI:2148811  RO:0001025 GO:0031012 MGI:MGI:2153230|PMID:11546798 ECO:0000314   2002-01-15 MGI  creation-date=2002-01-15|modification-date=2002-01-15|contributor-id=https://orcid.org/0000-0001-7476-6306"
+ ] .
+
+
+###  http://model.geneontology.org/MGI_MGI_2148811/1e0f94b1-ec42-47cc-864a-a7e284e96321
+<http://model.geneontology.org/MGI_MGI_2148811/1e0f94b1-ec42-47cc-864a-a7e284e96321> rdf:type owl:NamedIndividual ,
+                                                                                              <http://purl.obolibrary.org/obo/GO_0003674> ;
+                                                                                     <http://purl.obolibrary.org/obo/RO_0002333> <http://model.geneontology.org/MGI_MGI_2148811/9b02f1a2-f17c-48a6-b6ab-c0b8f50587cb> ;
+                                                                                     <http://purl.obolibrary.org/obo/RO_0002418> <http://model.geneontology.org/MGI_MGI_2148811/56e31bff-47ad-4e32-9e1e-7a0265e66ca1> ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ,
+                                                                                                                                   "https://orcid.org/0000-0003-2689-5511" ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2005-10-03" ;
+                                                                                     <http://purl.org/dc/terms/created> "2001-08-29" ;
+                                                                                     <http://purl.org/dc/terms/dateAccepted> "2021-09-29" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org" .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource <http://model.geneontology.org/MGI_MGI_2148811/1e0f94b1-ec42-47cc-864a-a7e284e96321> ;
+   owl:annotatedProperty <http://purl.obolibrary.org/obo/RO_0002333> ;
+   owl:annotatedTarget <http://model.geneontology.org/MGI_MGI_2148811/9b02f1a2-f17c-48a6-b6ab-c0b8f50587cb> ;
+   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_2148811/17b23e0b-b098-43a1-9808-7fefb870a60e> ,
+                                           <http://model.geneontology.org/MGI_MGI_2148811/52ba3970-983b-4df9-b822-9ba8d66d9595> ,
+                                           <http://model.geneontology.org/MGI_MGI_2148811/94f72196-0f29-46dd-93bf-e22882b03df1> ;
+   <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ,
+                                                 "https://orcid.org/0000-0003-2689-5511" ;
+   <http://purl.org/dc/elements/1.1/date> "2005-10-03" ;
+   <http://purl.org/dc/terms/created> "2001-08-29" ;
+   <http://purl.org/dc/terms/dateAccepted> "2021-09-29" ;
+   <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+   rdfs:comment "MGI:MGI:2148811  RO:0002264 GO:0007160 MGI:MGI:2137765|PMID:11470831 ECO:0000314   2001-08-29 MGI  creation-date=2001-08-29|modification-date=2001-08-29|contributor-id=https://orcid.org/0000-0001-7476-6306" ,
+                "MGI:MGI:2148811  RO:0002264 GO:0007160 MGI:MGI:2137765|PMID:11470831 ECO:0000353 UniProtKB:Q8BPT3  2005-10-03 MGI  creation-date=2001-08-29|modification-date=2005-10-03|contributor-id=https://orcid.org/0000-0001-7476-6306|contributor-id=https://orcid.org/0000-0003-2689-5511" ,
+                "MGI:MGI:2148811  RO:0002264 GO:0007160 MGI:MGI:2153230|PMID:11546798 ECO:0000314   2002-01-15 MGI  creation-date=2002-01-15|modification-date=2002-01-15|contributor-id=https://orcid.org/0000-0001-7476-6306"
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource <http://model.geneontology.org/MGI_MGI_2148811/1e0f94b1-ec42-47cc-864a-a7e284e96321> ;
+   owl:annotatedProperty <http://purl.obolibrary.org/obo/RO_0002418> ;
+   owl:annotatedTarget <http://model.geneontology.org/MGI_MGI_2148811/56e31bff-47ad-4e32-9e1e-7a0265e66ca1> ;
+   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_2148811/c50c9f1c-f2a6-499e-ad0e-437f8ea5e23b> ,
+                                           <http://model.geneontology.org/MGI_MGI_2148811/57f52905-ecb9-45b6-85cc-f986ea47d4b7> ,
+                                           <http://model.geneontology.org/MGI_MGI_2148811/84ebe592-6cff-4873-b7bc-7925e4d4660b> ;
+   <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ,
+                                                 "https://orcid.org/0000-0003-2689-5511" ;
+   <http://purl.org/dc/elements/1.1/date> "2005-10-03" ;
+   <http://purl.org/dc/terms/created> "2001-08-29" ;
+   <http://purl.org/dc/terms/dateAccepted> "2021-09-29" ;
+   <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+   rdfs:comment "MGI:MGI:2148811  RO:0002264 GO:0007160 MGI:MGI:2137765|PMID:11470831 ECO:0000314   2001-08-29 MGI  creation-date=2001-08-29|modification-date=2001-08-29|contributor-id=https://orcid.org/0000-0001-7476-6306" ,
+                "MGI:MGI:2148811  RO:0002264 GO:0007160 MGI:MGI:2137765|PMID:11470831 ECO:0000353 UniProtKB:Q8BPT3  2005-10-03 MGI  creation-date=2001-08-29|modification-date=2005-10-03|contributor-id=https://orcid.org/0000-0001-7476-6306|contributor-id=https://orcid.org/0000-0003-2689-5511" ,
+                "MGI:MGI:2148811  RO:0002264 GO:0007160 MGI:MGI:2153230|PMID:11546798 ECO:0000314   2002-01-15 MGI  creation-date=2002-01-15|modification-date=2002-01-15|contributor-id=https://orcid.org/0000-0001-7476-6306"
+ ] .
+
+
+###  http://model.geneontology.org/MGI_MGI_2148811/153d839d-3050-46c8-826e-51fc3cb35228
+<http://model.geneontology.org/MGI_MGI_2148811/153d839d-3050-46c8-826e-51fc3cb35228> rdf:type owl:NamedIndividual ,
+                                                                                              <http://identifiers.org/mgi/MGI:2148811> ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2007-08-08" ;
+                                                                                     <http://purl.org/dc/terms/created> "2007-08-08" ;
+                                                                                     <http://purl.org/dc/terms/dateAccepted> "2021-09-29" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org" .
+
+
+###  http://model.geneontology.org/MGI_MGI_2148811/16afea91-a7d4-44b6-829c-c84bdbe495e3
+<http://model.geneontology.org/MGI_MGI_2148811/16afea91-a7d4-44b6-829c-c84bdbe495e3> rdf:type owl:NamedIndividual ,
+                                                                                              <http://purl.obolibrary.org/obo/ECO_0000314> ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2001-08-29" ;
+                                                                                     <http://purl.org/dc/elements/1.1/source> "PMID:11470831" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org" .
+
+
+###  http://model.geneontology.org/MGI_MGI_2148811/17b23e0b-b098-43a1-9808-7fefb870a60e
+<http://model.geneontology.org/MGI_MGI_2148811/17b23e0b-b098-43a1-9808-7fefb870a60e> rdf:type owl:NamedIndividual ,
+                                                                                              <http://purl.obolibrary.org/obo/ECO_0000353> ;
+                                                                                     <http://geneontology.org/lego/evidence-with> "UniProtKB:Q8BPT3" ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ,
+                                                                                                                                   "https://orcid.org/0000-0003-2689-5511" ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2005-10-03" ;
+                                                                                     <http://purl.org/dc/elements/1.1/source> "PMID:11470831" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org" .
+
+
+###  http://model.geneontology.org/MGI_MGI_2148811/2a26108c-b426-4734-aa54-23815a7bb189
+<http://model.geneontology.org/MGI_MGI_2148811/2a26108c-b426-4734-aa54-23815a7bb189> rdf:type owl:NamedIndividual ,
+                                                                                              <http://purl.obolibrary.org/obo/GO_0030198> ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0003-3394-9805" ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2008-12-01" ;
+                                                                                     <http://purl.org/dc/terms/created> "2008-12-01" ;
+                                                                                     <http://purl.org/dc/terms/dateAccepted> "2021-09-29" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org" .
+
+
+###  http://model.geneontology.org/MGI_MGI_2148811/2ccf9143-90b7-4b6d-bd06-a8aae021c732
+<http://model.geneontology.org/MGI_MGI_2148811/2ccf9143-90b7-4b6d-bd06-a8aae021c732> rdf:type owl:NamedIndividual ,
+                                                                                              <http://purl.obolibrary.org/obo/EMAPA_17376> ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2007-08-08" ;
+                                                                                     <http://purl.org/dc/terms/created> "2007-08-08" ;
+                                                                                     <http://purl.org/dc/terms/dateAccepted> "2021-09-29" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org" .
+
+
+###  http://model.geneontology.org/MGI_MGI_2148811/21931373-d125-41dc-83ef-57404d493e6a
+<http://model.geneontology.org/MGI_MGI_2148811/21931373-d125-41dc-83ef-57404d493e6a> rdf:type owl:NamedIndividual ,
+                                                                                              <http://identifiers.org/mgi/MGI:2148811> ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0003-3394-9805" ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2008-12-03" ;
+                                                                                     <http://purl.org/dc/terms/created> "2008-12-03" ;
+                                                                                     <http://purl.org/dc/terms/dateAccepted> "2021-09-29" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org" .
+
+
+###  http://model.geneontology.org/MGI_MGI_2148811/23c2fd79-b615-469b-89fa-e761aa217055
+<http://model.geneontology.org/MGI_MGI_2148811/23c2fd79-b615-469b-89fa-e761aa217055> rdf:type owl:NamedIndividual ,
+                                                                                              <http://purl.obolibrary.org/obo/GO_0005178> ;
+                                                                                     <http://purl.obolibrary.org/obo/RO_0002233> <http://model.geneontology.org/MGI_MGI_2148811/4ad6e887-c39e-4149-bb2d-eff9ac1f5de5> ;
+                                                                                     <http://purl.obolibrary.org/obo/RO_0002333> <http://model.geneontology.org/MGI_MGI_2148811/7aa58ec8-db93-4917-aea1-aaed6da3ccce> ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ,
+                                                                                                                                   "https://orcid.org/0000-0002-9796-7693" ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2021-04-09"^^xsd:string ;
+                                                                                     <http://purl.org/dc/terms/created> "2002-01-15" ;
+                                                                                     <http://purl.org/dc/terms/dateAccepted> "2021-09-29" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org" .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource <http://model.geneontology.org/MGI_MGI_2148811/23c2fd79-b615-469b-89fa-e761aa217055> ;
+   owl:annotatedProperty <http://purl.obolibrary.org/obo/RO_0002333> ;
+   owl:annotatedTarget <http://model.geneontology.org/MGI_MGI_2148811/7aa58ec8-db93-4917-aea1-aaed6da3ccce> ;
+   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_2148811/c3d3dfe7-03a3-4645-b521-fa338fef7ed4> ;
+   <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ,
+                                                 "https://orcid.org/0000-0002-9796-7693" ;
+   <http://purl.org/dc/elements/1.1/date> "2021-04-09"^^xsd:string ;
+   <http://purl.org/dc/terms/created> "2002-01-15" ;
+   <http://purl.org/dc/terms/dateAccepted> "2021-09-29" ;
+   <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+   rdfs:comment "MGI:MGI:2148811  RO:0002327 GO:0005178 MGI:MGI:2153230|PMID:11546798 ECO:0000353 PR:Q3V3R4  2021-04-09 MGI  creation-date=2002-01-15|modification-date=2021-04-09|contributor-id=https://orcid.org/0000-0001-7476-6306|contributor-id=https://orcid.org/0000-0002-9796-7693"
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource <http://model.geneontology.org/MGI_MGI_2148811/23c2fd79-b615-469b-89fa-e761aa217055> ;
+   owl:annotatedProperty <http://purl.obolibrary.org/obo/RO_0002233> ;
+   owl:annotatedTarget <http://model.geneontology.org/MGI_MGI_2148811/4ad6e887-c39e-4149-bb2d-eff9ac1f5de5> ;
+   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_2148811/5e5aa5cb-f095-4122-83d7-999f50e32d6d> ;
+   <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ,
+                                                 "https://orcid.org/0000-0002-9796-7693" ;
+   <http://purl.org/dc/elements/1.1/date> "2021-04-09"^^xsd:string ;
+   <http://purl.org/dc/terms/created> "2002-01-15" ;
+   <http://purl.org/dc/terms/dateAccepted> "2021-09-29" ;
+   <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+   rdfs:comment "MGI:MGI:2148811  RO:0002327 GO:0005178 MGI:MGI:2153230|PMID:11546798 ECO:0000353 PR:Q3V3R4  2021-04-09 MGI  creation-date=2002-01-15|modification-date=2021-04-09|contributor-id=https://orcid.org/0000-0001-7476-6306|contributor-id=https://orcid.org/0000-0002-9796-7693"
+ ] .
+
+
+###  http://model.geneontology.org/MGI_MGI_2148811/28a0a495-450f-40b3-9c0a-aa1fa7c49b79
+<http://model.geneontology.org/MGI_MGI_2148811/28a0a495-450f-40b3-9c0a-aa1fa7c49b79> rdf:type owl:NamedIndividual ,
+                                                                                              <http://identifiers.org/mgi/MGI:2148811> ;
+                                                                                     <http://purl.obolibrary.org/obo/RO_0001025> <http://model.geneontology.org/MGI_MGI_2148811/a6d63c10-8994-4174-a345-79a8089a8f05> ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0003-3394-9805" ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2008-12-05" ;
+                                                                                     <http://purl.org/dc/terms/created> "2008-12-05" ;
+                                                                                     <http://purl.org/dc/terms/dateAccepted> "2021-09-29" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org" .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource <http://model.geneontology.org/MGI_MGI_2148811/28a0a495-450f-40b3-9c0a-aa1fa7c49b79> ;
+   owl:annotatedProperty <http://purl.obolibrary.org/obo/RO_0001025> ;
+   owl:annotatedTarget <http://model.geneontology.org/MGI_MGI_2148811/a6d63c10-8994-4174-a345-79a8089a8f05> ;
+   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_2148811/7a6b2b04-98ba-4bdd-9777-fe098ca0fa3d> ;
+   <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0003-3394-9805" ;
+   <http://purl.org/dc/elements/1.1/date> "2008-12-05" ;
+   <http://purl.org/dc/terms/created> "2008-12-05" ;
+   <http://purl.org/dc/terms/dateAccepted> "2021-09-29" ;
+   <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+   rdfs:comment "MGI:MGI:2148811  RO:0001025 GO:0005604 MGI:MGI:3807344|PMID:18757743 ECO:0000314   2008-12-05 MGI BFO:0000050(EMAPA:16039) creation-date=2008-12-05|modification-date=2008-12-05|comment=anatomy Ts24\\  embryo ; EMAP:8439|contributor-id=https://orcid.org/0000-0003-3394-9805"
+ ] .
+
+
+###  http://model.geneontology.org/MGI_MGI_2148811/28d0057d-93e9-4fad-b529-912c04f0b26b
+<http://model.geneontology.org/MGI_MGI_2148811/28d0057d-93e9-4fad-b529-912c04f0b26b> rdf:type owl:NamedIndividual ,
+                                                                                              <http://purl.obolibrary.org/obo/ECO_0000314> ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0003-3394-9805" ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2008-12-03" ;
+                                                                                     <http://purl.org/dc/elements/1.1/source> "PMID:18757743" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+                                                                                     rdfs:comment "evidence ECO:0000181" ,
+                                                                                                  "proteins were captured on 96-well plates via anti-GFP antibody and used as substrates in cell adhesion assays" .
+
+
+###  http://model.geneontology.org/MGI_MGI_2148811/3e704b03-b986-425b-acb7-b4cdf88dbded
+<http://model.geneontology.org/MGI_MGI_2148811/3e704b03-b986-425b-acb7-b4cdf88dbded> rdf:type owl:NamedIndividual ,
+                                                                                              <http://purl.obolibrary.org/obo/GO_0001658> ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2007-08-08" ;
+                                                                                     <http://purl.org/dc/terms/created> "2007-08-08" ;
+                                                                                     <http://purl.org/dc/terms/dateAccepted> "2021-09-29" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org" .
+
+
+###  http://model.geneontology.org/MGI_MGI_2148811/3ee16a2e-e3ba-42b0-a455-fee5d82f5f28
+<http://model.geneontology.org/MGI_MGI_2148811/3ee16a2e-e3ba-42b0-a455-fee5d82f5f28> rdf:type owl:NamedIndividual ,
+                                                                                              <http://identifiers.org/mgi/MGI:2148811> ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2007-08-08" ;
+                                                                                     <http://purl.org/dc/terms/created> "2007-08-08" ;
+                                                                                     <http://purl.org/dc/terms/dateAccepted> "2021-09-29" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org" .
+
+
+###  http://model.geneontology.org/MGI_MGI_2148811/3f3d0a30-b7ee-4389-930f-17a764eb1520
+<http://model.geneontology.org/MGI_MGI_2148811/3f3d0a30-b7ee-4389-930f-17a764eb1520> rdf:type owl:NamedIndividual ,
+                                                                                              <http://purl.obolibrary.org/obo/ECO_0000314> ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0003-3394-9805" ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2008-12-05" ;
+                                                                                     <http://purl.org/dc/elements/1.1/source> "PMID:18757743" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+                                                                                     rdfs:comment "anatomy Ts24\\  embryo ; EMAP:8439" .
+
+
+###  http://model.geneontology.org/MGI_MGI_2148811/4ad6e887-c39e-4149-bb2d-eff9ac1f5de5
+<http://model.geneontology.org/MGI_MGI_2148811/4ad6e887-c39e-4149-bb2d-eff9ac1f5de5> rdf:type owl:NamedIndividual ,
+                                                                                              <http://purl.obolibrary.org/obo/PR_Q3V3R4> ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ,
+                                                                                                                                   "https://orcid.org/0000-0002-9796-7693" ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2021-04-09" ;
+                                                                                     <http://purl.org/dc/terms/created> "2002-01-15" ;
+                                                                                     <http://purl.org/dc/terms/dateAccepted> "2021-09-29" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org" .
+
+
+###  http://model.geneontology.org/MGI_MGI_2148811/419df810-dea2-4e05-ad4a-3f188c75e674
+<http://model.geneontology.org/MGI_MGI_2148811/419df810-dea2-4e05-ad4a-3f188c75e674> rdf:type owl:NamedIndividual ,
+                                                                                              <http://purl.obolibrary.org/obo/GO_0003674> ;
+                                                                                     <http://purl.obolibrary.org/obo/RO_0002333> <http://model.geneontology.org/MGI_MGI_2148811/21931373-d125-41dc-83ef-57404d493e6a> ;
+                                                                                     <http://purl.obolibrary.org/obo/RO_0002418> <http://model.geneontology.org/MGI_MGI_2148811/7a0d4baf-b64b-4cd6-9b84-83becb7b90b1> ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0003-3394-9805" ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2008-12-03" ;
+                                                                                     <http://purl.org/dc/terms/created> "2008-12-03" ;
+                                                                                     <http://purl.org/dc/terms/dateAccepted> "2021-09-29" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org" .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource <http://model.geneontology.org/MGI_MGI_2148811/419df810-dea2-4e05-ad4a-3f188c75e674> ;
+   owl:annotatedProperty <http://purl.obolibrary.org/obo/RO_0002333> ;
+   owl:annotatedTarget <http://model.geneontology.org/MGI_MGI_2148811/21931373-d125-41dc-83ef-57404d493e6a> ;
+   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_2148811/28d0057d-93e9-4fad-b529-912c04f0b26b> ;
+   <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0003-3394-9805" ;
+   <http://purl.org/dc/elements/1.1/date> "2008-12-03" ;
+   <http://purl.org/dc/terms/created> "2008-12-03" ;
+   <http://purl.org/dc/terms/dateAccepted> "2021-09-29" ;
+   <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+   rdfs:comment "MGI:MGI:2148811  RO:0002264 GO:0010811 MGI:MGI:3807344|PMID:18757743 ECO:0000314   2008-12-03 MGI  creation-date=2008-12-03|modification-date=2008-12-03|comment=evidence ECO:0000181|comment=proteins were captured on 96-well plates via anti-GFP antibody and used as substrates in cell adhesion assays|contributor-id=https://orcid.org/0000-0003-3394-9805"
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource <http://model.geneontology.org/MGI_MGI_2148811/419df810-dea2-4e05-ad4a-3f188c75e674> ;
+   owl:annotatedProperty <http://purl.obolibrary.org/obo/RO_0002418> ;
+   owl:annotatedTarget <http://model.geneontology.org/MGI_MGI_2148811/7a0d4baf-b64b-4cd6-9b84-83becb7b90b1> ;
+   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_2148811/58edcb39-8f2d-4c9e-a51c-dea6f626d439> ;
+   <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0003-3394-9805" ;
+   <http://purl.org/dc/elements/1.1/date> "2008-12-03" ;
+   <http://purl.org/dc/terms/created> "2008-12-03" ;
+   <http://purl.org/dc/terms/dateAccepted> "2021-09-29" ;
+   <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+   rdfs:comment "MGI:MGI:2148811  RO:0002264 GO:0010811 MGI:MGI:3807344|PMID:18757743 ECO:0000314   2008-12-03 MGI  creation-date=2008-12-03|modification-date=2008-12-03|comment=evidence ECO:0000181|comment=proteins were captured on 96-well plates via anti-GFP antibody and used as substrates in cell adhesion assays|contributor-id=https://orcid.org/0000-0003-3394-9805"
+ ] .
+
+
+###  http://model.geneontology.org/MGI_MGI_2148811/4735aa1c-4e9d-4b87-a1ed-0527e41735b4
+<http://model.geneontology.org/MGI_MGI_2148811/4735aa1c-4e9d-4b87-a1ed-0527e41735b4> rdf:type owl:NamedIndividual ,
+                                                                                              <http://purl.obolibrary.org/obo/ECO_0000315> ;
+                                                                                     <http://geneontology.org/lego/evidence-with> "MGI:MGI:3715213" ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2007-08-08" ;
+                                                                                     <http://purl.org/dc/elements/1.1/source> "PMID:17537792" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+                                                                                     rdfs:comment "anatomy metanephros ; EMAP:3841" ,
+                                                                                                  "regulates_o_has_participant(MGI:107430)" ,
+                                                                                                  "target Gdnf ; MGI:107430" .
+
+
+###  http://model.geneontology.org/MGI_MGI_2148811/4830f5e7-7dc0-489c-b8ec-55a5a201e2c5
+<http://model.geneontology.org/MGI_MGI_2148811/4830f5e7-7dc0-489c-b8ec-55a5a201e2c5> rdf:type owl:NamedIndividual ,
+                                                                                              <http://purl.obolibrary.org/obo/GO_0030511> ;
+                                                                                     <http://purl.obolibrary.org/obo/RO_0002213> <http://model.geneontology.org/MGI_MGI_2148811/63b0e46f-57b9-43b3-bb1b-661bd4f2d7e5> ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2007-08-08" ;
+                                                                                     <http://purl.org/dc/terms/created> "2007-08-08" ;
+                                                                                     <http://purl.org/dc/terms/dateAccepted> "2021-09-29" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org" .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource <http://model.geneontology.org/MGI_MGI_2148811/4830f5e7-7dc0-489c-b8ec-55a5a201e2c5> ;
+   owl:annotatedProperty <http://purl.obolibrary.org/obo/RO_0002213> ;
+   owl:annotatedTarget <http://model.geneontology.org/MGI_MGI_2148811/63b0e46f-57b9-43b3-bb1b-661bd4f2d7e5> ;
+   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_2148811/52ff1a5c-7b6b-46dd-9642-1ac56e65ccbe> ;
+   <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ;
+   <http://purl.org/dc/elements/1.1/date> "2007-08-08" ;
+   <http://purl.org/dc/terms/created> "2007-08-08" ;
+   <http://purl.org/dc/terms/dateAccepted> "2021-09-29" ;
+   <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+   rdfs:comment "MGI:MGI:2148811  RO:0002264 GO:0030511 MGI:MGI:3714574|PMID:17537792 ECO:0000315 MGI:MGI:3715213  2007-08-08 MGI GOREL:0001004(EMAPA:17373) creation-date=2007-08-08|modification-date=2007-08-08|comment=anatomy metanephros ; EMAP:3841|comment=regulates_o_has_participant(MGI:107430)|comment=target Gdnf ; MGI:107430|contributor-id=https://orcid.org/0000-0001-7476-6306"
+ ] .
+
+
+###  http://model.geneontology.org/MGI_MGI_2148811/487bcb59-2b03-4677-964a-af94707640a6
+<http://model.geneontology.org/MGI_MGI_2148811/487bcb59-2b03-4677-964a-af94707640a6> rdf:type owl:NamedIndividual ,
+                                                                                              <http://identifiers.org/mgi/MGI:2148811> ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0003-3394-9805" ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2008-12-01" ;
+                                                                                     <http://purl.org/dc/terms/created> "2008-12-01" ;
+                                                                                     <http://purl.org/dc/terms/dateAccepted> "2021-09-29" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org" .
+
+
+###  http://model.geneontology.org/MGI_MGI_2148811/5e5aa5cb-f095-4122-83d7-999f50e32d6d
+<http://model.geneontology.org/MGI_MGI_2148811/5e5aa5cb-f095-4122-83d7-999f50e32d6d> rdf:type owl:NamedIndividual ,
+                                                                                              <http://purl.obolibrary.org/obo/ECO_0000353> ;
+                                                                                     <http://geneontology.org/lego/evidence-with> "PR:Q3V3R4" ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ,
+                                                                                                                                   "https://orcid.org/0000-0002-9796-7693" ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2021-04-09" ;
+                                                                                     <http://purl.org/dc/elements/1.1/source> "PMID:11546798" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org" .
+
+
+###  http://model.geneontology.org/MGI_MGI_2148811/52ba3970-983b-4df9-b822-9ba8d66d9595
+<http://model.geneontology.org/MGI_MGI_2148811/52ba3970-983b-4df9-b822-9ba8d66d9595> rdf:type owl:NamedIndividual ,
+                                                                                              <http://purl.obolibrary.org/obo/ECO_0000314> ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2002-01-15" ;
+                                                                                     <http://purl.org/dc/elements/1.1/source> "PMID:11546798" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org" .
+
+
+###  http://model.geneontology.org/MGI_MGI_2148811/52ff1a5c-7b6b-46dd-9642-1ac56e65ccbe
+<http://model.geneontology.org/MGI_MGI_2148811/52ff1a5c-7b6b-46dd-9642-1ac56e65ccbe> rdf:type owl:NamedIndividual ,
+                                                                                              <http://purl.obolibrary.org/obo/ECO_0000315> ;
+                                                                                     <http://geneontology.org/lego/evidence-with> "MGI:MGI:3715213" ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2007-08-08" ;
+                                                                                     <http://purl.org/dc/elements/1.1/source> "PMID:17537792" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+                                                                                     rdfs:comment "anatomy metanephros ; EMAP:3841" ,
+                                                                                                  "regulates_o_has_participant(MGI:107430)" ,
+                                                                                                  "target Gdnf ; MGI:107430" .
+
+
+###  http://model.geneontology.org/MGI_MGI_2148811/56e31bff-47ad-4e32-9e1e-7a0265e66ca1
+<http://model.geneontology.org/MGI_MGI_2148811/56e31bff-47ad-4e32-9e1e-7a0265e66ca1> rdf:type owl:NamedIndividual ,
+                                                                                              <http://purl.obolibrary.org/obo/GO_0007160> ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ,
+                                                                                                                                   "https://orcid.org/0000-0003-2689-5511" ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2005-10-03" ;
+                                                                                     <http://purl.org/dc/terms/created> "2001-08-29" ;
+                                                                                     <http://purl.org/dc/terms/dateAccepted> "2021-09-29" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org" .
+
+
+###  http://model.geneontology.org/MGI_MGI_2148811/57f52905-ecb9-45b6-85cc-f986ea47d4b7
+<http://model.geneontology.org/MGI_MGI_2148811/57f52905-ecb9-45b6-85cc-f986ea47d4b7> rdf:type owl:NamedIndividual ,
+                                                                                              <http://purl.obolibrary.org/obo/ECO_0000314> ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2001-08-29" ;
+                                                                                     <http://purl.org/dc/elements/1.1/source> "PMID:11470831" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org" .
+
+
+###  http://model.geneontology.org/MGI_MGI_2148811/571f1618-c690-4324-8ddc-f86188e27368
+<http://model.geneontology.org/MGI_MGI_2148811/571f1618-c690-4324-8ddc-f86188e27368> rdf:type owl:NamedIndividual ,
+                                                                                              <http://purl.obolibrary.org/obo/GO_0003674> ;
+                                                                                     <http://purl.obolibrary.org/obo/RO_0002333> <http://model.geneontology.org/MGI_MGI_2148811/153d839d-3050-46c8-826e-51fc3cb35228> ;
+                                                                                     <http://purl.obolibrary.org/obo/RO_0002418> <http://model.geneontology.org/MGI_MGI_2148811/3e704b03-b986-425b-acb7-b4cdf88dbded> ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2007-08-08" ;
+                                                                                     <http://purl.org/dc/terms/created> "2007-08-08" ;
+                                                                                     <http://purl.org/dc/terms/dateAccepted> "2021-09-29" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org" .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource <http://model.geneontology.org/MGI_MGI_2148811/571f1618-c690-4324-8ddc-f86188e27368> ;
+   owl:annotatedProperty <http://purl.obolibrary.org/obo/RO_0002333> ;
+   owl:annotatedTarget <http://model.geneontology.org/MGI_MGI_2148811/153d839d-3050-46c8-826e-51fc3cb35228> ;
+   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_2148811/c104e977-4b3a-4a3f-bf5a-947197bbc70b> ;
+   <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ;
+   <http://purl.org/dc/elements/1.1/date> "2007-08-08" ;
+   <http://purl.org/dc/terms/created> "2007-08-08" ;
+   <http://purl.org/dc/terms/dateAccepted> "2021-09-29" ;
+   <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+   rdfs:comment "MGI:MGI:2148811  RO:0002264 GO:0001658 MGI:MGI:3714574|PMID:17537792 ECO:0000315 MGI:MGI:3715213  2007-08-08 MGI  creation-date=2007-08-08|modification-date=2007-08-08|comment=anatomy ureteric bud ; EMAP:3844|comment=has_participant(EMAPA:17376 TS19)|comment=bud outgrowth into metanephric mesenchyme|contributor-id=https://orcid.org/0000-0001-7476-6306"
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource <http://model.geneontology.org/MGI_MGI_2148811/571f1618-c690-4324-8ddc-f86188e27368> ;
+   owl:annotatedProperty <http://purl.obolibrary.org/obo/RO_0002418> ;
+   owl:annotatedTarget <http://model.geneontology.org/MGI_MGI_2148811/3e704b03-b986-425b-acb7-b4cdf88dbded> ;
+   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_2148811/f88beeba-8311-4dbb-9127-5754b3d0d277> ;
+   <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ;
+   <http://purl.org/dc/elements/1.1/date> "2007-08-08" ;
+   <http://purl.org/dc/terms/created> "2007-08-08" ;
+   <http://purl.org/dc/terms/dateAccepted> "2021-09-29" ;
+   <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+   rdfs:comment "MGI:MGI:2148811  RO:0002264 GO:0001658 MGI:MGI:3714574|PMID:17537792 ECO:0000315 MGI:MGI:3715213  2007-08-08 MGI  creation-date=2007-08-08|modification-date=2007-08-08|comment=anatomy ureteric bud ; EMAP:3844|comment=has_participant(EMAPA:17376 TS19)|comment=bud outgrowth into metanephric mesenchyme|contributor-id=https://orcid.org/0000-0001-7476-6306"
+ ] .
+
+
+###  http://model.geneontology.org/MGI_MGI_2148811/58edcb39-8f2d-4c9e-a51c-dea6f626d439
+<http://model.geneontology.org/MGI_MGI_2148811/58edcb39-8f2d-4c9e-a51c-dea6f626d439> rdf:type owl:NamedIndividual ,
+                                                                                              <http://purl.obolibrary.org/obo/ECO_0000314> ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0003-3394-9805" ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2008-12-03" ;
+                                                                                     <http://purl.org/dc/elements/1.1/source> "PMID:18757743" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+                                                                                     rdfs:comment "evidence ECO:0000181" ,
+                                                                                                  "proteins were captured on 96-well plates via anti-GFP antibody and used as substrates in cell adhesion assays" .
+
+
+###  http://model.geneontology.org/MGI_MGI_2148811/621fe387-0962-4ad0-a291-be36555f56a4
+<http://model.geneontology.org/MGI_MGI_2148811/621fe387-0962-4ad0-a291-be36555f56a4> rdf:type owl:NamedIndividual ,
+                                                                                              <http://purl.obolibrary.org/obo/EMAPA_16039> ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0003-3394-9805" ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2008-12-05" ;
+                                                                                     <http://purl.org/dc/terms/created> "2008-12-05" ;
+                                                                                     <http://purl.org/dc/terms/dateAccepted> "2021-09-29" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org" .
+
+
+###  http://model.geneontology.org/MGI_MGI_2148811/63b0e46f-57b9-43b3-bb1b-661bd4f2d7e5
+<http://model.geneontology.org/MGI_MGI_2148811/63b0e46f-57b9-43b3-bb1b-661bd4f2d7e5> rdf:type owl:NamedIndividual ,
+                                                                                              <http://purl.obolibrary.org/obo/GO_0007179> ;
+                                                                                     <http://purl.obolibrary.org/obo/BFO_0000066> <http://model.geneontology.org/MGI_MGI_2148811/875cacd8-cb81-473e-812f-a337d1d2de30> ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2007-08-08" ;
+                                                                                     <http://purl.org/dc/terms/created> "2007-08-08" ;
+                                                                                     <http://purl.org/dc/terms/dateAccepted> "2021-09-29" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org" .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource <http://model.geneontology.org/MGI_MGI_2148811/63b0e46f-57b9-43b3-bb1b-661bd4f2d7e5> ;
+   owl:annotatedProperty <http://purl.obolibrary.org/obo/BFO_0000066> ;
+   owl:annotatedTarget <http://model.geneontology.org/MGI_MGI_2148811/875cacd8-cb81-473e-812f-a337d1d2de30> ;
+   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_2148811/0a0ee23f-9eca-43dc-942d-4cf343336e6d> ;
+   <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ;
+   <http://purl.org/dc/elements/1.1/date> "2007-08-08" ;
+   <http://purl.org/dc/terms/created> "2007-08-08" ;
+   <http://purl.org/dc/terms/dateAccepted> "2021-09-29" ;
+   <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+   rdfs:comment "MGI:MGI:2148811  RO:0002264 GO:0030511 MGI:MGI:3714574|PMID:17537792 ECO:0000315 MGI:MGI:3715213  2007-08-08 MGI GOREL:0001004(EMAPA:17373) creation-date=2007-08-08|modification-date=2007-08-08|comment=anatomy metanephros ; EMAP:3841|comment=regulates_o_has_participant(MGI:107430)|comment=target Gdnf ; MGI:107430|contributor-id=https://orcid.org/0000-0001-7476-6306"
+ ] .
+
+
+###  http://model.geneontology.org/MGI_MGI_2148811/7a0d4baf-b64b-4cd6-9b84-83becb7b90b1
+<http://model.geneontology.org/MGI_MGI_2148811/7a0d4baf-b64b-4cd6-9b84-83becb7b90b1> rdf:type owl:NamedIndividual ,
+                                                                                              <http://purl.obolibrary.org/obo/GO_0010811> ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0003-3394-9805" ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2008-12-03" ;
+                                                                                     <http://purl.org/dc/terms/created> "2008-12-03" ;
+                                                                                     <http://purl.org/dc/terms/dateAccepted> "2021-09-29" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org" .
+
+
+###  http://model.geneontology.org/MGI_MGI_2148811/7a6b2b04-98ba-4bdd-9777-fe098ca0fa3d
+<http://model.geneontology.org/MGI_MGI_2148811/7a6b2b04-98ba-4bdd-9777-fe098ca0fa3d> rdf:type owl:NamedIndividual ,
+                                                                                              <http://purl.obolibrary.org/obo/ECO_0000314> ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0003-3394-9805" ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2008-12-05" ;
+                                                                                     <http://purl.org/dc/elements/1.1/source> "PMID:18757743" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+                                                                                     rdfs:comment "anatomy Ts24\\  embryo ; EMAP:8439" .
+
+
+###  http://model.geneontology.org/MGI_MGI_2148811/7aa58ec8-db93-4917-aea1-aaed6da3ccce
+<http://model.geneontology.org/MGI_MGI_2148811/7aa58ec8-db93-4917-aea1-aaed6da3ccce> rdf:type owl:NamedIndividual ,
+                                                                                              <http://identifiers.org/mgi/MGI:2148811> ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ,
+                                                                                                                                   "https://orcid.org/0000-0002-9796-7693" ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2021-04-09" ;
+                                                                                     <http://purl.org/dc/terms/created> "2002-01-15" ;
+                                                                                     <http://purl.org/dc/terms/dateAccepted> "2021-09-29" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org" .
+
+
+###  http://model.geneontology.org/MGI_MGI_2148811/7d680ba7-77c1-4884-8c62-7c3705a41c9a
+<http://model.geneontology.org/MGI_MGI_2148811/7d680ba7-77c1-4884-8c62-7c3705a41c9a> rdf:type owl:NamedIndividual ,
+                                                                                              <http://purl.obolibrary.org/obo/GO_0003674> ;
+                                                                                     <http://purl.obolibrary.org/obo/RO_0002333> <http://model.geneontology.org/MGI_MGI_2148811/89ffe9af-5603-4134-837a-5c11f502d227> ;
+                                                                                     <http://purl.obolibrary.org/obo/RO_0002418> <http://model.geneontology.org/MGI_MGI_2148811/88def303-cf3a-4651-a972-65e669bf6343> ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2007-08-08" ;
+                                                                                     <http://purl.org/dc/terms/created> "2007-08-08" ;
+                                                                                     <http://purl.org/dc/terms/dateAccepted> "2021-09-29" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org" .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource <http://model.geneontology.org/MGI_MGI_2148811/7d680ba7-77c1-4884-8c62-7c3705a41c9a> ;
+   owl:annotatedProperty <http://purl.obolibrary.org/obo/RO_0002333> ;
+   owl:annotatedTarget <http://model.geneontology.org/MGI_MGI_2148811/89ffe9af-5603-4134-837a-5c11f502d227> ;
+   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_2148811/7f27dc1e-63e1-4859-8cbc-61b0a579392f> ;
+   <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ;
+   <http://purl.org/dc/elements/1.1/date> "2007-08-08" ;
+   <http://purl.org/dc/terms/created> "2007-08-08" ;
+   <http://purl.org/dc/terms/dateAccepted> "2021-09-29" ;
+   <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+   rdfs:comment "MGI:MGI:2148811  RO:0002264 GO:0001657 MGI:MGI:3714574|PMID:17537792 ECO:0000315 MGI:MGI:3715213  2007-08-08 MGI RO:0002296(EMAPA:17376) creation-date=2007-08-08|modification-date=2007-08-08|comment=anatomy ureteric bud ; EMAP:3844|comment=bud outgrowth into metanephric mesenchyme|contributor-id=https://orcid.org/0000-0001-7476-6306"
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource <http://model.geneontology.org/MGI_MGI_2148811/7d680ba7-77c1-4884-8c62-7c3705a41c9a> ;
+   owl:annotatedProperty <http://purl.obolibrary.org/obo/RO_0002418> ;
+   owl:annotatedTarget <http://model.geneontology.org/MGI_MGI_2148811/88def303-cf3a-4651-a972-65e669bf6343> ;
+   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_2148811/c3687aea-756a-4053-bb0c-8f34509741f5> ;
+   <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ;
+   <http://purl.org/dc/elements/1.1/date> "2007-08-08" ;
+   <http://purl.org/dc/terms/created> "2007-08-08" ;
+   <http://purl.org/dc/terms/dateAccepted> "2021-09-29" ;
+   <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+   rdfs:comment "MGI:MGI:2148811  RO:0002264 GO:0001657 MGI:MGI:3714574|PMID:17537792 ECO:0000315 MGI:MGI:3715213  2007-08-08 MGI RO:0002296(EMAPA:17376) creation-date=2007-08-08|modification-date=2007-08-08|comment=anatomy ureteric bud ; EMAP:3844|comment=bud outgrowth into metanephric mesenchyme|contributor-id=https://orcid.org/0000-0001-7476-6306"
+ ] .
+
+
+###  http://model.geneontology.org/MGI_MGI_2148811/7f27dc1e-63e1-4859-8cbc-61b0a579392f
+<http://model.geneontology.org/MGI_MGI_2148811/7f27dc1e-63e1-4859-8cbc-61b0a579392f> rdf:type owl:NamedIndividual ,
+                                                                                              <http://purl.obolibrary.org/obo/ECO_0000315> ;
+                                                                                     <http://geneontology.org/lego/evidence-with> "MGI:MGI:3715213" ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2007-08-08" ;
+                                                                                     <http://purl.org/dc/elements/1.1/source> "PMID:17537792" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+                                                                                     rdfs:comment "anatomy ureteric bud ; EMAP:3844" ,
+                                                                                                  "bud outgrowth into metanephric mesenchyme" .
+
+
+###  http://model.geneontology.org/MGI_MGI_2148811/84ebe592-6cff-4873-b7bc-7925e4d4660b
+<http://model.geneontology.org/MGI_MGI_2148811/84ebe592-6cff-4873-b7bc-7925e4d4660b> rdf:type owl:NamedIndividual ,
+                                                                                              <http://purl.obolibrary.org/obo/ECO_0000353> ;
+                                                                                     <http://geneontology.org/lego/evidence-with> "UniProtKB:Q8BPT3" ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ,
+                                                                                                                                   "https://orcid.org/0000-0003-2689-5511" ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2005-10-03" ;
+                                                                                     <http://purl.org/dc/elements/1.1/source> "PMID:11470831" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org" .
+
+
+###  http://model.geneontology.org/MGI_MGI_2148811/875cacd8-cb81-473e-812f-a337d1d2de30
+<http://model.geneontology.org/MGI_MGI_2148811/875cacd8-cb81-473e-812f-a337d1d2de30> rdf:type owl:NamedIndividual ,
+                                                                                              <http://purl.obolibrary.org/obo/EMAPA_17373> ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2007-08-08" ;
+                                                                                     <http://purl.org/dc/terms/created> "2007-08-08" ;
+                                                                                     <http://purl.org/dc/terms/dateAccepted> "2021-09-29" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org" .
+
+
+###  http://model.geneontology.org/MGI_MGI_2148811/88def303-cf3a-4651-a972-65e669bf6343
+<http://model.geneontology.org/MGI_MGI_2148811/88def303-cf3a-4651-a972-65e669bf6343> rdf:type owl:NamedIndividual ,
+                                                                                              <http://purl.obolibrary.org/obo/GO_0001657> ;
+                                                                                     <http://purl.obolibrary.org/obo/RO_0002296> <http://model.geneontology.org/MGI_MGI_2148811/2ccf9143-90b7-4b6d-bd06-a8aae021c732> ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2007-08-08" ;
+                                                                                     <http://purl.org/dc/terms/created> "2007-08-08" ;
+                                                                                     <http://purl.org/dc/terms/dateAccepted> "2021-09-29" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org" .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource <http://model.geneontology.org/MGI_MGI_2148811/88def303-cf3a-4651-a972-65e669bf6343> ;
+   owl:annotatedProperty <http://purl.obolibrary.org/obo/RO_0002296> ;
+   owl:annotatedTarget <http://model.geneontology.org/MGI_MGI_2148811/2ccf9143-90b7-4b6d-bd06-a8aae021c732> ;
+   <http://geneontology.org/lego/evidence> <http://model.geneontology.org/MGI_MGI_2148811/a2f8c100-f43e-4d22-a82e-c74b0506ecc9> ;
+   <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ;
+   <http://purl.org/dc/elements/1.1/date> "2007-08-08" ;
+   <http://purl.org/dc/terms/created> "2007-08-08" ;
+   <http://purl.org/dc/terms/dateAccepted> "2021-09-29" ;
+   <http://purl.org/pav/providedBy> "http://informatics.jax.org" ;
+   rdfs:comment "MGI:MGI:2148811  RO:0002264 GO:0001657 MGI:MGI:3714574|PMID:17537792 ECO:0000315 MGI:MGI:3715213  2007-08-08 MGI RO:0002296(EMAPA:17376) creation-date=2007-08-08|modification-date=2007-08-08|comment=anatomy ureteric bud ; EMAP:3844|comment=bud outgrowth into metanephric mesenchyme|contributor-id=https://orcid.org/0000-0001-7476-6306"
+ ] .
+
+
+###  http://model.geneontology.org/MGI_MGI_2148811/89ffe9af-5603-4134-837a-5c11f502d227
+<http://model.geneontology.org/MGI_MGI_2148811/89ffe9af-5603-4134-837a-5c11f502d227> rdf:type owl:NamedIndividual ,
+                                                                                              <http://identifiers.org/mgi/MGI:2148811> ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2007-08-08" ;
+                                                                                     <http://purl.org/dc/terms/created> "2007-08-08" ;
+                                                                                     <http://purl.org/dc/terms/dateAccepted> "2021-09-29" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org" .
+
+
+###  http://model.geneontology.org/MGI_MGI_2148811/9b02f1a2-f17c-48a6-b6ab-c0b8f50587cb
+<http://model.geneontology.org/MGI_MGI_2148811/9b02f1a2-f17c-48a6-b6ab-c0b8f50587cb> rdf:type owl:NamedIndividual ,
+                                                                                              <http://identifiers.org/mgi/MGI:2148811> ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ,
+                                                                                                                                   "https://orcid.org/0000-0003-2689-5511" ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2005-10-03" ;
+                                                                                     <http://purl.org/dc/terms/created> "2001-08-29" ;
+                                                                                     <http://purl.org/dc/terms/dateAccepted> "2021-09-29" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org" .
+
+
+###  http://model.geneontology.org/MGI_MGI_2148811/94f72196-0f29-46dd-93bf-e22882b03df1
+<http://model.geneontology.org/MGI_MGI_2148811/94f72196-0f29-46dd-93bf-e22882b03df1> rdf:type owl:NamedIndividual ,
+                                                                                              <http://purl.obolibrary.org/obo/ECO_0000314> ;
+                                                                                     <http://purl.org/dc/elements/1.1/contributor> "https://orcid.org/0000-0001-7476-6306" ;
+                                                                                     <http://purl.org/dc/elements/1.1/date> "2001-08-29" ;
+                                                                                     <http://purl.org/dc/elements/1.1/source> "PMID:11470831" ;
+                                                                                     <http://purl.org/pav/providedBy> "http://informatics.jax.org" .
+
+
+###  Generated by the OWL API (version 4.5.15) https://github.com/owlcs/owlapi

--- a/minerva-core/src/main/java/org/geneontology/minerva/BlazegraphOntologyManager.java
+++ b/minerva-core/src/main/java/org/geneontology/minerva/BlazegraphOntologyManager.java
@@ -8,6 +8,7 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -16,6 +17,8 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.zip.GZIPInputStream;
 
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.log4j.Logger;
 import org.openrdf.model.URI;
 import org.openrdf.model.Value;
@@ -65,6 +68,7 @@ public class BlazegraphOntologyManager {
 	public static String in_taxon_uri = "https://w3id.org/biolink/vocab/in_taxon";
 	public static OWLAnnotationProperty in_taxon;
 	private static final Set<String> root_types;
+	public final Map<IRI, Set<IRI>> regulatorsToRegulated;
 	public Map<String, Integer> class_depth;
 	static {
 		root_types =  new HashSet<String>();
@@ -108,6 +112,7 @@ public class BlazegraphOntologyManager {
 		class_depth.put("http://purl.obolibrary.org/obo/GO_0003674", 0);
 		class_depth.put("http://purl.obolibrary.org/obo/GO_0005575", 0);
 		class_depth.put("http://purl.obolibrary.org/obo/go/extensions/reacto.owl#molecular_event", 0);
+		regulatorsToRegulated = buildRegulationMap();
 	}
 
 	public BigdataSailRepository getGo_lego_repo() {
@@ -334,6 +339,36 @@ public class BlazegraphOntologyManager {
 			throw new IOException(e);
 		}
 		return depth;
+	}
+
+	private Map<IRI, Set<IRI>> buildRegulationMap() throws IOException {
+		String regulationTargetsQuery = IOUtils.toString(BlazegraphOntologyManager.class.getResourceAsStream("regulation_targets.rq"), StandardCharsets.UTF_8);
+		try {
+			BigdataSailRepositoryConnection connection = go_lego_repo.getReadOnlyConnection();
+			try {
+				TupleQuery tupleQuery = connection.prepareTupleQuery(QueryLanguage.SPARQL, regulationTargetsQuery);
+				TupleQueryResult result = tupleQuery.evaluate();
+				Map<IRI, Set<IRI>> regulators = new HashMap<>();
+				while (result.hasNext()) {
+					BindingSet binding = result.next();
+					IRI regulator = IRI.create(binding.getValue("subjectDown").stringValue());
+					IRI regulated = IRI.create(binding.getValue("fillerUp").stringValue());
+					if (!regulators.containsKey(regulator)) {
+						regulators.put(regulator, new HashSet<>());
+					}
+					regulators.get(regulator).add(regulated);
+				}
+				return regulators;
+			} catch (MalformedQueryException e) {
+				throw new IOException(e);
+			} catch (QueryEvaluationException e) {
+				throw new IOException(e);
+			} finally {
+				connection.close();
+			}
+		} catch (RepositoryException e) {
+			throw new IOException(e);
+		}
 	}
 
 	public Map<OWLNamedIndividual, Set<String>> getSuperCategoryMapForIndividuals(Set<OWLNamedIndividual> inds, OWLOntology ont, boolean fix_deprecated) throws IOException{

--- a/minerva-core/src/main/resources/org/geneontology/minerva/regulation_targets.rq
+++ b/minerva-core/src/main/resources/org/geneontology/minerva/regulation_targets.rq
@@ -1,0 +1,16 @@
+# This query generates a table of all "regulation" GO terms paired with the GO terms they regulate.
+# It precomputes the closure "down" for regulation terms and "up" for regulated terms.
+# The query assumes the ontology has been through `robot reason relax`.
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX regulates: <http://purl.obolibrary.org/obo/RO_0002211>
+SELECT DISTINCT ?subjectDown ?fillerUp
+WHERE {
+    ?regulates rdfs:subPropertyOf* regulates: .
+    ?exp owl:onProperty ?regulates .
+    ?exp owl:someValuesFrom ?filler .
+    ?filler rdfs:subClassOf* ?fillerUp .
+    ?subjectDown rdfs:subClassOf+ ?exp .
+    FILTER(isIRI(?fillerUp))
+    FILTER(isIRI(?subjectDown))
+}

--- a/minerva-server/src/main/java/org/geneontology/minerva/server/handler/OperationsImpl.java
+++ b/minerva-server/src/main/java/org/geneontology/minerva/server/handler/OperationsImpl.java
@@ -722,7 +722,7 @@ abstract class OperationsImpl extends ModelCreator {
 		if ("gpad".equals(format)) {
 			initMetaResponse(response);
 			try {
-				GPADSPARQLExport exporter = new GPADSPARQLExport(curieHandler, m3.getLegacyRelationShorthandIndex(), m3.getTboxShorthandIndex());
+				GPADSPARQLExport exporter = new GPADSPARQLExport(curieHandler, m3.getLegacyRelationShorthandIndex(), m3.getTboxShorthandIndex(), m3.getGolego_repo().regulatorsToRegulated);
 				WorkingMemory wm = m3.createCanonicalInferredModel(model.getModelId());
 				response.data.exportModel = exporter.exportGPAD(wm, model.getModelId());				
 		//		response.data.exportModel = new GPADSPARQLExport(curieHandler, m3.getLegacyRelationShorthandIndex(), m3.getTboxShorthandIndex(), m3.getDoNotAnnotateSubset()).exportGPAD(


### PR DESCRIPTION
Exclude annotations to a regulated term when there is also an annotation to a regulation of that term, for a particular gene product instance. See #394.