### PR TITLE
Replace CARO anatomical entity with Uberon.

### DIFF
--- a/minerva-core/src/main/java/org/geneontology/minerva/BlazegraphOntologyManager.java
+++ b/minerva-core/src/main/java/org/geneontology/minerva/BlazegraphOntologyManager.java
@@ -61,6 +61,7 @@ public class BlazegraphOntologyManager {
         root_types.add("http://purl.obolibrary.org/obo/UBERON_0001062"); //anatomical entity
         root_types.add("http://purl.obolibrary.org/obo/GO_0110165"); //cellular anatomical entity
         root_types.add("http://purl.obolibrary.org/obo/CARO_0000000"); // root root anatomical entity
+        root_types.add("http://purl.obolibrary.org/obo/UBERON_0001062"); // anatomical entity
         root_types.add("http://purl.obolibrary.org/obo/UBERON_0000105"); // life cycle stage
         root_types.add("http://purl.obolibrary.org/obo/PO_0009012"); // plant structure development stage
         root_types.add("http://purl.obolibrary.org/obo/GO_0044848"); // biological phase

--- a/minerva-core/src/test/java/org/geneontology/minerva/BlazegraphOntologyManagerTest.java
+++ b/minerva-core/src/test/java/org/geneontology/minerva/BlazegraphOntologyManagerTest.java
@@ -161,7 +161,7 @@ public class BlazegraphOntologyManagerTest {
         //GO native cell - used a lot in shex
         assertTrue("WBbt_0005753 not subclass of CL_0000003", supers.contains("http://purl.obolibrary.org/obo/CL_0000003"));
         //anatomy - also used a lot in shex
-        assertTrue("WBbt_0005753 not subclass of CARO_0000000", supers.contains("http://purl.obolibrary.org/obo/CARO_0000000"));
+        assertTrue("WBbt_0005753 not subclass of UBERON_0001062", supers.contains("http://purl.obolibrary.org/obo/UBERON_0001062"));
         //Cell component
         uri = "http://purl.obolibrary.org/obo/GO_0000776";
         supers = onto_repo.getAllSuperClasses(uri);
@@ -227,7 +227,7 @@ public class BlazegraphOntologyManagerTest {
         //GO native cell - used a lot in shex
         //assertTrue("WBbt_0005753 not subclass of CL_0000003", supers.contains("http://purl.obolibrary.org/obo/CL_0000003"));
         //anatomy - also used a lot in shex
-        assertTrue("WBbt_0005753 not subclass of CARO_0000000", supers.contains("http://purl.obolibrary.org/obo/CARO_0000000"));
+        assertTrue("WBbt_0005753 not subclass of UBERON_0001062", supers.contains("http://purl.obolibrary.org/obo/UBERON_0001062"));
         //Cell component
         supers = uri_roots.get(cc);
         assertTrue("GO_0000776 not subclass of GO_0110165 'cellular anatomical entity'", supers.contains("http://purl.obolibrary.org/obo/GO_0110165"));


### PR DESCRIPTION
Leaving the CARO root type for now. For https://github.com/geneontology/go-ontology/issues/25485.