### PR TITLE
Start SPARQL endpoint for ontology journal to be used in federated query for SPARQL updates

### DIFF
--- a/minerva-cli/src/main/java/org/geneontology/minerva/cli/CommandLineInterface.java
+++ b/minerva-cli/src/main/java/org/geneontology/minerva/cli/CommandLineInterface.java
@@ -38,16 +38,12 @@ import org.geneontology.minerva.validation.Violation;
 import org.geneontology.minerva.validation.pipeline.BatchPipelineValidationReport;
 import org.geneontology.minerva.validation.pipeline.ErrorMessage;
 import org.obolibrary.robot.CatalogXmlIRIMapper;
-import org.openrdf.model.Statement;
-import org.openrdf.model.ValueFactory;
-import org.openrdf.model.impl.URIImpl;
-import org.openrdf.model.vocabulary.OWL;
-import org.openrdf.model.vocabulary.RDF;
 import org.openrdf.query.MalformedQueryException;
 import org.openrdf.query.QueryLanguage;
 import org.openrdf.query.UpdateExecutionException;
 import org.openrdf.repository.RepositoryException;
-import org.openrdf.rio.*;
+import org.openrdf.rio.RDFHandlerException;
+import org.openrdf.rio.RDFParseException;
 import org.semanticweb.owlapi.apibinding.OWLManager;
 import org.semanticweb.owlapi.formats.TurtleDocumentFormat;
 import org.semanticweb.owlapi.io.IRIDocumentSource;
@@ -66,8 +62,6 @@ import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
 import java.util.*;
