### PR TITLE
Return root types for obsolete GO terms

### DIFF
--- a/minerva-core/src/main/java/org/geneontology/minerva/BlazegraphOntologyManager.java
+++ b/minerva-core/src/main/java/org/geneontology/minerva/BlazegraphOntologyManager.java
@@ -424,11 +424,25 @@ public class BlazegraphOntologyManager {
                 }
                 categories += "} . ";
                 String query = "PREFIX owl: <http://www.w3.org/2002/07/owl#> " +
-                        "PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> "
-                        + "PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#> " +
+                        "PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> " +
+                        "PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#> " +
+                        "PREFIX xsd: <http://www.w3.org/2001/XMLSchema#> " +
+                        "PREFIX oboInOwl: <http://www.geneontology.org/formats/oboInOwl#> " +
                         "SELECT ?sub ?super " +
-                        "WHERE { " + q + categories
-                        + "?sub rdfs:subClassOf* ?super . " +
+                        "WHERE { " + q + categories +
+                        " { ?sub rdfs:subClassOf* ?super . } " +
+                        " UNION " +
+                        " { ?sub owl:deprecated true . " +
+                        " ?sub oboInOwl:hasOBONamespace ?namespace . " +
+                        " VALUES (?namespace ?super) { " +
+                        " ( \"biological_process\" <http://purl.obolibrary.org/obo/GO_0008150> ) " +
+                        " ( \"molecular_function\" <http://purl.obolibrary.org/obo/GO_0003674> ) " +
+                        " ( \"cellular_component\" <http://purl.obolibrary.org/obo/GO_0005575> ) " +
+                        " ( \"biological_process\"^^xsd:string <http://purl.obolibrary.org/obo/GO_0008150> ) " +
+                        " ( \"molecular_function\"^^xsd:string <http://purl.obolibrary.org/obo/GO_0003674> ) " +
+                        " ( \"cellular_component\"^^xsd:string <http://purl.obolibrary.org/obo/GO_0005575> ) " +
+                        "  } " +
+                        " } " +
                         "} ";
                 TupleQuery tupleQuery = connection.prepareTupleQuery(QueryLanguage.SPARQL, query);
                 TupleQueryResult result = tupleQuery.evaluate();

--- a/minerva-core/src/test/java/org/geneontology/minerva/BlazegraphOntologyManagerTest.java
+++ b/minerva-core/src/test/java/org/geneontology/minerva/BlazegraphOntologyManagerTest.java
@@ -206,6 +206,9 @@ public class BlazegraphOntologyManagerTest {
         String cc = "http://purl.obolibrary.org/obo/GO_0000776";
         String bp = "http://purl.obolibrary.org/obo/GO_0022607";
         String mf = "http://purl.obolibrary.org/obo/GO_0060090";
+        String obsoleteCC = "http://purl.obolibrary.org/obo/GO_0005810";
+        String obsoleteBP = "http://purl.obolibrary.org/obo/GO_2000803";
+        String obsoleteMF = "http://purl.obolibrary.org/obo/GO_0008529";
         String human_protein = "http://identifiers.org/uniprot/Q13253";
         String zfin_protein = "http://identifiers.org/zfin/ZDB-GENE-010410-3";
         String worm_gene = "http://identifiers.org/wormbase/WBGene00000275";
@@ -214,6 +217,9 @@ public class BlazegraphOntologyManagerTest {
         uris.add(cc);
         uris.add(bp);
         uris.add(mf);
+        uris.add(obsoleteCC);
+        uris.add(obsoleteBP);
+        uris.add(obsoleteMF);
         uris.add(human_protein);
         uris.add(zfin_protein);
         uris.add(worm_gene);
@@ -239,6 +245,15 @@ public class BlazegraphOntologyManagerTest {
         //molecular function
         supers = uri_roots.get(mf);
         assertTrue("GO_0060090 not subclass of molecular function GO_0003674", supers.contains("http://purl.obolibrary.org/obo/GO_0003674"));
+        // Obsolete biological process
+        supers = uri_roots.get(obsoleteBP);
+        assertTrue("GO_2000803 should be in namespace biological_process", supers.contains("http://purl.obolibrary.org/obo/GO_0008150"));
+        // Obsolete molecular function
+        supers = uri_roots.get(obsoleteMF);
+        assertTrue("GO_0008529 should be in namespace molecular_function", supers.contains("http://purl.obolibrary.org/obo/GO_0003674"));
+        // Obsolete cellular component
+        supers = uri_roots.get(obsoleteCC);
+        assertTrue("GO_0005810 should be in namespace molecular_function", supers.contains("http://purl.obolibrary.org/obo/GO_0005575"));
         //Gene products
         //uniprot
         supers = uri_roots.get(human_protein);


### PR DESCRIPTION
Fixes #511. This currently only works for GO terms and not other ontologies.