### PR TITLE
Remove 'involved in' from allowed extensions relations

### DIFF
--- a/minerva-converter/src/main/resources/org/geneontology/minerva/legacy/sparql/gpad-extensions.rq
+++ b/minerva-converter/src/main/resources/org/geneontology/minerva/legacy/sparql/gpad-extensions.rq
@@ -71,7 +71,6 @@ VALUES ?extension_rel {
 <http://purl.obolibrary.org/obo/RO_0002313>
 <http://purl.obolibrary.org/obo/RO_0002315>
 <http://purl.obolibrary.org/obo/RO_0002327>
-<http://purl.obolibrary.org/obo/RO_0002331>
 <http://purl.obolibrary.org/obo/RO_0002332>
 <http://purl.obolibrary.org/obo/RO_0002333>
 <http://purl.obolibrary.org/obo/RO_0002334>


### PR DESCRIPTION
@alexsign @vanaukenk removing [involved in](http://purl.obolibrary.org/obo/RO_0002331) from GPAD extensions output.