-
-import static org.geneontology.minerva.server.handler.OperationsTools.createModelRenderer;
 
 
 public class CommandLineInterface {
@@ -253,11 +247,13 @@ public class CommandLineInterface {
                 Options sparql_options = new Options();
                 sparql_options.addOption(sparql);
                 sparql_options.addOption("j", "journal", true, "Sets the Blazegraph journal file for the database");
+                sparql_options.addOption("ontojournal", "ontojournal", true, "Specify a blazegraph journal file containing the merged, pre-reasoned tbox aka go-lego.owl");
                 sparql_options.addOption("f", "file", true, "Sets the file containing a SPARQL update");
                 cmd = parser.parse(sparql_options, args, false);
                 String journalFilePath = cmd.getOptionValue("j"); //--journal
+                String ontojournalFilePath = cmd.getOptionValue("ontojournal"); //--journal
                 String file = cmd.getOptionValue("f");
-                sparqlUpdate(journalFilePath, file);
+                sparqlUpdate(journalFilePath, ontojournalFilePath, file);
             } else if (cmd.hasOption("replace-obsolete")) {
                 Options replaceOptions = new Options();
                 replaceOptions.addOption(replaceObsolete);
@@ -707,10 +703,15 @@ public class CommandLineInterface {
      * @throws MalformedQueryException
      * @throws UpdateExecutionException
      */
-    public static void sparqlUpdate(String journalFilePath, String updateFile) throws OWLOntologyCreationException, IOException, RepositoryException, MalformedQueryException, UpdateExecutionException {
+    public static void sparqlUpdate(String journalFilePath, String ontoJournalFilePath, String updateFile) throws Exception {
         // minimal inputs
         if (journalFilePath == null) {
             System.err.println("No journal file was configured.");
+            System.exit(-1);
+            return;
+        }
+        if (ontoJournalFilePath == null) {
+            System.err.println("No ontology journal file was configured.");
             System.exit(-1);
             return;
         }
@@ -720,11 +721,18 @@ public class CommandLineInterface {
             return;
         }
 
+        Properties ontoJournalProperties = new Properties();
+        ontoJournalProperties.load(CommandLineInterface.class.getResourceAsStream("/org/geneontology/minerva/blazegraph.properties"));
+        ontoJournalProperties.setProperty(com.bigdata.journal.Options.FILE, ontoJournalFilePath);
+        BigdataSail ontoSail = new BigdataSail(ontoJournalProperties);
+        BigdataSailRepository ontRepository = new BigdataSailRepository(ontoSail);
+        ontRepository.initialize();
+        EmbeddedSparqlEndpoint endpoint = new EmbeddedSparqlEndpoint(ontRepository, 6666);
+        endpoint.start();
         String update = FileUtils.readFileToString(new File(updateFile), StandardCharsets.UTF_8);
         Properties properties = new Properties();
         properties.load(CommandLineInterface.class.getResourceAsStream("/org/geneontology/minerva/blazegraph.properties"));
         properties.setProperty(com.bigdata.journal.Options.FILE, journalFilePath);
-
         BigdataSail sail = new BigdataSail(properties);
         BigdataSailRepository repository = new BigdataSailRepository(sail);
         repository.initialize();
@@ -736,6 +744,10 @@ public class CommandLineInterface {
         conn.removeChangeLog(counter);
         System.out.println("\nApplied " + changes + " changes");
         conn.close();
+        endpoint.stop();
+        ontRepository.shutDown();
+        repository.shutDown();
+        System.exit(0); // needed since adding federated query machinery
     }
 
     /**

--- a/minerva-cli/src/main/java/org/geneontology/minerva/cli/EmbeddedSparqlEndpoint.java
+++ b/minerva-cli/src/main/java/org/geneontology/minerva/cli/EmbeddedSparqlEndpoint.java
@@ -1,4 +1,109 @@
 package org.geneontology.minerva.cli;
 
+import com.bigdata.rdf.sail.BigdataSailRepository;
+import com.bigdata.rdf.sail.BigdataSailRepositoryConnection;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.servlet.ServletContextHandler;
+import org.eclipse.jetty.servlet.ServletHolder;
+import org.openrdf.query.MalformedQueryException;
+import org.openrdf.query.QueryLanguage;
+import org.openrdf.query.TupleQuery;
+import org.openrdf.query.resultio.sparqlxml.SPARQLResultsXMLWriter;
+
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
 public class EmbeddedSparqlEndpoint {
+
+    private final Server server;
+
+    public EmbeddedSparqlEndpoint(BigdataSailRepository repository, int port) {
+        // Create server with no arguments
+        this.server = new Server();
+
+        // Create and add connector explicitly
+        ServerConnector connector = new ServerConnector(server);
+        connector.setPort(port);
+        server.addConnector(connector);
+
+        // Use ServletContextHandler, NOT WebAppContext
+        ServletContextHandler context = new ServletContextHandler();
+        context.setContextPath("/");
+
+        // Register our servlet
+        ServletHolder holder = new ServletHolder("sparql", new SparqlServlet(repository));
+        context.addServlet(holder, "/sparql/*");
+
+        server.setHandler(context);
+    }
+
+    public void start() throws Exception {
+        server.start();
+        System.out.println("SPARQL endpoint started at http://localhost:" +
+                ((ServerConnector) server.getConnectors()[0]).getLocalPort() + "/sparql");
+    }
+
+    public void stop() throws Exception {
+        server.stop();
+    }
+
+    public void join() throws InterruptedException {
+        server.join();
+    }
+
+    public static class SparqlServlet extends HttpServlet {
+
+        private final BigdataSailRepository repository;
+
+        public SparqlServlet(BigdataSailRepository repository) {
+            this.repository = repository;
+        }
+
+        @Override
+        protected void doGet(HttpServletRequest req, HttpServletResponse resp)
+                throws IOException {
+            handleQuery(req, resp);
+        }
+
+        @Override
+        protected void doPost(HttpServletRequest req, HttpServletResponse resp)
+                throws IOException {
+            handleQuery(req, resp);
+        }
+
+        private void handleQuery(HttpServletRequest req, HttpServletResponse resp)
+                throws IOException {
+
+            String query = req.getParameter("query");
+            if (query == null || query.trim().isEmpty()) {
+                resp.sendError(HttpServletResponse.SC_BAD_REQUEST, "Missing 'query' parameter");
+                return;
+            }
+
+            BigdataSailRepositoryConnection conn = null;
+            try {
+                conn = repository.getConnection();
+                TupleQuery tupleQuery = conn.prepareTupleQuery(QueryLanguage.SPARQL, query);
+
+                resp.setContentType("application/sparql-results+xml");
+                SPARQLResultsXMLWriter writer = new SPARQLResultsXMLWriter(resp.getOutputStream());
+                tupleQuery.evaluate(writer);
+
+            } catch (MalformedQueryException e) {
+                resp.sendError(HttpServletResponse.SC_BAD_REQUEST, "Malformed query: " + e.getMessage());
+            } catch (Exception e) {
+                resp.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, e.getMessage());
+            } finally {
+                if (conn != null) {
+                    try {
+                        conn.close();
+                    } catch (Exception ignored) {
+                    }
+                }
+            }
+        }
+    }
 }

--- a/minerva-cli/src/main/java/org/geneontology/minerva/cli/EmbeddedSparqlEndpoint.java
+++ b/minerva-cli/src/main/java/org/geneontology/minerva/cli/EmbeddedSparqlEndpoint.java
@@ -1,0 +1,4 @@
+package org.geneontology.minerva.cli;
+
+public class EmbeddedSparqlEndpoint {
+}


### PR DESCRIPTION
Adds a servlet that runs on a background thread so that the main update query can access ontology information if needed. Required addition of ontojournal argument for SPARQL update command.

For issues like #580.