### PR TITLE
Reject add-edge requests when edge already exists

### DIFF
--- a/minerva-server/src/main/java/org/geneontology/minerva/server/handler/OperationsImpl.java
+++ b/minerva-server/src/main/java/org/geneontology/minerva/server/handler/OperationsImpl.java
@@ -335,6 +335,17 @@ abstract class OperationsImpl extends ModelCreator {
 
         // add edge
         if (Operation.add == operation) {
+            // Reject if an edge with the same subject, property, and object already exists.
+            // Use addAnnotation to modify annotations on an existing edge.
+            OWLOntology ont = values.model.getAboxOntology();
+            for (OWLObjectPropertyAssertionAxiom existing : ont.getObjectPropertyAssertionAxioms(s)) {
+                if (p.equals(existing.getProperty()) && o.equals(existing.getObject())) {
+                    return "An edge already exists between " + s.getIRI().getShortForm()
+                        + " and " + o.getIRI().getShortForm()
+                        + " with property " + p.getIRI().getShortForm()
+                        + ". Use addAnnotation to add evidence to an existing edge.";
+                }
+            }
             // optional: values
             Set<OWLAnnotation> annotations = extract(request.arguments.values, userId, providerGroups, values, values.model);
             addDateAnnotation(annotations, values.model.getOWLDataFactory());

--- a/minerva-server/src/test/java/org/geneontology/minerva/server/handler/BatchModelHandlerTest.java
+++ b/minerva-server/src/test/java/org/geneontology/minerva/server/handler/BatchModelHandlerTest.java
@@ -2191,6 +2191,51 @@ public class BatchModelHandlerTest {
         return response;
     }
 
+    @Test
+    public void testAddDuplicateEdgeRejected() throws Exception {
+        final String modelId = generateBlankModel();
+
+        // Create two individuals and an edge between them
+        final List<M3Request> batch1 = new ArrayList<M3Request>();
+        M3Request r = BatchTestTools.addIndividual(modelId, "GO:0003674");
+        r.arguments.assignToVariable = "mf";
+        batch1.add(r);
+
+        r = BatchTestTools.addIndividual(modelId, "GO:0008150");
+        r.arguments.assignToVariable = "bp";
+        batch1.add(r);
+
+        r = BatchTestTools.addEdge(modelId, "mf", "BFO:0000050", "bp");
+        batch1.add(r);
+
+        final M3BatchResponse response1 = executeBatch(batch1, false);
+        JsonOwlIndividual[] iObjs = BatchTestTools.responseIndividuals(response1);
+        assertEquals(2, iObjs.length);
+
+        // Find the created individual IDs
+        String mf = null;
+        String bp = null;
+        for (JsonOwlIndividual iObj : iObjs) {
+            String typeId = iObj.type[0].id;
+            if ("GO:0003674".equals(typeId)) {
+                mf = iObj.id;
+            } else if ("GO:0008150".equals(typeId)) {
+                bp = iObj.id;
+            }
+        }
+        assertNotNull(mf);
+        assertNotNull(bp);
+
+        // Try to add the same edge again — should be rejected
+        final List<M3Request> batch2 = new ArrayList<M3Request>();
+        r = BatchTestTools.addEdge(modelId, mf, "BFO:0000050", bp);
+        batch2.add(r);
+
+        M3BatchResponse response2 = handler.m3Batch(uid, providedBy, intention, packetId, batch2.toArray(new M3Request[batch2.size()]), false, true);
+        assertEquals(M3BatchResponse.MESSAGE_TYPE_ERROR, response2.messageType);
+        assertTrue(response2.message.contains("already exists"));
+    }
+
     /**
      * @return modelId
      */


### PR DESCRIPTION
Instead of silently creating a duplicate reified axiom, return an error when the client attempts to add an edge with a subject, property, and object that already exist in the model. The error message directs users to use addAnnotation for modifying evidence on existing edges.

Fixes #587.