### PR TITLE
Add log4j xml config

### DIFF
--- a/minerva-cli/pom.xml
+++ b/minerva-cli/pom.xml
@@ -96,6 +96,10 @@
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-core</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-1.2-api</artifactId>
+		</dependency>
 	</dependencies>
 
 </project>

--- a/minerva-cli/src/main/resources/log4j.properties
+++ b/minerva-cli/src/main/resources/log4j.properties
@@ -1,6 +1,6 @@
 log4j.appender.console=org.apache.log4j.ConsoleAppender
 log4j.appender.console.layout=org.apache.log4j.PatternLayout
-log4j.appender.console.layout.ConversionPattern=%d %-5p (%c{1}:%L) %m\n
+log4j.appender.console.layout.ConversionPattern=%d %-5p (%c:%L) %m\n
 
 log4j.logger.org.semanticweb.elk = ERROR
 log4j.logger.org.obolibrary.obo2owl=OFF

--- a/minerva-cli/src/main/resources/log4j2.xml
+++ b/minerva-cli/src/main/resources/log4j2.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration>
+    <Appenders>
+        <Console name="STDOUT" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d %-5p (%c:%L) %m\n"/>
+        </Console>
+    </Appenders>
+    <Loggers>
+        <Logger name="org.apache.log4j.xml" level="info"/>
+        <Logger name="org.semanticweb.elk" level="error">
+            <AppenderRef ref="STDOUT"/>
+        </Logger>
+        <Logger name="org.obolibrary.obo2owl" level="off">
+            <AppenderRef ref="STDOUT"/>
+        </Logger>
+        <Logger name="org.semanticweb.owlapi" level="error">
+            <AppenderRef ref="STDOUT"/>
+        </Logger>
+        <Logger name="com.bigdata" level="warn">
+            <AppenderRef ref="STDOUT"/>
+        </Logger>
+        <Root level="info">
+            <AppenderRef ref="STDOUT"/>
+        </Root>
+    </Loggers>
+</Configuration>

--- a/minerva-server/pom.xml
+++ b/minerva-server/pom.xml
@@ -185,5 +185,9 @@
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-core</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-1.2-api</artifactId>
+		</dependency>
 	</dependencies>
 </project>

--- a/minerva-server/src/main/resources/log4j.properties
+++ b/minerva-server/src/main/resources/log4j.properties
@@ -1,6 +1,6 @@
 log4j.appender.console=org.apache.log4j.ConsoleAppender
 log4j.appender.console.layout=org.apache.log4j.PatternLayout
-log4j.appender.console.layout.ConversionPattern=%d %-5p (%c{1}:%L) %m\n
+log4j.appender.console.layout.ConversionPattern=%d %-5p (%c:%L) %m\n
 
 log4j.logger.org.semanticweb.elk = ERROR
 log4j.logger.org.obolibrary.obo2owl=OFF

--- a/minerva-server/src/main/resources/log4j2.xml
+++ b/minerva-server/src/main/resources/log4j2.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration>
+    <Appenders>
+        <Console name="STDOUT" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d %-5p (%c:%L) %m\n"/>
+        </Console>
+    </Appenders>
+    <Loggers>
+        <Logger name="org.apache.log4j.xml" level="info"/>
+        <Logger name="org.semanticweb.elk" level="error">
+            <AppenderRef ref="STDOUT"/>
+        </Logger>
+        <Logger name="org.obolibrary.obo2owl" level="off">
+            <AppenderRef ref="STDOUT"/>
+        </Logger>
+        <Logger name="org.semanticweb.owlapi" level="error">
+            <AppenderRef ref="STDOUT"/>
+        </Logger>
+        <Logger name="com.bigdata" level="warn">
+            <AppenderRef ref="STDOUT"/>
+        </Logger>
+        <Root level="info">
+            <AppenderRef ref="STDOUT"/>
+        </Root>
+    </Loggers>
+</Configuration>


### PR DESCRIPTION
I realized that log4j 2.x requires a different config file format. However part of Blazegraph seems to independently load the old properties format, so I have left that in place as well.