### PR TITLE
Write model files deterministically

### DIFF
--- a/minerva-core/src/main/java/org/geneontology/minerva/BlazegraphMolecularModelManager.java
+++ b/minerva-core/src/main/java/org/geneontology/minerva/BlazegraphMolecularModelManager.java
@@ -835,9 +835,10 @@ public class BlazegraphMolecularModelManager<METADATA> extends CoreMolecularMode
                     // consistent set of prefixes (see DeterministicTurtleRenderer).
                     StatementCollector collector = new StatementCollector();
                     connection.export(collector, new URIImpl(modelId.toString()));
-                    DeterministicTurtleRenderer.render(collector.getStatements(), modelId.toString(), out);
-                    // copy temp file to the finalFile
-                    FileUtils.copyFile(tempFile, targetFile);
+DeterministicTurtleRenderer.render(collector.getStatements(), modelId.toString(), out);
+out.flush();
+// copy temp file to the finalFile
+FileUtils.copyFile(tempFile, targetFile);
                 } finally {
                     out.close();
                     connection.close();

--- a/minerva-core/src/main/java/org/geneontology/minerva/BlazegraphMolecularModelManager.java
+++ b/minerva-core/src/main/java/org/geneontology/minerva/BlazegraphMolecularModelManager.java
@@ -12,6 +12,7 @@ import org.geneontology.minerva.MolecularModelManager.UnknownIdentifierException
 import org.geneontology.minerva.curie.CurieHandler;
 import org.geneontology.minerva.util.AnnotationShorthand;
 import org.geneontology.minerva.util.BlazegraphMutationCounter;
+import org.geneontology.minerva.util.DeterministicTurtleRenderer;
 import org.geneontology.minerva.util.ReverseChangeGenerator;
 import org.openrdf.model.*;
 import org.openrdf.model.impl.URIImpl;
@@ -829,15 +830,12 @@ public class BlazegraphMolecularModelManager<METADATA> extends CoreMolecularMode
                 BigdataSailRepositoryConnection connection = repo.getReadOnlyConnection();
                 OutputStream out = new FileOutputStream(tempFile);
                 try {
-                    // Workaround for order dependence of RDF reading by OWL API
-                    // Need to output ontology triple first until this bug is fixed:
-                    // https://github.com/owlcs/owlapi/issues/574
-                    ValueFactory factory = connection.getValueFactory();
-                    Statement ontologyDeclaration = factory.createStatement(factory.createURI(modelId.toString()), RDF.TYPE, OWL.ONTOLOGY);
-                    Rio.write(Collections.singleton(ontologyDeclaration), out, RDFFormat.TURTLE);
-                    // end workaround
-                    RDFWriter writer = Rio.createWriter(RDFFormat.TURTLE, out);
-                    connection.export(writer, new URIImpl(modelId.toString()));
+                    // Render the model deterministically so that the same RDF always
+                    // produces byte-identical Turtle, with anonymous blank nodes and a
+                    // consistent set of prefixes (see DeterministicTurtleRenderer).
+                    StatementCollector collector = new StatementCollector();
+                    connection.export(collector, new URIImpl(modelId.toString()));
+                    DeterministicTurtleRenderer.render(collector.getStatements(), modelId.toString(), out);
                     // copy temp file to the finalFile
                     FileUtils.copyFile(tempFile, targetFile);
                 } finally {

--- a/minerva-core/src/main/java/org/geneontology/minerva/BlazegraphMolecularModelManager.java
+++ b/minerva-core/src/main/java/org/geneontology/minerva/BlazegraphMolecularModelManager.java
@@ -835,10 +835,10 @@ public class BlazegraphMolecularModelManager<METADATA> extends CoreMolecularMode
                     // consistent set of prefixes (see DeterministicTurtleRenderer).
                     StatementCollector collector = new StatementCollector();
                     connection.export(collector, new URIImpl(modelId.toString()));
-DeterministicTurtleRenderer.render(collector.getStatements(), modelId.toString(), out);
-out.flush();
-// copy temp file to the finalFile
-FileUtils.copyFile(tempFile, targetFile);
+                    DeterministicTurtleRenderer.render(collector.getStatements(), modelId.toString(), out);
+                    out.flush();
+                    // copy temp file to the finalFile
+                    FileUtils.copyFile(tempFile, targetFile);
                 } finally {
                     out.close();
                     connection.close();

--- a/minerva-core/src/main/java/org/geneontology/minerva/util/DeterministicTurtleRenderer.java
+++ b/minerva-core/src/main/java/org/geneontology/minerva/util/DeterministicTurtleRenderer.java
@@ -1,0 +1,284 @@
+package org.geneontology.minerva.util;
+
+import org.apache.jena.datatypes.RDFDatatype;
+import org.apache.jena.datatypes.TypeMapper;
+import org.apache.jena.rdf.model.AnonId;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.rdf.model.Property;
+import org.apache.jena.rdf.model.RDFNode;
+import org.apache.jena.riot.RDFDataMgr;
+import org.apache.jena.riot.RDFFormat;
+import org.openrdf.model.BNode;
+import org.openrdf.model.Literal;
+import org.openrdf.model.Resource;
+import org.openrdf.model.Statement;
+import org.openrdf.model.URI;
+import org.openrdf.model.Value;
+
+import java.io.OutputStream;
+import java.io.UnsupportedEncodingException;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Renders a set of RDF statements (as read from Blazegraph via the Sesame/OpenRDF
+ * API) to Turtle in a deterministic way, so that the same RDF graph always produces
+ * byte-identical output regardless of the machine or the order in which the
+ * triples were returned by the triplestore.
+ * <p>
+ * Determinism is achieved by:
+ * <ul>
+ * <li>using a fixed set of namespace prefixes;</li>
+ * <li>assigning every blank node a content-derived identifier instead of the
+ * volatile identifier handed out by the triplestore. This both fixes the iteration
+ * order of Jena's pretty Turtle writer and keeps any identifiers that must be
+ * written (for blank nodes referenced more than once) stable across runs;</li>
+ * <li>delegating the actual serialization to Jena's {@code TURTLE_PRETTY} writer,
+ * which renders blank nodes anonymously ({@code [ ... ]}) wherever possible and
+ * sorts predicates within each subject.</li>
+ * </ul>
+ * For {@code owl:Axiom} reification nodes the identifier (and therefore the output
+ * position) is derived only from the triple the axiom is about
+ * ({@code owl:annotatedSource}/{@code annotatedProperty}/{@code annotatedTarget}),
+ * so that editing an axiom's annotations (evidence, dates, comments, ...) changes
+ * only the affected lines without moving the whole block.
+ */
+public class DeterministicTurtleRenderer {
+
+    private static final String OWL_NS = "http://www.w3.org/2002/07/owl#";
+    private static final String RDF_TYPE = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type";
+    private static final String OWL_AXIOM = OWL_NS + "Axiom";
+    private static final String ANNOTATED_SOURCE = OWL_NS + "annotatedSource";
+    private static final String ANNOTATED_PROPERTY = OWL_NS + "annotatedProperty";
+    private static final String ANNOTATED_TARGET = OWL_NS + "annotatedTarget";
+
+    // Separators for content keys, chosen so they cannot occur in IRIs or labels.
+    private static final String SEP = "\u0001";
+    private static final String PART_SEP = "\u0002";
+
+    private static final Map<String, String> PREFIXES = buildPrefixes();
+
+    private static Map<String, String> buildPrefixes() {
+        Map<String, String> p = new LinkedHashMap<>();
+        p.put("rdf", "http://www.w3.org/1999/02/22-rdf-syntax-ns#");
+        p.put("rdfs", "http://www.w3.org/2000/01/rdf-schema#");
+        p.put("owl", "http://www.w3.org/2002/07/owl#");
+        p.put("xsd", "http://www.w3.org/2001/XMLSchema#");
+        p.put("dc", "http://purl.org/dc/elements/1.1/");
+        p.put("dcterms", "http://purl.org/dc/terms/");
+        p.put("obo", "http://purl.obolibrary.org/obo/");
+        p.put("oboInOwl", "http://www.geneontology.org/formats/oboInOwl#");
+        p.put("lego", "http://geneontology.org/lego/");
+        p.put("layout", "http://geneontology.org/lego/hint/layout/");
+        p.put("pav", "http://purl.org/pav/");
+        p.put("skos", "http://www.w3.org/2004/02/skos/core#");
+        p.put("biolink", "https://w3id.org/biolink/vocab/");
+        p.put("gomodel", "http://model.geneontology.org/");
+        return Collections.unmodifiableMap(p);
+    }
+
+    /**
+     * Write the given statements to {@code out} as deterministic Turtle. The
+     * {@code modelId} is the model/ontology IRI; the model's own entities (which live
+     * under {@code modelId + "/"}) are abbreviated with the empty {@code :} prefix.
+     * The stream is not closed by this method.
+     */
+    public static void render(Collection<Statement> statements, String modelId, OutputStream out) {
+        DeterministicTurtleRenderer renderer = new DeterministicTurtleRenderer(statements, modelId);
+        renderer.write(out);
+    }
+
+    // outgoing statements grouped by subject, used to describe blank nodes
+    private final Map<Resource, List<Statement>> outgoing = new HashMap<>();
+    private final Collection<Statement> statements;
+    private final String modelBaseIri;
+    private final Map<BNode, String> keyCache = new HashMap<>();
+    private final Set<BNode> keyInProgress = new HashSet<>();
+    private final Map<BNode, String> bnodeLabels = new HashMap<>();
+
+    private DeterministicTurtleRenderer(Collection<Statement> statements, String modelId) {
+        this.statements = statements;
+        this.modelBaseIri = (modelId == null) ? null : modelId + "/";
+        for (Statement s : statements) {
+            outgoing.computeIfAbsent(s.getSubject(), k -> new ArrayList<>()).add(s);
+        }
+        assignBlankNodeLabels();
+    }
+
+    private void write(OutputStream out) {
+        Model model = ModelFactory.createDefaultModel();
+        // Insert statements in canonical order. Combined with the content-derived
+        // blank node ids this makes Jena's output byte-stable across runs.
+        List<Statement> sorted = new ArrayList<>(statements);
+        sorted.sort(Comparator
+                .comparing((Statement s) -> key(s.getSubject()))
+                .thenComparing(s -> key(s.getPredicate()))
+                .thenComparing(s -> key(s.getObject())));
+        for (Statement s : sorted) {
+            org.apache.jena.rdf.model.Resource subj = toJenaResource(model, s.getSubject());
+            Property pred = model.createProperty(s.getPredicate().stringValue());
+            RDFNode obj = toJenaNode(model, s.getObject());
+            model.add(subj, pred, obj);
+        }
+        for (Map.Entry<String, String> e : PREFIXES.entrySet()) {
+            model.setNsPrefix(e.getKey(), e.getValue());
+        }
+        if (modelBaseIri != null) {
+            model.setNsPrefix("", modelBaseIri);
+        }
+        RDFDataMgr.write(out, model, RDFFormat.TURTLE_PRETTY);
+    }
+
+    private org.apache.jena.rdf.model.Resource toJenaResource(Model model, Resource res) {
+        if (res instanceof BNode) {
+            return model.createResource(new AnonId(bnodeLabels.get(res)));
+        }
+        return model.createResource(res.stringValue());
+    }
+
+    private RDFNode toJenaNode(Model model, Value value) {
+        if (value instanceof Resource) {
+            return toJenaResource(model, (Resource) value);
+        }
+        Literal lit = (Literal) value;
+        if (lit.getLanguage() != null) {
+            return model.createLiteral(lit.getLabel(), lit.getLanguage());
+        }
+        if (lit.getDatatype() != null) {
+            RDFDatatype dt = TypeMapper.getInstance().getSafeTypeByName(lit.getDatatype().stringValue());
+            return model.createTypedLiteral(lit.getLabel(), dt);
+        }
+        return model.createLiteral(lit.getLabel());
+    }
+
+    /**
+     * Assign a stable, content-derived identifier to every blank node. The
+     * identifier is hashed from the node's {@link #positioningKey}; nodes that hash
+     * to the same value are disambiguated, in order of their full description, with
+     * a counter so that distinct nodes remain distinct.
+     */
+    private void assignBlankNodeLabels() {
+        Set<BNode> bnodes = new HashSet<>();
+        for (Statement s : statements) {
+            if (s.getSubject() instanceof BNode) {
+                bnodes.add((BNode) s.getSubject());
+            }
+            if (s.getObject() instanceof BNode) {
+                bnodes.add((BNode) s.getObject());
+            }
+        }
+        List<BNode> sorted = new ArrayList<>(bnodes);
+        sorted.sort(Comparator.comparing(this::positioningKey).thenComparing(this::key));
+        String previousKey = null;
+        int tie = 0;
+        for (BNode b : sorted) {
+            String pk = positioningKey(b);
+            if (pk.equals(previousKey)) {
+                tie++;
+            } else {
+                tie = 0;
+                previousKey = pk;
+            }
+            bnodeLabels.put(b, sha1(pk) + "-" + tie);
+        }
+    }
+
+    /**
+     * The key that determines a blank node's identifier, and therefore its position
+     * in the output. For {@code owl:Axiom} reification nodes this is derived only
+     * from the triple the axiom is about, so that editing the axiom's annotations
+     * does not move the block. For all other blank nodes the full description (see
+     * {@link #key}) is used.
+     */
+    private String positioningKey(BNode bnode) {
+        List<Statement> out = outgoing.get(bnode);
+        if (out != null && isAxiom(out)) {
+            List<String> parts = new ArrayList<>();
+            for (Statement s : out) {
+                String p = s.getPredicate().stringValue();
+                if (p.equals(ANNOTATED_SOURCE) || p.equals(ANNOTATED_PROPERTY) || p.equals(ANNOTATED_TARGET)) {
+                    parts.add(p + SEP + key(s.getObject()));
+                }
+            }
+            Collections.sort(parts);
+            return "axiom[" + String.join(PART_SEP, parts) + "]";
+        }
+        return key(bnode);
+    }
+
+    private static boolean isAxiom(List<Statement> out) {
+        for (Statement s : out) {
+            if (s.getPredicate().stringValue().equals(RDF_TYPE)
+                    && (s.getObject() instanceof URI)
+                    && s.getObject().stringValue().equals(OWL_AXIOM)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * A content-based key for a value. For blank nodes this is built recursively
+     * from the (predicate, object) pairs that describe the node, so it does not
+     * depend on the blank node's triplestore-assigned identifier.
+     */
+    private String key(Value value) {
+        if (value instanceof URI) {
+            return "u" + SEP + value.stringValue();
+        }
+        if (value instanceof Literal) {
+            Literal lit = (Literal) value;
+            return "l" + SEP + lit.getLabel()
+                    + SEP + (lit.getDatatype() == null ? "" : lit.getDatatype().stringValue())
+                    + SEP + (lit.getLanguage() == null ? "" : lit.getLanguage());
+        }
+        BNode bnode = (BNode) value;
+        String cached = keyCache.get(bnode);
+        if (cached != null) {
+            return cached;
+        }
+        if (!keyInProgress.add(bnode)) {
+            // Cycle among blank nodes (not expected in GO-CAM data); break it.
+            return "b" + SEP + "<cycle>";
+        }
+        List<String> parts = new ArrayList<>();
+        List<Statement> out = outgoing.get(bnode);
+        if (out != null) {
+            for (Statement s : out) {
+                parts.add(key(s.getPredicate()) + SEP + key(s.getObject()));
+            }
+        }
+        Collections.sort(parts);
+        String result = "b[" + String.join(PART_SEP, parts) + "]";
+        keyInProgress.remove(bnode);
+        keyCache.put(bnode, result);
+        return result;
+    }
+
+    private static String sha1(String s) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-1");
+            byte[] hash = digest.digest(s.getBytes("UTF-8"));
+            StringBuilder sb = new StringBuilder(hash.length * 2);
+            for (byte b : hash) {
+                sb.append(Character.forDigit((b >> 4) & 0xF, 16));
+                sb.append(Character.forDigit(b & 0xF, 16));
+            }
+            return sb.toString();
+        } catch (NoSuchAlgorithmException | UnsupportedEncodingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+}

--- a/minerva-core/src/test/java/org/geneontology/minerva/util/DeterministicTurtleRendererTest.java
+++ b/minerva-core/src/test/java/org/geneontology/minerva/util/DeterministicTurtleRendererTest.java
@@ -1,0 +1,137 @@
+package org.geneontology.minerva.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+import org.openrdf.model.Statement;
+import org.openrdf.model.ValueFactory;
+import org.openrdf.model.impl.ValueFactoryImpl;
+import org.openrdf.model.vocabulary.OWL;
+import org.openrdf.model.vocabulary.RDF;
+
+import java.io.ByteArrayOutputStream;
+import java.io.UnsupportedEncodingException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
+
+public class DeterministicTurtleRendererTest {
+
+    private static final String MODEL = "http://model.geneontology.org/0001";
+    private static final String OBO = "http://purl.obolibrary.org/obo/";
+    private static final String LEGO = "http://geneontology.org/lego/";
+    private static final String OWL_NS = "http://www.w3.org/2002/07/owl#";
+    private static final String DATE = "http://purl.org/dc/elements/1.1/date";
+
+    /**
+     * Build a logical graph. The blank node identifiers, the statement order and the
+     * date annotation on the first axiom are all parameterized so the tests can vary
+     * them independently. The two axioms describe different triples (distinct
+     * skeletons) so that each gets a stable, independent position.
+     */
+    private List<Statement> buildGraph(String bnodeNamespace, long shuffleSeed, String firstAxiomDate) {
+        ValueFactory f = new ValueFactoryImpl();
+        List<Statement> s = new ArrayList<>();
+
+        // ontology declaration
+        s.add(f.createStatement(f.createURI(MODEL), RDF.TYPE, OWL.ONTOLOGY));
+
+        // named individuals with types
+        s.add(f.createStatement(f.createURI(MODEL + "/i1"), RDF.TYPE, f.createURI(OBO + "GO_0003674")));
+        s.add(f.createStatement(f.createURI(MODEL + "/i2"), RDF.TYPE, f.createURI(OBO + "GO_0008150")));
+        s.add(f.createStatement(f.createURI(MODEL + "/i3"), RDF.TYPE, f.createURI(OBO + "GO_0005575")));
+        s.add(f.createStatement(f.createURI(MODEL + "/i1"), f.createURI(OBO + "RO_0002333"), f.createURI(MODEL + "/i2")));
+        s.add(f.createStatement(f.createURI(MODEL + "/i1"), f.createURI(OBO + "RO_0002333"), f.createURI(MODEL + "/i3")));
+
+        // two owl:Axiom reification nodes (subject-only blank nodes), each about a
+        // different triple
+        for (int i = 1; i <= 2; i++) {
+            String target = MODEL + "/i" + (i + 1);
+            String date = (i == 1 && firstAxiomDate != null) ? firstAxiomDate : "2026-0" + i + "-01";
+            org.openrdf.model.BNode ax = f.createBNode(bnodeNamespace + "ax" + i);
+            s.add(f.createStatement(ax, RDF.TYPE, f.createURI(OWL_NS + "Axiom")));
+            s.add(f.createStatement(ax, f.createURI(OWL_NS + "annotatedSource"), f.createURI(MODEL + "/i1")));
+            s.add(f.createStatement(ax, f.createURI(OWL_NS + "annotatedProperty"), f.createURI(OBO + "RO_0002333")));
+            s.add(f.createStatement(ax, f.createURI(OWL_NS + "annotatedTarget"), f.createURI(target)));
+            s.add(f.createStatement(ax, f.createURI(LEGO + "evidence"), f.createURI(MODEL + "/ev" + i)));
+            s.add(f.createStatement(ax, f.createURI(DATE), f.createLiteral(date)));
+        }
+
+        // a blank node referenced more than once (must keep a stable id)
+        org.openrdf.model.BNode shared = f.createBNode(bnodeNamespace + "shared");
+        s.add(f.createStatement(shared, RDF.TYPE, f.createURI(OWL_NS + "Class")));
+        s.add(f.createStatement(f.createURI(MODEL + "/i1"), f.createURI("http://www.w3.org/2000/01/rdf-schema#subClassOf"), shared));
+        s.add(f.createStatement(f.createURI(MODEL + "/i2"), f.createURI("http://www.w3.org/2000/01/rdf-schema#subClassOf"), shared));
+
+        Collections.shuffle(s, new Random(shuffleSeed));
+        return s;
+    }
+
+    private String render(List<Statement> statements) throws UnsupportedEncodingException {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        DeterministicTurtleRenderer.render(statements, MODEL, out);
+        return new String(out.toByteArray(), "UTF-8");
+    }
+
+    private static String stripDateLines(String ttl) {
+        StringBuilder sb = new StringBuilder();
+        for (String line : ttl.split("\n", -1)) {
+            if (!line.contains("dc:date")) {
+                sb.append(line).append('\n');
+            }
+        }
+        return sb.toString();
+    }
+
+    @Test
+    public void rendersIdenticalOutputRegardlessOfBlankNodeIdsAndOrder() throws Exception {
+        String a = render(buildGraph("aaa", 1, null));
+        String b = render(buildGraph("zzz", 99, null));
+        assertEquals("Rendered Turtle must be byte-identical for the same RDF graph", a, b);
+    }
+
+    @Test
+    public void doesNotLeakTriplestoreBlankNodeIds() throws Exception {
+        String ttl = render(buildGraph("tttt", 7, null));
+        // The triplestore-assigned identifiers must not appear in the output.
+        assertFalse(ttl.contains("tttt"));
+        // Subject-only axiom nodes are rendered anonymously, so the only blank node
+        // labels that may appear belong to the shared node (referenced twice).
+        assertTrue("axiom nodes should be rendered as anonymous blank nodes", ttl.contains("owl:Axiom"));
+    }
+
+    @Test
+    public void usesConfiguredPrefixes() throws Exception {
+        String ttl = render(buildGraph("p", 3, null));
+        assertTrue(ttl.contains("@prefix gomodel:"));
+        assertTrue(ttl.contains("@prefix obo:"));
+        assertTrue(ttl.contains("@prefix owl:"));
+        assertTrue(ttl.contains("@prefix oboInOwl:"));
+        assertTrue(ttl.contains("@prefix layout:"));
+        // gomodel: abbreviates the model IRI itself; the empty ':' prefix abbreviates
+        // the model's own entities (which live under modelIRI + "/")
+        assertTrue(ttl.contains("gomodel:0001"));
+        assertTrue(ttl.contains("@prefix :"));
+        assertTrue(ttl.contains(":i1"));
+    }
+
+    /**
+     * Editing an axiom's annotation (here, its date) should change only the affected
+     * line and must not move the axiom's block: its position is derived from the
+     * triple it annotates, not from its annotations. Stripping the date lines from
+     * both renderings should therefore leave identical text.
+     */
+    @Test
+    public void editingAxiomAnnotationKeepsBlockInPlace() throws Exception {
+        String base = render(buildGraph("n", 4, null));
+        String edited = render(buildGraph("n", 4, "2099-12-31"));
+        assertNotEquals(base, edited);
+        assertTrue(edited.contains("2099-12-31"));
+        assertEquals("changing an axiom annotation must not reorder the output",
+                stripDateLines(base), stripDateLines(edited));
+    }
+}

--- a/minerva-core/src/test/java/org/geneontology/minerva/util/DeterministicTurtleRendererTest.java
+++ b/minerva-core/src/test/java/org/geneontology/minerva/util/DeterministicTurtleRendererTest.java
@@ -5,19 +5,35 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
+import org.apache.jena.datatypes.TypeMapper;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.rdf.model.Property;
+import org.apache.jena.rdf.model.RDFNode;
+import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.riot.Lang;
+import org.apache.jena.riot.RDFDataMgr;
 import org.junit.Test;
+import org.openrdf.model.BNode;
+import org.openrdf.model.Literal;
 import org.openrdf.model.Statement;
+import org.openrdf.model.URI;
+import org.openrdf.model.Value;
 import org.openrdf.model.ValueFactory;
 import org.openrdf.model.impl.ValueFactoryImpl;
 import org.openrdf.model.vocabulary.OWL;
 import org.openrdf.model.vocabulary.RDF;
 
+import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Random;
+import java.util.regex.Pattern;
 
 public class DeterministicTurtleRendererTest {
 
@@ -99,9 +115,12 @@ public class DeterministicTurtleRendererTest {
         String ttl = render(buildGraph("tttt", 7, null));
         // The triplestore-assigned identifiers must not appear in the output.
         assertFalse(ttl.contains("tttt"));
-        // Subject-only axiom nodes are rendered anonymously, so the only blank node
-        // labels that may appear belong to the shared node (referenced twice).
-        assertTrue("axiom nodes should be rendered as anonymous blank nodes", ttl.contains("owl:Axiom"));
+        // Subject-only axiom nodes must be rendered in anonymous blank node form
+        // ("[ a owl:Axiom"), not as labeled blank nodes ("_:b0 a owl:Axiom").
+        assertTrue("axiom nodes should be rendered as anonymous blank nodes",
+                Pattern.compile("\\[\\s+a\\s+owl:Axiom").matcher(ttl).find());
+        assertFalse("axiom nodes must not be rendered as labeled blank nodes",
+                Pattern.compile("_:\\S+\\s+a\\s+owl:Axiom").matcher(ttl).find());
     }
 
     @Test
@@ -133,5 +152,55 @@ public class DeterministicTurtleRendererTest {
         assertTrue(edited.contains("2099-12-31"));
         assertEquals("changing an axiom annotation must not reorder the output",
                 stripDateLines(base), stripDateLines(edited));
+    }
+
+    /**
+     * The renderer must be lossless: the rendered Turtle, parsed back, must contain
+     * exactly the input triples - nothing added, dropped, or altered - up to blank
+     * node identity (checked via graph isomorphism).
+     */
+    @Test
+    public void outputContainsExactlyTheInputTriples() throws Exception {
+        List<Statement> input = buildGraph("iso", 11, null);
+        Model inputModel = toJenaModel(input);
+
+        String ttl = render(input);
+        Model outputModel = ModelFactory.createDefaultModel();
+        RDFDataMgr.read(outputModel, new ByteArrayInputStream(ttl.getBytes("UTF-8")), MODEL + "/", Lang.TURTLE);
+
+        assertEquals("triple count must be preserved", inputModel.size(), outputModel.size());
+        assertTrue("rendered output must contain exactly the input triples (up to blank node identity)",
+                inputModel.isIsomorphicWith(outputModel));
+    }
+
+    /** Convert Sesame statements to a Jena model for graph comparison. */
+    private static Model toJenaModel(List<Statement> statements) {
+        Model model = ModelFactory.createDefaultModel();
+        Map<String, Resource> bnodes = new HashMap<>();
+        for (Statement s : statements) {
+            Resource subj = s.getSubject() instanceof BNode
+                    ? bnodes.computeIfAbsent(((BNode) s.getSubject()).getID(), k -> model.createResource())
+                    : model.createResource(s.getSubject().stringValue());
+            Property pred = model.createProperty(s.getPredicate().stringValue());
+            Value o = s.getObject();
+            RDFNode obj;
+            if (o instanceof BNode) {
+                obj = bnodes.computeIfAbsent(((BNode) o).getID(), k -> model.createResource());
+            } else if (o instanceof URI) {
+                obj = model.createResource(o.stringValue());
+            } else {
+                Literal lit = (Literal) o;
+                if (lit.getLanguage() != null) {
+                    obj = model.createLiteral(lit.getLabel(), lit.getLanguage());
+                } else if (lit.getDatatype() != null) {
+                    obj = model.createTypedLiteral(lit.getLabel(),
+                            TypeMapper.getInstance().getSafeTypeByName(lit.getDatatype().stringValue()));
+                } else {
+                    obj = model.createLiteral(lit.getLabel());
+                }
+            }
+            model.add(subj, pred, obj);
+        }
+        return model;
     }
 }


### PR DESCRIPTION
Dumping models from Blazegraph previously produced different triple ordering on different machines and changing blank node identifiers, making diffs of exported models hard to read.

Render dumped Turtle through a new DeterministicTurtleRenderer that:
- gives every blank node a content-derived identifier, so output is byte-identical for the same RDF regardless of machine or the order the triplestore returns triples;
- derives an owl:Axiom node's identifier from only the triple it annotates (annotatedSource/Property/Target), so editing its annotations does not move the whole block;
- uses a fixed set of namespace prefixes, including an empty ':' prefix for the model's own entities;
- delegates serialization to Jena's TURTLE_PRETTY, which writes blank nodes anonymously and sorts predicates.

Fixes #591.